### PR TITLE
feat!: simplify async_register_scanner by removing connectable argument

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -612,12 +612,11 @@ class BluetoothManager:
     def async_register_scanner(
         self,
         scanner: BaseHaScanner,
-        connectable: bool,
         connection_slots: int | None = None,
     ) -> CALLBACK_TYPE:
         """Register a new scanner."""
         _LOGGER.debug("Registering scanner %s", scanner.name)
-        if connectable:
+        if scanner.connectable:
             scanners = self._connectable_scanners
         else:
             scanners = self._non_connectable_scanners


### PR DESCRIPTION
This can be obtained from the scanner itself.

All other args will be kwargs to avoid future breaking changes