### PR TITLE
feat: override DeviceFound and DeviceLost for passive monitoring

### DIFF
--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -63,7 +63,12 @@ if IS_LINUX:
         def DeviceLost(self, device: "o"):  # noqa: UP037, F821
             """Device lost."""
 
-    advertisement_monitor.AdvertisementMonitor = HaAdvertisementMonitor
+    advertisement_monitor.AdvertisementMonitor.DeviceFound = (
+        HaAdvertisementMonitor.DeviceFound
+    )
+    advertisement_monitor.AdvertisementMonitor.DeviceLost = (
+        HaAdvertisementMonitor.DeviceLost
+    )
 
 OriginalBleakScanner = bleak.BleakScanner
 


### PR DESCRIPTION
These are only used for debugging and they generate 10000s of callbacks per minute that flood the debug logs with useless data.  Passive mode generated ~100x more log messages than active mode.