### PR TITLE
fix: ensure discovered_devices returns an empty list for offline scanners

### DIFF
--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import platform
-from typing import TYPE_CHECKING, Any, Coroutine, Iterable
+from typing import Any, Coroutine, Iterable
 
 import bleak
 from bleak import BleakError
@@ -166,8 +166,8 @@ class HaScanner(BaseHaScanner):
     @property
     def discovered_devices(self) -> list[BLEDevice]:
         """Return a list of discovered devices."""
-        if TYPE_CHECKING:
-            assert self.scanner is not None
+        if not self.scanner:
+            return []
         return self.scanner.discovered_devices
 
     @property
@@ -175,8 +175,8 @@ class HaScanner(BaseHaScanner):
         self,
     ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
         """Return a list of discovered devices and advertisement data."""
-        if TYPE_CHECKING:
-            assert self.scanner is not None
+        if not self.scanner:
+            return {}
         return self.scanner.discovered_devices_and_advertisement_data
 
     @property

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -56,6 +56,15 @@ def manager():
 
 
 @pytest.mark.asyncio
+async def test_empty_data_no_scanner() -> None:
+    """Test we handle empty data."""
+    scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
+    scanner.async_setup()
+    assert scanner.discovered_devices == []
+    assert scanner.discovered_devices_and_advertisement_data == {}
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif("platform.system() != 'Linux'")
 async def test_dbus_socket_missing_in_container(
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
This to fix a un-intended breaking change introduced in 2.5.0