### PR TITLE
feat!: eliminate the need to pass the new_info_callback

### DIFF
--- a/src/habluetooth/__init__.py
+++ b/src/habluetooth/__init__.py
@@ -5,6 +5,7 @@ from .advertisement_tracker import (
     AdvertisementTracker,
 )
 from .base_scanner import BaseHaRemoteScanner, BaseHaScanner, BluetoothScannerDevice
+from .central_manager import get_manager, set_manager
 from .const import (
     CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -17,8 +18,6 @@ from .models import (
     BluetoothServiceInfo,
     BluetoothServiceInfoBleak,
     HaBluetoothConnector,
-    get_manager,
-    set_manager,
 )
 from .scanner import BluetoothScanningMode, HaScanner, ScannerStartError
 from .wrappers import HaBleakClientWrapper, HaBleakScannerWrapper

--- a/src/habluetooth/__init__.py
+++ b/src/habluetooth/__init__.py
@@ -4,7 +4,7 @@ from .advertisement_tracker import (
     TRACKER_BUFFERING_WOBBLE_SECONDS,
     AdvertisementTracker,
 )
-from .base_scanner import BaseHaRemoteScanner, BaseHaScanner, BluetoothScannerDevice
+from .base_scanner import BaseHaRemoteScanner, BaseHaScanner
 from .central_manager import get_manager, set_manager
 from .const import (
     CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -20,6 +20,7 @@ from .models import (
     HaBluetoothConnector,
 )
 from .scanner import BluetoothScanningMode, HaScanner, ScannerStartError
+from .scanner_device import BluetoothScannerDevice
 from .wrappers import HaBleakClientWrapper, HaBleakScannerWrapper
 
 __all__ = [

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -2,6 +2,7 @@
 import cython
 
 from .models cimport BluetoothServiceInfoBleak
+from .manager cimport BluetoothManager
 
 cdef object NO_RSSI_VALUE
 cdef object BluetoothServiceInfoBleak
@@ -22,11 +23,11 @@ cdef class BaseHaScanner:
     cdef public object _start_time
     cdef public object _cancel_watchdog
     cdef public object _loop
+    cdef BluetoothManager _manager
 
 
 cdef class BaseHaRemoteScanner(BaseHaScanner):
 
-    cdef public object _new_info_callback
     cdef public dict _discovered_device_advertisement_datas
     cdef public dict _details
     cdef public float _expire_seconds

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, final
 
 from bleak.backends.device import BLEDevice
@@ -30,15 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 _float = float
 _int = int
 _str = str
-
-
-@dataclass(slots=True)
-class BluetoothScannerDevice:
-    """Data for a bluetooth device from a given scanner."""
-
-    scanner: BaseHaScanner
-    ble_device: BLEDevice
-    advertisement: AdvertisementData
 
 
 class BaseHaScanner:

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, final
@@ -14,6 +14,7 @@ from bleak_retry_connector import NO_RSSI_VALUE
 from bluetooth_adapters import DiscoveredDeviceAdvertisementData, adapter_human_name
 from bluetooth_data_tools import monotonic_time_coarse
 
+from .central_manager import get_manager
 from .const import (
     CALLBACK_TYPE,
     CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -55,6 +56,7 @@ class BaseHaScanner:
         "_start_time",
         "_cancel_watchdog",
         "_loop",
+        "_manager",
     )
 
     def __init__(
@@ -75,6 +77,7 @@ class BaseHaScanner:
         self._start_time = 0.0
         self._cancel_watchdog: asyncio.TimerHandle | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._manager = get_manager()
 
     def async_setup(self) -> CALLBACK_TYPE:
         """Set up the scanner."""
@@ -191,7 +194,6 @@ class BaseHaRemoteScanner(BaseHaScanner):
     """Base class for a high availability remote BLE scanner."""
 
     __slots__ = (
-        "_new_info_callback",
         "_discovered_device_advertisement_datas",
         "_details",
         "_expire_seconds",
@@ -203,13 +205,11 @@ class BaseHaRemoteScanner(BaseHaScanner):
         self,
         scanner_id: str,
         name: str,
-        new_info_callback: Callable[[BluetoothServiceInfoBleak], None],
         connector: HaBluetoothConnector | None,
         connectable: bool,
     ) -> None:
         """Initialize the scanner."""
         super().__init__(scanner_id, name, connector)
-        self._new_info_callback = new_info_callback
         self._discovered_device_advertisement_datas: dict[
             str, tuple[BLEDevice, AdvertisementData]
         ] = {}
@@ -434,7 +434,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
             advertisement_monotonic_time,
         )
         self._previous_service_info[address] = service_info
-        self._new_info_callback(service_info)
+        self._manager.scanner_adv_received(service_info)
 
     async def async_diagnostics(self) -> dict[str, Any]:
         """Return diagnostic information about the scanner."""

--- a/src/habluetooth/central_manager.py
+++ b/src/habluetooth/central_manager.py
@@ -15,8 +15,8 @@ class CentralBluetoothManager:
 
 def get_manager() -> BluetoothManager:
     """Get the BluetoothManager."""
-    if TYPE_CHECKING:
-        assert CentralBluetoothManager.manager is not None
+    if CentralBluetoothManager.manager is None:
+        raise RuntimeError("BluetoothManager has not been set")
     return CentralBluetoothManager.manager
 
 

--- a/src/habluetooth/central_manager.py
+++ b/src/habluetooth/central_manager.py
@@ -1,0 +1,25 @@
+"""Central manager for bluetooth."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .manager import BluetoothManager
+
+
+class CentralBluetoothManager:
+    """Central Bluetooth Manager."""
+
+    manager: BluetoothManager | None = None
+
+
+def get_manager() -> BluetoothManager:
+    """Get the BluetoothManager."""
+    if TYPE_CHECKING:
+        assert CentralBluetoothManager.manager is not None
+    return CentralBluetoothManager.manager
+
+
+def set_manager(manager: BluetoothManager) -> None:
+    """Set the BluetoothManager."""
+    CentralBluetoothManager.manager = manager

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -17,21 +17,24 @@ from bluetooth_adapters import (
 )
 from bluetooth_data_tools import monotonic_time_coarse
 
-from habluetooth import TRACKER_BUFFERING_WOBBLE_SECONDS
-
-from .advertisement_tracker import AdvertisementTracker
-from .base_scanner import BaseHaScanner, BluetoothScannerDevice
+from .advertisement_tracker import (
+    TRACKER_BUFFERING_WOBBLE_SECONDS,
+    AdvertisementTracker,
+)
 from .const import (
     CALLBACK_TYPE,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .models import BluetoothServiceInfoBleak
+from .scanner_device import BluetoothScannerDevice
 from .usage import install_multiple_bleak_catcher, uninstall_multiple_bleak_catcher
 
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
     from bleak.backends.scanner import AdvertisementData
+
+    from .base_scanner import BaseHaScanner
 
 
 FILTER_UUIDS: Final = "UUIDs"

--- a/src/habluetooth/scanner.pxd
+++ b/src/habluetooth/scanner.pxd
@@ -15,7 +15,6 @@ cdef class HaScanner(BaseHaScanner):
     cdef public object mac_address
     cdef public object mode
     cdef public object _start_stop_lock
-    cdef public object _new_info_callback
     cdef public object _background_tasks
     cdef public object scanner
 

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import platform
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Coroutine
 
 import bleak
@@ -123,7 +122,6 @@ class HaScanner(BaseHaScanner):
         mode: BluetoothScanningMode,
         adapter: str,
         address: str,
-        new_info_callback: Callable[[BluetoothServiceInfoBleak], None],
     ) -> None:
         """Init bluetooth discovery."""
         self.mac_address = address
@@ -132,7 +130,6 @@ class HaScanner(BaseHaScanner):
         self.connectable = True
         self.mode = mode
         self._start_stop_lock = asyncio.Lock()
-        self._new_info_callback = new_info_callback
         self.scanning = False
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self.scanner: bleak.BleakScanner | None = None
@@ -199,7 +196,7 @@ class HaScanner(BaseHaScanner):
         name = advertisement_data.local_name or device.name or device.address
         if name is not None and type(name) is not str:
             name = str(name)
-        self._new_info_callback(
+        self._manager.scanner_adv_received(
             BluetoothServiceInfoBleak(
                 name,
                 device.address,

--- a/src/habluetooth/scanner_device.py
+++ b/src/habluetooth/scanner_device.py
@@ -1,19 +1,11 @@
 """Base classes for HA Bluetooth scanners for bluetooth."""
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-
-from .const import (
-    SCANNER_WATCHDOG_INTERVAL,
-)
-
-SCANNER_WATCHDOG_INTERVAL_SECONDS: Final = SCANNER_WATCHDOG_INTERVAL.total_seconds()
-_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .base_scanner import BaseHaScanner

--- a/src/habluetooth/scanner_device.py
+++ b/src/habluetooth/scanner_device.py
@@ -1,0 +1,28 @@
+"""Base classes for HA Bluetooth scanners for bluetooth."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+from .const import (
+    SCANNER_WATCHDOG_INTERVAL,
+)
+
+SCANNER_WATCHDOG_INTERVAL_SECONDS: Final = SCANNER_WATCHDOG_INTERVAL.total_seconds()
+_LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .base_scanner import BaseHaScanner
+
+
+@dataclass(slots=True)
+class BluetoothScannerDevice:
+    """Data for a bluetooth device from a given scanner."""
+
+    scanner: BaseHaScanner
+    ble_device: BLEDevice
+    advertisement: AdvertisementData

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -26,8 +26,8 @@ from bleak_retry_connector import (
 )
 
 from .base_scanner import BaseHaScanner, BluetoothScannerDevice
+from .central_manager import get_manager
 from .const import CALLBACK_TYPE
-from .models import get_manager
 
 FILTER_UUIDS: Final = "UUIDs"
 _LOGGER = logging.getLogger(__name__)

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -25,15 +25,16 @@ from bleak_retry_connector import (
     device_source,
 )
 
-from .base_scanner import BaseHaScanner, BluetoothScannerDevice
 from .central_manager import get_manager
 from .const import CALLBACK_TYPE
+from .scanner_device import BluetoothScannerDevice
 
 FILTER_UUIDS: Final = "UUIDs"
 _LOGGER = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
+    from .base_scanner import BaseHaScanner
     from .manager import BluetoothManager
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,15 +1,27 @@
 from unittest.mock import ANY
 
+import pytest
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+from bleak_retry_connector import BleakSlotManager
+from bluetooth_adapters import BluetoothAdapters
 
 from habluetooth import (
     BaseHaRemoteScanner,
     BaseHaScanner,
+    BluetoothManager,
     BluetoothScanningMode,
     HaBluetoothConnector,
     HaScanner,
+    set_manager,
 )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def manager():
+    slot_manager = BleakSlotManager()
+    bluetooth_adapters = BluetoothAdapters()
+    set_manager(BluetoothManager(bluetooth_adapters, slot_manager))
 
 
 class MockBleakClient:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest.mock import ANY
 
 from bleak.backends.device import BLEDevice
@@ -36,20 +35,14 @@ def test_create_scanner():
 def test_create_remote_scanner():
     connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
 
-    def callback(data: Any) -> None:
-        pass
-
-    scanner = BaseHaRemoteScanner("any", "any", callback, connector, True)
+    scanner = BaseHaRemoteScanner("any", "any", connector, True)
     assert isinstance(scanner, BaseHaRemoteScanner)
 
 
 def test__async_on_advertisement():
     connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
 
-    def callback(data: Any) -> None:
-        pass
-
-    scanner = BaseHaRemoteScanner("any", "any", callback, connector, True)
+    scanner = BaseHaRemoteScanner("any", "any", connector, True)
     details = scanner._details | {}
     scanner._async_on_advertisement(
         "AA:BB:CC:DD:EE:FF",
@@ -105,10 +98,5 @@ def test__async_on_advertisement():
 
 
 def test_create_ha_scanner():
-    def callback(data: Any) -> None:
-        pass
-
-    scanner = HaScanner(
-        BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF", callback
-    )
+    scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
     assert isinstance(scanner, HaScanner)


### PR DESCRIPTION
The callback always feeds into the manager so there is no need to pass it every time we create a scanner