### PR TITLE
fix: android beacons in passive mode with flags 0x02

### DIFF
--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -38,6 +38,7 @@ if SYSTEM == "Linux":
     # will match all devices.
     PASSIVE_SCANNER_ARGS = BlueZScannerArgs(
         or_patterns=[
+            OrPattern(0, AdvertisementDataType.FLAGS, b"\x02"),
             OrPattern(0, AdvertisementDataType.FLAGS, b"\x06"),
             OrPattern(0, AdvertisementDataType.FLAGS, b"\x1a"),
         ]


### PR DESCRIPTION
bleak uses DBus BlueZ Interface org.bluez.AdvertisementMonitor1 that will return ble packet data always filtred by [data section flags](https://www.google.com/search?q=ble+datasection+flags&oq=ble+datasection+flags&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQLhhA0gEINDA1NGowajSoAgCwAgA&sourceid=chrome&ie=UTF-8#ip=1) 
```
BLE_SIG_ADV_FLAG_LE_LIMITED_DISC_MODE (0x01)
BLE_SIG_ADV_FLAG_LE_GENERAL_DISC_MODE (0x02)
BLE_SIG_ADV_FLAG_BR_EDR_NOT_SUPPORTED (0x04)
BLE_SIG_ADV_FLAG_LE_BR_EDR_CONTROLLER (0x08)
BLE_SIG_ADV_FLAG_LE_BR_EDR_HOST (0x10)
BLE_SIG_ADV_FLAGS_LE_ONLY_LIMITED_DISC_MODE (0x05)
BLE_SIG_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE (0x06)
```
there seems to be no way to force it to return all packets like in active scan mode 

currenty we are filterining flags **06** `(LE_SIG_ADV_FLAG_LE_GENERAL_DISC_MODE and BLE_SIG_ADV_FLAG_BR_EDR_NOT_SUPPORTED)` or **1a** `(LE_SIG_ADV_FLAG_LE_GENERAL_DISC_MODE, BLE_SIG_ADV_FLAG_LE_BR_EDR_HOST, BLE_SIG_ADV_FLAG_LE_BR_EDR_CONTROLLER)`

problem is that Android BLE doesn't have API to configure these flags, there is one solution we can set [AdvertiseSettings.Builder.setConnectable](https://developer.android.com/reference/android/bluetooth/le/AdvertiseSettings.Builder#setConnectable(boolean)) to true and we will get 
![image](https://github.com/Bluetooth-Devices/habluetooth/assets/1270275/e1812c13-8c6f-42f8-91ff-5ddc1dfabc4e)

it should be already set in HA companion app

but as you can see it sets just flag BLE_SIG_ADV_FLAG_LE_GENERAL_DISC_MODE and currently such packet will be filtered out.

this PR changes filtering to include all ble packets that have set BLE_SIG_ADV_FLAG_LE_GENERAL_DISC_MODE (0x02)

all BLE devices that was working before this change continues working 
IBeacon integration works in passive mode for Android devices

![image](https://github.com/Bluetooth-Devices/habluetooth/assets/1270275/01cbca35-eaa0-491c-afbc-3d5698dae1fd)
![image](https://github.com/Bluetooth-Devices/habluetooth/assets/1270275/5a97b34f-6ee5-4e27-a029-1603ff5d6957)






