### PR TITLE
feat: relocate BluetoothServiceInfoBleak

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -34,6 +34,7 @@ def build(setup_kwargs: Any) -> None:
                         "src/habluetooth/advertisement_tracker.py",
                         "src/habluetooth/base_scanner.py",
                         "src/habluetooth/manager.py",
+                        "src/habluetooth/models.py",
                         "src/habluetooth/scanner.py",
                     ],
                     compiler_directives={"language_level": "3"},  # Python 3

--- a/poetry.lock
+++ b/poetry.lock
@@ -818,17 +818,6 @@ sphinx = ">=6.0,<8.0"
 sphinx-basic-ng = "*"
 
 [[package]]
-name = "home-assistant-bluetooth"
-version = "1.10.4"
-description = "Home Assistant Bluetooth Models and Helpers"
-optional = false
-python-versions = ">=3.9,<4.0"
-files = [
-    {file = "home_assistant_bluetooth-1.10.4-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:7c3434bdec5dcfe733d3e7c56d4a24418fcd03718dc2e7707c9133d1e48145a8"},
-    {file = "home_assistant_bluetooth-1.10.4.tar.gz", hash = "sha256:21216b6be9d028bc232b9188ac4dce773798c6b4e47482cc3524bfc5f82515e3"},
-]
-
-[[package]]
 name = "idna"
 version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1999,4 +1988,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "c78f3beecb22cbb2ba6c702901b5b36073386a03282e8fdaade921200d9e1742"
+content-hash = "8069ed0042bdec4df811629f2b11b937a0f8d018804fe4cd1de1b7cc16ac8931"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ exclude_lines = [
 target-version = "py38"
 line-length = 88
 ignore = [
+    "E721", # type checks for cython
     "D203", # 1 blank line required before class docstring
     "D212", # Multi-line docstring summary should start at the first line
     "D100", # Missing docstring in public module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ python = ">=3.10,<3.13"
 bleak = ">=0.21.1"
 bleak-retry-connector = ">=3.3.0"
 bluetooth-data-tools = ">=1.16.0"
-home-assistant-bluetooth = ">=1.10.4"
 bluetooth-adapters = ">=0.16.1"
 bluetooth-auto-recovery = ">=1.2.3"
 

--- a/src/habluetooth/__init__.py
+++ b/src/habluetooth/__init__.py
@@ -13,11 +13,19 @@ from .const import (
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .manager import BluetoothManager
-from .models import HaBluetoothConnector, get_manager, set_manager
+from .models import (
+    BluetoothServiceInfo,
+    BluetoothServiceInfoBleak,
+    HaBluetoothConnector,
+    get_manager,
+    set_manager,
+)
 from .scanner import BluetoothScanningMode, HaScanner, ScannerStartError
 from .wrappers import HaBleakClientWrapper, HaBleakScannerWrapper
 
 __all__ = [
+    "BluetoothServiceInfo",
+    "BluetoothServiceInfoBleak",
     "HaBleakScannerWrapper",
     "HaBleakClientWrapper",
     "BluetoothManager",

--- a/src/habluetooth/advertisement_tracker.pxd
+++ b/src/habluetooth/advertisement_tracker.pxd
@@ -1,5 +1,7 @@
 import cython
 
+from .models cimport BluetoothServiceInfoBleak
+
 cdef class AdvertisementTracker:
 
     cdef public dict intervals
@@ -8,6 +10,6 @@ cdef class AdvertisementTracker:
     cdef public dict _timings
 
     @cython.locals(timings=list)
-    cpdef void async_collect(self, object service_info)
+    cpdef void async_collect(self, BluetoothServiceInfoBleak service_info)
 
     cpdef void async_remove_address(self, object address)

--- a/src/habluetooth/advertisement_tracker.py
+++ b/src/habluetooth/advertisement_tracker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from home_assistant_bluetooth import BluetoothServiceInfoBleak
+from .models import BluetoothServiceInfoBleak
 
 ADVERTISING_TIMES_NEEDED = 16
 

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -28,7 +28,6 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
 
     cdef public object _new_info_callback
     cdef public dict _discovered_device_advertisement_datas
-    cdef public dict _discovered_device_timestamps
     cdef public dict _details
     cdef public float _expire_seconds
     cdef public object _cancel_track

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -1,6 +1,8 @@
 
 import cython
 
+from .models cimport BluetoothServiceInfoBleak
+
 cdef object NO_RSSI_VALUE
 cdef object BluetoothServiceInfoBleak
 cdef object AdvertisementData

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -32,6 +32,7 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
     cdef public dict _details
     cdef public float _expire_seconds
     cdef public object _cancel_track
+    cdef dict _previous_service_info
 
     @cython.locals(
         prev_service_uuids=list,
@@ -42,7 +43,8 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
         has_manufacturer_data=bint,
         has_service_data=bint,
         has_service_uuids=bint,
-        prev_details=dict
+        prev_details=dict,
+        prev_service_info=BluetoothServiceInfoBleak
     )
     cpdef void _async_on_advertisement(
         self,

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -31,7 +31,7 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
     cdef public dict _details
     cdef public float _expire_seconds
     cdef public object _cancel_track
-    cdef dict _previous_service_info
+    cdef public dict _previous_service_info
 
     @cython.locals(
         prev_service_uuids=list,
@@ -58,5 +58,5 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
         object advertisement_monotonic_time
     )
 
-    @cython.locals(now=float, timestamp=float)
+    @cython.locals(now=float, timestamp=float, service_info=BluetoothServiceInfoBleak)
     cpdef void _async_expire_devices(self)

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -228,25 +228,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
         self._discovered_device_advertisement_datas = (
             history.discovered_device_advertisement_datas
         )
-        self._previous_service_info = {
-            address: BluetoothServiceInfoBleak(
-                device.name or address,
-                address,
-                device.rssi,
-                adv.manufacturer_data,
-                adv.service_data,
-                adv.service_uuids,
-                self.source,
-                device,
-                adv,
-                self.connectable,
-                history.discovered_device_timestamps[address],
-            )
-            for address, (
-                device,
-                adv,
-            ) in history.discovered_device_advertisement_datas.items()
-        }
+        self._discovered_device_timestamps = history.discovered_device_timestamps
         # Expire anything that is too old
         self._async_expire_devices()
 
@@ -267,6 +249,31 @@ class BaseHaRemoteScanner(BaseHaScanner):
         return {
             address: service_info.time
             for address, service_info in self._previous_service_info.items()
+        }
+
+    @property.setter
+    def _discovered_device_timestamps(
+        self, discovered_device_timestamps: dict[str, float]
+    ) -> None:
+        """Set the discovered device timestamps."""
+        self._previous_service_info = {
+            address: BluetoothServiceInfoBleak(
+                device.name or address,
+                address,
+                device.rssi,
+                adv.manufacturer_data,
+                adv.service_data,
+                adv.service_uuids,
+                self.source,
+                device,
+                adv,
+                self.connectable,
+                discovered_device_timestamps[address],
+            )
+            for address, (
+                device,
+                adv,
+            ) in self._discovered_device_advertisement_datas.items()
         }
 
     def _cancel_expire_devices(self) -> None:

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -13,7 +13,6 @@ from bleak.backends.scanner import AdvertisementData
 from bleak_retry_connector import NO_RSSI_VALUE
 from bluetooth_adapters import adapter_human_name
 from bluetooth_data_tools import monotonic_time_coarse
-from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from .const import (
     CALLBACK_TYPE,
@@ -21,7 +20,7 @@ from .const import (
     SCANNER_WATCHDOG_INTERVAL,
     SCANNER_WATCHDOG_TIMEOUT,
 )
-from .models import HaBluetoothConnector
+from .models import BluetoothServiceInfoBleak, HaBluetoothConnector
 
 SCANNER_WATCHDOG_INTERVAL_SECONDS: Final = SCANNER_WATCHDOG_INTERVAL.total_seconds()
 _LOGGER = logging.getLogger(__name__)

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -251,7 +251,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
             for address, service_info in self._previous_service_info.items()
         }
 
-    @property.setter
+    @_discovered_device_timestamps.setter
     def _discovered_device_timestamps(
         self, discovered_device_timestamps: dict[str, float]
     ) -> None:

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -260,7 +260,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
             address: BluetoothServiceInfoBleak(
                 device.name or address,
                 address,
-                device.rssi,
+                adv.rssi,
                 adv.manufacturer_data,
                 adv.service_data,
                 adv.service_uuids,

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -4,15 +4,15 @@ from .advertisement_tracker cimport AdvertisementTracker
 from .base_scanner cimport BaseHaScanner
 from .models cimport BluetoothServiceInfoBleak
 
-cdef object NO_RSSI_VALUE
-cdef object RSSI_SWITCH_THRESHOLD
+cdef int NO_RSSI_VALUE
+cdef int RSSI_SWITCH_THRESHOLD
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice
 cdef bint TYPE_CHECKING
 cdef set APPLE_START_BYTES_WANTED
 
-cdef unsigned int APPLE_MFR_ID
+cdef object APPLE_MFR_ID
 
 @cython.locals(uuids=set)
 cdef _dispatch_bleak_callback(
@@ -21,6 +21,11 @@ cdef _dispatch_bleak_callback(
     object device,
     object advertisement_data
 )
+
+cdef class BleakCallback:
+
+    cdef public object callback
+    cdef public dict filters
 
 cdef class BluetoothManager:
 
@@ -43,6 +48,7 @@ cdef class BluetoothManager:
     cdef public bint shutdown
     cdef public object _loop
 
+    @cython.locals(stale_seconds=float)
     cdef bint _prefer_previous_adv_from_different_source(self, object address, BluetoothServiceInfoBleak old, BluetoothServiceInfoBleak new)
 
     @cython.locals(
@@ -51,6 +57,10 @@ cdef class BluetoothManager:
         source=str,
         connectable=bint,
         scanner=BaseHaScanner,
-        connectable_scanner=BaseHaScanner
+        connectable_scanner=BaseHaScanner,
+        apple_data=bytes,
+        bleak_callback=BleakCallback
     )
     cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
+
+    cdef _async_describe_source(self, BluetoothServiceInfoBleak service_info)

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -45,5 +45,12 @@ cdef class BluetoothManager:
 
     cdef bint _prefer_previous_adv_from_different_source(self, object address, BluetoothServiceInfoBleak old, BluetoothServiceInfoBleak new)
 
-    @cython.locals(source=str, connectable=bint, scanner=BaseHaScanner, connectable_scanner=BaseHaScanner)
+    @cython.locals(
+        old_service_info=BluetoothServiceInfoBleak,
+        old_connectable_service_info=BluetoothServiceInfoBleak,
+        source=str,
+        connectable=bint,
+        scanner=BaseHaScanner,
+        connectable_scanner=BaseHaScanner
+    )
     cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -49,7 +49,12 @@ cdef class BluetoothManager:
     cdef public object _loop
 
     @cython.locals(stale_seconds=float)
-    cdef bint _prefer_previous_adv_from_different_source(self, object address, BluetoothServiceInfoBleak old, BluetoothServiceInfoBleak new)
+    cdef bint _prefer_previous_adv_from_different_source(
+        self,
+        object address,
+        BluetoothServiceInfoBleak old,
+        BluetoothServiceInfoBleak new
+    )
 
     @cython.locals(
         old_service_info=BluetoothServiceInfoBleak,

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -2,11 +2,11 @@ import cython
 
 from .advertisement_tracker cimport AdvertisementTracker
 from .base_scanner cimport BaseHaScanner
+from .models cimport BluetoothServiceInfoBleak
 
 cdef object NO_RSSI_VALUE
 cdef object RSSI_SWITCH_THRESHOLD
 cdef object FILTER_UUIDS
-cdef object BluetoothServiceInfoBleak
 cdef object AdvertisementData
 cdef object BLEDevice
 cdef bint TYPE_CHECKING
@@ -43,7 +43,7 @@ cdef class BluetoothManager:
     cdef public bint shutdown
     cdef public object _loop
 
-    cdef bint _prefer_previous_adv_from_different_source(self, object address, object old, object new)
+    cdef bint _prefer_previous_adv_from_different_source(self, object address, BluetoothServiceInfoBleak old, BluetoothServiceInfoBleak new)
 
     @cython.locals(source=str, connectable=bint, scanner=BaseHaScanner, connectable_scanner=BaseHaScanner)
-    cpdef void scanner_adv_received(self, object service_info)
+    cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -68,4 +68,4 @@ cdef class BluetoothManager:
     )
     cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
 
-    cdef _async_describe_source(self, BluetoothServiceInfoBleak service_info)
+    cpdef _async_describe_source(self, BluetoothServiceInfoBleak service_info)

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -16,7 +16,6 @@ from bluetooth_adapters import (
     BluetoothAdapters,
 )
 from bluetooth_data_tools import monotonic_time_coarse
-from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from habluetooth import TRACKER_BUFFERING_WOBBLE_SECONDS
 
@@ -27,6 +26,7 @@ from .const import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     UNAVAILABLE_TRACK_SECONDS,
 )
+from .models import BluetoothServiceInfoBleak
 from .usage import install_multiple_bleak_catcher, uninstall_multiple_bleak_catcher
 
 if TYPE_CHECKING:

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -1,0 +1,33 @@
+
+cdef object BLEDevice
+cdef object AdvertisementData
+
+cdef object _float
+cdef object _int
+cdef object _str
+cdef object _BluetoothServiceInfoBleakSelfT
+cdef object _BluetoothServiceInfoSelfT
+
+cdef class BaseServiceInfo:
+    """Base class for discovery ServiceInfo."""
+
+
+cdef class BluetoothServiceInfo(BaseServiceInfo):
+    """Prepared info from bluetooth entries."""
+
+    cdef public object name
+    cdef public object address
+    cdef public object rssi
+    cdef public object manufacturer_data
+    cdef public object service_data
+    cdef public object service_uuids
+    cdef public object source
+
+
+cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
+    """BluetoothServiceInfo with bleak data."""
+
+    cdef public object device
+    cdef public object advertisement
+    cdef public object connectable
+    cdef public object time

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -14,7 +14,7 @@ cdef class BluetoothServiceInfo:
 
     cdef public str name
     cdef public str address
-    cdef public object rssi
+    cdef public int rssi
     cdef public dict manufacturer_data
     cdef public dict service_data
     cdef public list service_uuids
@@ -27,4 +27,4 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public object device
     cdef public object advertisement
     cdef public bint connectable
-    cdef public object time
+    cdef public float time

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -27,4 +27,4 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public object device
     cdef public object advertisement
     cdef public bint connectable
-    cdef public float time
+    cdef public double time

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -8,20 +8,17 @@ cdef object _str
 cdef object _BluetoothServiceInfoBleakSelfT
 cdef object _BluetoothServiceInfoSelfT
 
-cdef class BaseServiceInfo:
-    """Base class for discovery ServiceInfo."""
 
-
-cdef class BluetoothServiceInfo(BaseServiceInfo):
+cdef class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""
 
-    cdef public object name
-    cdef public object address
+    cdef public str name
+    cdef public str address
     cdef public object rssi
-    cdef public object manufacturer_data
-    cdef public object service_data
-    cdef public object service_uuids
-    cdef public object source
+    cdef public dict manufacturer_data
+    cdef public dict service_data
+    cdef public list service_uuids
+    cdef public str source
 
 
 cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
@@ -29,5 +26,5 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
 
     cdef public object device
     cdef public object advertisement
-    cdef public object connectable
+    cdef public bint connectable
     cdef public object time

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -6,14 +6,25 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
-if TYPE_CHECKING:
-    from bleak.backends.device import BLEDevice
-    from bleak.backends.scanner import AdvertisementData
-
 from bleak import BaseBleakClient
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
 
 if TYPE_CHECKING:
     from .manager import BluetoothManager
+
+_BluetoothServiceInfoSelfT = TypeVar(
+    "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
+)
+
+_BluetoothServiceInfoBleakSelfT = TypeVar(
+    "_BluetoothServiceInfoBleakSelfT", bound="BluetoothServiceInfoBleak"
+)
+SOURCE_LOCAL: Final = "local"
+
+_float = float  # avoid cython conversion since we always want a pyfloat
+_str = str  # avoid cython conversion since we always want a pystr
+_int = int  # avoid cython conversion since we always want a pyint
 
 
 class CentralBluetoothManager:
@@ -50,25 +61,7 @@ class BluetoothScanningMode(Enum):
     ACTIVE = "active"
 
 
-_BluetoothServiceInfoSelfT = TypeVar(
-    "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
-)
-
-_BluetoothServiceInfoBleakSelfT = TypeVar(
-    "_BluetoothServiceInfoBleakSelfT", bound="BluetoothServiceInfoBleak"
-)
-SOURCE_LOCAL: Final = "local"
-
-_float = float  # avoid cython conversion since we always want a pyfloat
-_str = str  # avoid cython conversion since we always want a pystr
-_int = int  # avoid cython conversion since we always want a pyint
-
-
-class BaseServiceInfo:
-    """Base class for discovery ServiceInfo."""
-
-
-class BluetoothServiceInfo(BaseServiceInfo):
+class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""
 
     __slots__ = (

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Final, TypeVar
+
+if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
+    from bleak.backends.scanner import AdvertisementData
 
 from bleak import BaseBleakClient
 
@@ -44,3 +48,200 @@ class BluetoothScanningMode(Enum):
 
     PASSIVE = "passive"
     ACTIVE = "active"
+
+
+_BluetoothServiceInfoSelfT = TypeVar(
+    "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
+)
+
+_BluetoothServiceInfoBleakSelfT = TypeVar(
+    "_BluetoothServiceInfoBleakSelfT", bound="BluetoothServiceInfoBleak"
+)
+SOURCE_LOCAL: Final = "local"
+
+_float = float  # avoid cython conversion since we always want a pyfloat
+_str = str  # avoid cython conversion since we always want a pystr
+_int = int  # avoid cython conversion since we always want a pyint
+
+
+class BaseServiceInfo:
+    """Base class for discovery ServiceInfo."""
+
+
+class BluetoothServiceInfo(BaseServiceInfo):
+    """Prepared info from bluetooth entries."""
+
+    __slots__ = (
+        "name",
+        "address",
+        "rssi",
+        "manufacturer_data",
+        "service_data",
+        "service_uuids",
+        "source",
+    )
+
+    def __init__(
+        self,
+        name: _str,  # may be a pyobjc object
+        address: _str,  # may be a pyobjc object
+        rssi: _int,  # may be a pyobjc object
+        manufacturer_data: dict[_int, bytes],
+        service_data: dict[_str, bytes],
+        service_uuids: list[_str],
+        source: _str,
+    ) -> None:
+        """Initialize a bluetooth service info."""
+        self.name = name
+        self.address = address
+        self.rssi = rssi
+        self.manufacturer_data = manufacturer_data
+        self.service_data = service_data
+        self.service_uuids = service_uuids
+        self.source = source
+
+    @classmethod
+    def from_advertisement(
+        cls: type[_BluetoothServiceInfoSelfT],
+        device: BLEDevice,
+        advertisement_data: AdvertisementData,
+        source: str,
+    ) -> _BluetoothServiceInfoSelfT:
+        """Create a BluetoothServiceInfo from an advertisement."""
+        return cls(
+            advertisement_data.local_name or device.name or device.address,
+            device.address,
+            advertisement_data.rssi,
+            advertisement_data.manufacturer_data,
+            advertisement_data.service_data,
+            advertisement_data.service_uuids,
+            source,
+        )
+
+    @property
+    def manufacturer(self) -> str | None:
+        """Convert manufacturer data to a string."""
+        from bleak.backends._manufacturers import (
+            MANUFACTURERS,  # pylint: disable=import-outside-toplevel
+        )
+
+        for manufacturer in self.manufacturer_data:
+            if manufacturer in MANUFACTURERS:
+                name: str = MANUFACTURERS[manufacturer]
+                return name
+        return None
+
+    @property
+    def manufacturer_id(self) -> int | None:
+        """Get the first manufacturer id."""
+        for manufacturer in self.manufacturer_data:
+            return manufacturer
+        return None
+
+
+class BluetoothServiceInfoBleak(BluetoothServiceInfo):
+    """
+    BluetoothServiceInfo with bleak data.
+
+    Integrations may need BLEDevice and AdvertisementData
+    to connect to the device without having bleak trigger
+    another scan to translate the address to the system's
+    internal details.
+    """
+
+    __slots__ = ("device", "advertisement", "connectable", "time")
+
+    def __init__(
+        self,
+        name: _str,  # may be a pyobjc object
+        address: _str,  # may be a pyobjc object
+        rssi: _int,  # may be a pyobjc object
+        manufacturer_data: dict[_int, bytes],
+        service_data: dict[_str, bytes],
+        service_uuids: list[_str],
+        source: _str,
+        device: BLEDevice,
+        advertisement: AdvertisementData,
+        connectable: bool,
+        time: _float,
+    ) -> None:
+        self.name = name
+        self.address = address
+        self.rssi = rssi
+        self.manufacturer_data = manufacturer_data
+        self.service_data = service_data
+        self.service_uuids = service_uuids
+        self.source = source
+        self.device = device
+        self.advertisement = advertisement
+        self.connectable = connectable
+        self.time = time
+
+    def as_dict(self) -> dict[str, Any]:
+        """
+        Return as dict.
+
+        The dataclass asdict method is not used because
+        it will try to deepcopy pyobjc data which will fail.
+        """
+        return {
+            "name": self.name,
+            "address": self.address,
+            "rssi": self.rssi,
+            "manufacturer_data": self.manufacturer_data,
+            "service_data": self.service_data,
+            "service_uuids": self.service_uuids,
+            "source": self.source,
+            "advertisement": self.advertisement,
+            "device": self.device,
+            "connectable": self.connectable,
+            "time": self.time,
+        }
+
+    @classmethod
+    def from_scan(
+        cls: type[_BluetoothServiceInfoBleakSelfT],
+        source: str,
+        device: BLEDevice,
+        advertisement_data: AdvertisementData,
+        monotonic_time: _float,
+        connectable: bool,
+    ) -> _BluetoothServiceInfoBleakSelfT:
+        """Create a BluetoothServiceInfoBleak from a scanner."""
+        return cls(
+            advertisement_data.local_name or device.name or device.address,
+            device.address,
+            advertisement_data.rssi,
+            advertisement_data.manufacturer_data,
+            advertisement_data.service_data,
+            advertisement_data.service_uuids,
+            source,
+            device,
+            advertisement_data,
+            connectable,
+            monotonic_time,
+        )
+
+    @classmethod
+    def from_device_and_advertisement_data(
+        cls: type[_BluetoothServiceInfoBleakSelfT],
+        device: BLEDevice,
+        advertisement_data: AdvertisementData,
+        source: str,
+        time: _float,
+        connectable: bool,
+    ) -> _BluetoothServiceInfoBleakSelfT:
+        """Create a BluetoothServiceInfoBleak from a device and advertisement."""
+        return cls(
+            advertisement_data.local_name or device.name or device.address,
+            device.address,
+            advertisement_data.rssi,
+            advertisement_data.manufacturer_data,
+            advertisement_data.service_data,
+            advertisement_data.service_uuids,
+            source,
+            device,
+            advertisement_data,
+            connectable,
+            time,
+        )

--- a/src/habluetooth/scanner.pxd
+++ b/src/habluetooth/scanner.pxd
@@ -2,10 +2,9 @@ import cython
 
 
 from .base_scanner cimport BaseHaScanner
-
+from .models cimport BluetoothServiceInfoBleak
 
 cdef object NO_RSSI_VALUE
-cdef object BluetoothServiceInfoBleak
 cdef object AdvertisementData
 cdef object BLEDevice
 cdef bint TYPE_CHECKING

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -196,9 +196,12 @@ class HaScanner(BaseHaScanner):
             # as the adapter is in a failure
             # state if all the data is empty.
             self._last_detection = callback_time
+        name = advertisement_data.local_name or device.name or device.address
+        if name is not None and type(name) is not str:
+            name = str(name)
         self._new_info_callback(
             BluetoothServiceInfoBleak(
-                str(advertisement_data.local_name or device.name or device.address),
+                name,
                 device.address,
                 advertisement_data.rssi,
                 advertisement_data.manufacturer_data,

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -198,7 +198,7 @@ class HaScanner(BaseHaScanner):
             self._last_detection = callback_time
         self._new_info_callback(
             BluetoothServiceInfoBleak(
-                advertisement_data.local_name or device.name or device.address,
+                str(advertisement_data.local_name or device.name or device.address),
                 device.address,
                 advertisement_data.rssi,
                 advertisement_data.manufacturer_data,

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -18,7 +18,6 @@ from bleak_retry_connector import restore_discoveries
 from bluetooth_adapters import DEFAULT_ADDRESS
 from bluetooth_data_tools import monotonic_time_coarse
 from dbus_fast import InvalidMessageError
-from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from .base_scanner import BaseHaScanner
 from .const import (
@@ -28,7 +27,7 @@ from .const import (
     SOURCE_LOCAL,
     START_TIMEOUT,
 )
-from .models import BluetoothScanningMode
+from .models import BluetoothScanningMode, BluetoothServiceInfoBleak
 from .util import async_reset_adapter, is_docker_env
 
 OriginalBleakScanner = bleak.BleakScanner

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from bleak.backends.scanner import AdvertisementData
+
+ADVERTISEMENT_DATA_DEFAULTS = {
+    "manufacturer_data": {},
+    "service_data": {},
+    "service_uuids": [],
+    "rssi": -127,
+    "platform_data": ((),),
+    "tx_power": -127,
+}
+
+
+def generate_advertisement_data(**kwargs: Any) -> AdvertisementData:
+    """Generate advertisement data with defaults."""
+    new = kwargs.copy()
+    for key, value in ADVERTISEMENT_DATA_DEFAULTS.items():
+        new.setdefault(key, value)
+    return AdvertisementData(**new)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import time
+
+from bleak.backends.device import BLEDevice
+
+from habluetooth import (
+    BluetoothServiceInfo,
+    BluetoothServiceInfoBleak,
+)
+
+from . import generate_advertisement_data
+
+SOURCE_LOCAL = "local"
+
+
+def test_model():
+    service_info = BluetoothServiceInfo(
+        name="Test",
+        address="00:00:00:00:00:00",
+        rssi=0,
+        manufacturer_data={97: b"\x00\x00\x00\x00\x00\x00"},
+        service_data={},
+        service_uuids=[],
+        source=SOURCE_LOCAL,
+    )
+
+    assert service_info.manufacturer == "RDA Microelectronics"
+    assert service_info.manufacturer_id == 97
+
+    service_info = BluetoothServiceInfo(
+        name="Test",
+        address="00:00:00:00:00:00",
+        rssi=0,
+        manufacturer_data={954547: b"\x00\x00\x00\x00\x00\x00"},
+        service_data={},
+        service_uuids=[],
+        source=SOURCE_LOCAL,
+    )
+
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id == 954547
+
+
+def test_model_from_bleak():
+    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand", {}, -127)
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    )
+    service_info = BluetoothServiceInfo.from_advertisement(
+        switchbot_device, switchbot_adv, SOURCE_LOCAL
+    )
+
+    assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    assert service_info.name == "wohand"
+    assert service_info.source == SOURCE_LOCAL
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id is None
+
+
+def test_model_from_scanner():
+    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand", {}, -127)
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    )
+    now = time.monotonic()
+    service_info = BluetoothServiceInfoBleak.from_scan(
+        SOURCE_LOCAL, switchbot_device, switchbot_adv, now, True
+    )
+
+    assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    assert service_info.name == "wohand"
+    assert service_info.source == SOURCE_LOCAL
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id is None
+    assert service_info.time == now
+    assert service_info.connectable is True
+
+    safe_as_dict = service_info.as_dict()
+    assert safe_as_dict == {
+        "address": "44:44:33:11:23:45",
+        "advertisement": switchbot_adv,
+        "device": switchbot_device,
+        "connectable": True,
+        "manufacturer_data": {},
+        "name": "wohand",
+        "rssi": -127,
+        "service_data": {},
+        "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        "source": "local",
+        "time": now,
+    }
+
+
+def test_construct_service_info_bleak():
+    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand", {}, -127)
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    )
+    now = time.monotonic()
+    service_info = BluetoothServiceInfoBleak(
+        name="wohand",
+        address="44:44:33:11:23:45",
+        rssi=-127,
+        manufacturer_data=switchbot_adv.manufacturer_data,
+        service_data=switchbot_adv.service_data,
+        service_uuids=switchbot_adv.service_uuids,
+        source=SOURCE_LOCAL,
+        device=switchbot_device,
+        advertisement=switchbot_adv,
+        connectable=False,
+        time=now,
+    )
+
+    assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    assert service_info.name == "wohand"
+    assert service_info.source == SOURCE_LOCAL
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id is None
+    assert service_info.time == now
+    assert service_info.connectable is False
+
+    safe_as_dict = service_info.as_dict()
+    assert safe_as_dict == {
+        "address": "44:44:33:11:23:45",
+        "advertisement": switchbot_adv,
+        "device": switchbot_device,
+        "connectable": False,
+        "manufacturer_data": {},
+        "name": "wohand",
+        "rssi": -127,
+        "service_data": {},
+        "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        "source": "local",
+        "time": now,
+    }
+
+
+def test_from_device_and_advertisement_data():
+    """
+    Test creating a BluetoothServiceInfoBleak.
+
+    From a BLEDevice and AdvertisementData.
+    """
+    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand", {}, -127)
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    )
+    now_monotonic = time.monotonic()
+    service_info = BluetoothServiceInfoBleak.from_device_and_advertisement_data(
+        switchbot_device, switchbot_adv, SOURCE_LOCAL, now_monotonic, True
+    )
+
+    assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    assert service_info.name == "wohand"
+    assert service_info.source == SOURCE_LOCAL
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id is None
+
+    safe_as_dict = service_info.as_dict()
+    assert safe_as_dict == {
+        "address": "44:44:33:11:23:45",
+        "advertisement": switchbot_adv,
+        "device": switchbot_device,
+        "connectable": True,
+        "manufacturer_data": {},
+        "name": "wohand",
+        "rssi": -127,
+        "service_data": {},
+        "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        "source": "local",
+        "time": now_monotonic,
+    }
+
+
+def test_pyobjc_compat():
+    class pyobjc_str(str):
+        pass
+
+    class pyobjc_int(int):
+        pass
+
+    name = pyobjc_str("wohand")
+    address = pyobjc_str("44:44:33:11:23:45")
+    rssi = pyobjc_int(-127)
+
+    assert name == "wohand"
+    assert address == "44:44:33:11:23:45"
+    assert rssi == -127
+
+    switchbot_device = BLEDevice(address, name, {}, rssi)
+    switchbot_adv = generate_advertisement_data(
+        local_name=name, service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    )
+    now = time.monotonic()
+    service_info = BluetoothServiceInfoBleak(
+        name=name,
+        address=address,
+        rssi=rssi,
+        manufacturer_data=switchbot_adv.manufacturer_data,
+        service_data=switchbot_adv.service_data,
+        service_uuids=switchbot_adv.service_uuids,
+        source=SOURCE_LOCAL,
+        device=switchbot_device,
+        advertisement=switchbot_adv,
+        connectable=False,
+        time=now,
+    )
+
+    assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    assert service_info.name == "wohand"
+    assert service_info.source == SOURCE_LOCAL
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id is None
+    assert service_info.time == now
+    assert service_info.connectable is False
+
+    safe_as_dict = service_info.as_dict()
+    assert safe_as_dict == {
+        "address": "44:44:33:11:23:45",
+        "advertisement": switchbot_adv,
+        "device": switchbot_device,
+        "connectable": False,
+        "manufacturer_data": {},
+        "name": "wohand",
+        "rssi": -127,
+        "service_data": {},
+        "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        "source": "local",
+        "time": now,
+    }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -194,8 +194,8 @@ def test_pyobjc_compat():
     )
     now = time.monotonic()
     service_info = BluetoothServiceInfoBleak(
-        name=name,
-        address=address,
+        name=str(name),
+        address=str(address),
         rssi=rssi,
         manufacturer_data=switchbot_adv.manufacturer_data,
         service_data=switchbot_adv.service_data,


### PR DESCRIPTION
~~TODO: We can't do _previous_service_info yet because HA restores _discovered_device_timestamps which we want to get rid of~~

~~We need a `.restore` function that takes a `DiscoveredDeviceAdvertisementData` and a `.serialize` function that returns a `DiscoveredDeviceAdvertisementData`~~