### PR TITLE
feat!: make generation of AdvertisementData lazy

### DIFF
--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Final, Iterable, final
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-from bleak_retry_connector import NO_RSSI_VALUE
 from bluetooth_adapters import DiscoveredDeviceAdvertisementData, adapter_human_name
 from bluetooth_data_tools import monotonic_time_coarse
 
@@ -238,6 +237,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
                 adv,
                 self.connectable,
                 discovered_device_timestamps[address],
+                adv.tx_power,
             )
             for address, (
                 device,
@@ -422,15 +422,6 @@ class BaseHaRemoteScanner(BaseHaScanner):
             # pylint: disable-next=protected-access
             device._rssi = rssi  # deprecated, will be removed in newer bleak
 
-        advertisement_data = AdvertisementData(
-            None if local_name == "" else local_name,
-            manufacturer_data,
-            service_data,
-            service_uuids,
-            NO_RSSI_VALUE if tx_power is None else tx_power,
-            rssi,
-            (),
-        )
         service_info = BluetoothServiceInfoBleak(
             local_name or address,
             address,
@@ -440,9 +431,10 @@ class BaseHaRemoteScanner(BaseHaScanner):
             service_uuids,
             self.source,
             device,
-            advertisement_data,
+            None,
             self.connectable,
             advertisement_monotonic_time,
+            tx_power,
         )
         self._previous_service_info[address] = service_info
         self._manager.scanner_adv_received(service_info)

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -567,6 +567,7 @@ class BluetoothManager:
                 service_info.advertisement,
                 True,
                 service_info.time,
+                service_info.tx_power,
             )
 
         if (connectable or old_connectable_service_info is not None) and (

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -26,5 +26,6 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
 
     cdef public object device
     cdef public bint connectable
+    cdef public object _advertisement
     cdef public double time
     cdef public int tx_power

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -28,3 +28,4 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public object advertisement
     cdef public bint connectable
     cdef public double time
+    cdef public int tx_power

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -28,4 +28,4 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public bint connectable
     cdef public object _advertisement
     cdef public double time
-    cdef public int tx_power
+    cdef public object tx_power

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -25,7 +25,6 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     """BluetoothServiceInfo with bleak data."""
 
     cdef public object device
-    cdef public object advertisement
     cdef public bint connectable
     cdef public double time
     cdef public int tx_power

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -167,7 +167,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.service_uuids = service_uuids
         self.source = source
         self.device = device
-        if advertisement is None:
+        if advertisement is not None:
             self.__dict__["advertisement"] = advertisement
         self.connectable = connectable
         self.time = time

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -158,7 +158,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         advertisement: AdvertisementData | None,
         connectable: bool,
         time: _float,
-        tx_power: int | None,
+        tx_power: _int | None,
     ) -> None:
         self.name = name
         self.address = address

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
 from bleak import BaseBleakClient
@@ -144,6 +143,8 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     internal details.
     """
 
+    __slots__ = ("device", "_advertisement", "connectable", "time", "tx_power")
+
     def __init__(
         self,
         name: _str,  # may be a pyobjc object
@@ -167,24 +168,25 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.service_uuids = service_uuids
         self.source = source
         self.device = device
-        if advertisement is not None:
-            self.__dict__["advertisement"] = advertisement
+        self._advertisement = advertisement
         self.connectable = connectable
         self.time = time
         self.tx_power = tx_power
 
-    @cached_property
+    @property
     def advertisement(self) -> AdvertisementData:
         """Get the advertisement data."""
-        return AdvertisementData(
-            None if self.name == "" else self.name,
-            self.manufacturer_data,
-            self.service_data,
-            self.service_uuids,
-            NO_RSSI_VALUE if self.tx_power is None else self.tx_power,
-            self.rssi,
-            (),
-        )
+        if self._advertisement is None:
+            self._advertisement = AdvertisementData(
+                None if self.name == "" else self.name,
+                self.manufacturer_data,
+                self.service_data,
+                self.service_uuids,
+                NO_RSSI_VALUE if self.tx_power is None else self.tx_power,
+                self.rssi,
+                (),
+            )
+        return self._advertisement
 
     def as_dict(self) -> dict[str, Any]:
         """

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -205,6 +205,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
             "device": self.device,
             "connectable": self.connectable,
             "time": self.time,
+            "tx_power": self.tx_power,
         }
 
     @classmethod

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -236,6 +236,9 @@ class HaScanner(BaseHaScanner):
         name = advertisement_data.local_name or device.name or device.address
         if name is not None and type(name) is not str:
             name = str(name)
+        tx_power = advertisement_data.tx_power
+        if tx_power is not None and type(tx_power) is not int:
+            tx_power = int(tx_power)
         self._manager.scanner_adv_received(
             BluetoothServiceInfoBleak(
                 name,
@@ -249,7 +252,7 @@ class HaScanner(BaseHaScanner):
                 advertisement_data,
                 True,
                 callback_time,
-                advertisement_data.tx_power,
+                tx_power,
             )
         )
 

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -249,6 +249,7 @@ class HaScanner(BaseHaScanner):
                 advertisement_data,
                 True,
                 callback_time,
+                advertisement_data.tx_power,
             )
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -86,6 +86,7 @@ def test_model_from_scanner():
         "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
         "source": "local",
         "time": now,
+        "tx_power": -127,
     }
 
 
@@ -131,6 +132,7 @@ def test_construct_service_info_bleak():
         "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
         "source": "local",
         "time": now,
+        "tx_power": 1,
     }
 
 
@@ -168,6 +170,7 @@ def test_from_device_and_advertisement_data():
         "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
         "source": "local",
         "time": now_monotonic,
+        "tx_power": -127,
     }
 
 
@@ -227,4 +230,5 @@ def test_pyobjc_compat():
         "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
         "source": "local",
         "time": now,
+        "tx_power": 1,
     }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,6 +107,7 @@ def test_construct_service_info_bleak():
         advertisement=switchbot_adv,
         connectable=False,
         time=now,
+        tx_power=1,
     )
 
     assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
@@ -202,6 +203,7 @@ def test_pyobjc_compat():
         advertisement=switchbot_adv,
         connectable=False,
         time=now,
+        tx_power=1,
     )
 
     assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]


### PR DESCRIPTION
This is ~14% speed up for remote scanners.

`tx_power` is now required for `BluetoothServiceInfoBleak` which is a breaking change for tests