### PR TITLE
fix: switching scanners too quickly

### DIFF
--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -6,6 +6,7 @@ from .models cimport BluetoothServiceInfoBleak
 
 cdef int NO_RSSI_VALUE
 cdef int RSSI_SWITCH_THRESHOLD
+cdef unsigned int TRACKER_BUFFERING_WOBBLE_SECONDS
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -7,6 +7,7 @@ from .models cimport BluetoothServiceInfoBleak
 cdef int NO_RSSI_VALUE
 cdef int RSSI_SWITCH_THRESHOLD
 cdef unsigned int TRACKER_BUFFERING_WOBBLE_SECONDS
+cdef unsigned int FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -6,8 +6,8 @@ from .models cimport BluetoothServiceInfoBleak
 
 cdef int NO_RSSI_VALUE
 cdef int RSSI_SWITCH_THRESHOLD
-cdef unsigned int TRACKER_BUFFERING_WOBBLE_SECONDS
-cdef unsigned int FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
+cdef double TRACKER_BUFFERING_WOBBLE_SECONDS
+cdef double FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -352,7 +352,7 @@ class BluetoothManager:
     ) -> bool:
         """Prefer previous advertisement from a different source if it is better."""
         if stale_seconds := self._intervals.get(
-            address, self._fallback_intervals.get(address)
+            address, self._fallback_intervals.get(address, 0)
         ):
             stale_seconds += TRACKER_BUFFERING_WOBBLE_SECONDS
         else:

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -351,12 +351,12 @@ class BluetoothManager:
         new: BluetoothServiceInfoBleak,
     ) -> bool:
         """Prefer previous advertisement from a different source if it is better."""
-        stale_seconds = self._intervals.get(
-            address,
-            self._fallback_intervals.get(
-                address, FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
-            ),
-        )
+        if stale_seconds := self._intervals.get(
+            address, self._fallback_intervals.get(address)
+        ):
+            stale_seconds += TRACKER_BUFFERING_WOBBLE_SECONDS
+        else:
+            stale_seconds = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
         if new.time - old.time > stale_seconds:
             # If the old advertisement is stale, any new advertisement is preferred
             if self._debug:


### PR DESCRIPTION
We did not account for jitter in the advertising interval so it would switch too quickly.

We now account for up to 5s of jitter