### PR TITLE
fix: ensure unavailable callbacks can be removed from fired callbacks

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -325,7 +325,7 @@ class BluetoothManager:
                 if not (callbacks := unavailable_callbacks.get(address)):
                     continue
 
-                for callback in callbacks:
+                for callback in callbacks.copy():
                     try:
                         callback(service_info)
                     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Make a copy of the set in case it changes during iteration