### PR TITLE
feat: improve remote scanner performance

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -25,6 +25,8 @@ cdef class BaseHaScanner:
     cdef public object _loop
     cdef BluetoothManager _manager
 
+    cpdef tuple get_discovered_device_advertisement_data(self, str address)
+
 
 cdef class BaseHaRemoteScanner(BaseHaScanner):
 
@@ -63,4 +65,5 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
 
     cpdef void _schedule_expire_devices(self)
 
-    cpdef get_discovered_device_advertisement_data(self, str address)
+    @cython.locals(info=BluetoothServiceInfoBleak)
+    cpdef tuple get_discovered_device_advertisement_data(self, str address)

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -28,7 +28,6 @@ cdef class BaseHaScanner:
 
 cdef class BaseHaRemoteScanner(BaseHaScanner):
 
-    cdef public dict _discovered_device_advertisement_datas
     cdef public dict _details
     cdef public float _expire_seconds
     cdef public object _cancel_track
@@ -63,3 +62,5 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
     cpdef void _async_expire_devices(self)
 
     cpdef void _schedule_expire_devices(self)
+
+    cpdef get_discovered_device_advertisement_data(self, str address)

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -348,7 +348,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
         self, address: str
     ) -> tuple[BLEDevice, AdvertisementData] | None:
         """Return the advertisement data for a discovered device."""
-        if info := self._previous_service_info.get(address):
+        if (info := self._previous_service_info.get(address)) is not None:
             return info.device, info.advertisement
         return None
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -239,11 +239,7 @@ class BluetoothManager:
         return [
             BluetoothScannerDevice(scanner, *device_adv)
             for scanner in scanners
-            if (
-                device_adv := scanner.discovered_devices_and_advertisement_data.get(
-                    address
-                )
-            )
+            if (device_adv := scanner.get_discovered_device_advertisement_data(address))
         ]
 
     def _async_all_discovered_addresses(self, connectable: bool) -> Iterable[str]:
@@ -253,12 +249,11 @@ class BluetoothManager:
         Include addresses from all the scanners including duplicates.
         """
         yield from itertools.chain.from_iterable(
-            scanner.discovered_devices_and_advertisement_data
-            for scanner in self._connectable_scanners
+            scanner.discovered_addresses for scanner in self._connectable_scanners
         )
         if not connectable:
             yield from itertools.chain.from_iterable(
-                scanner.discovered_devices_and_advertisement_data
+                scanner.discovered_addresses
                 for scanner in self._non_connectable_scanners
             )
 

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import platform
-from typing import TYPE_CHECKING, Any, Coroutine
+from typing import TYPE_CHECKING, Any, Coroutine, Iterable
 
 import bleak
 from bleak import BleakError
@@ -160,6 +160,17 @@ class HaScanner(BaseHaScanner):
         if TYPE_CHECKING:
             assert self.scanner is not None
         return self.scanner.discovered_devices_and_advertisement_data
+
+    @property
+    def discovered_addresses(self) -> Iterable[str]:
+        """Return an iterable of discovered devices."""
+        return self.discovered_devices_and_advertisement_data
+
+    def get_discovered_device_advertisement_data(
+        self, address: str
+    ) -> tuple[BLEDevice, AdvertisementData] | None:
+        """Return the advertisement data for a discovered device."""
+        return self.discovered_devices_and_advertisement_data.get(address)
 
     def async_setup(self) -> CALLBACK_TYPE:
         """Set up the scanner."""

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -285,7 +285,12 @@ class HaBleakClientWrapper(BleakClient):
         if debug_logging:
             # Only lookup the description if we are going to log it
             description = ble_device_description(device)
-            _, adv = scanner.discovered_devices_and_advertisement_data[device.address]
+            device_adv = scanner.get_discovered_device_advertisement_data(
+                device.address
+            )
+            if TYPE_CHECKING:
+                assert device_adv is not None
+            adv = device_adv[1]
             rssi = adv.rssi
             _LOGGER.debug(
                 "%s: Connecting via %s (last rssi: %s)", description, scanner.name, rssi

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -107,6 +107,21 @@ def test__async_on_advertisement():
         rssi=-21,
         platform_data=(),
     )
+    assert len(scanner.discovered_devices) == 1
+    assert scanner.discovered_devices[0].address == "AA:BB:CC:DD:EE:FF"
+    assert len(scanner.discovered_devices_and_advertisement_data) == 1
+    assert (
+        scanner.discovered_devices_and_advertisement_data["AA:BB:CC:DD:EE:FF"][0].rssi
+        == -21
+    )
+    assert (
+        scanner.discovered_devices_and_advertisement_data["AA:BB:CC:DD:EE:FF"][1].rssi
+        == -21
+    )
+    assert "AA:BB:CC:DD:EE:FF" in scanner.discovered_addresses
+    device_adv = scanner.get_discovered_device_advertisement_data("AA:BB:CC:DD:EE:FF")
+    assert device_adv is not None
+    assert device_adv[1] == adv
 
 
 def test_create_ha_scanner():


### PR DESCRIPTION
only store BluetoothServiceInfoBleak as _discovered_device_advertisement_datas can be generated on demand and is now only used for diagnostics