### PR TITLE
fix: increase rssi switch threshold for advertisements

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -53,3 +53,11 @@ UNAVAILABLE_TRACK_SECONDS: Final = 60 * 5
 
 
 FAILED_ADAPTER_MAC = "00:00:00:00:00:00"
+
+
+ADV_RSSI_SWITCH_THRESHOLD: Final = 10
+# The switch threshold for the rssi value
+# to switch to a different adapter for advertisements
+# Note that this does not affect the connection
+# selection that uses RSSI_SWITCH_THRESHOLD from
+# bleak_retry_connector

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -5,7 +5,7 @@ from .base_scanner cimport BaseHaScanner
 from .models cimport BluetoothServiceInfoBleak
 
 cdef int NO_RSSI_VALUE
-cdef int RSSI_SWITCH_THRESHOLD
+cdef int ADV_RSSI_SWITCH_THRESHOLD
 cdef double TRACKER_BUFFERING_WOBBLE_SECONDS
 cdef double FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 cdef object FILTER_UUIDS

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -10,7 +10,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Final
 
 from bleak.backends.scanner import AdvertisementDataCallback
-from bleak_retry_connector import NO_RSSI_VALUE, RSSI_SWITCH_THRESHOLD, BleakSlotManager
+from bleak_retry_connector import NO_RSSI_VALUE, BleakSlotManager
 from bluetooth_adapters import (
     ADAPTER_ADDRESS,
     ADAPTER_PASSIVE_SCAN,
@@ -24,6 +24,7 @@ from .advertisement_tracker import (
     AdvertisementTracker,
 )
 from .const import (
+    ADV_RSSI_SWITCH_THRESHOLD,
     CALLBACK_TYPE,
     FAILED_ADAPTER_MAC,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -430,10 +431,10 @@ class BluetoothManager:
                     stale_seconds,
                 )
             return False
-        if (new.rssi or NO_RSSI_VALUE) - RSSI_SWITCH_THRESHOLD > (
+        if (new.rssi or NO_RSSI_VALUE) - ADV_RSSI_SWITCH_THRESHOLD > (
             old.rssi or NO_RSSI_VALUE
         ):
-            # If new advertisement is RSSI_SWITCH_THRESHOLD more,
+            # If new advertisement is ADV_RSSI_SWITCH_THRESHOLD more,
             # the new one is preferred.
             if self._debug:
                 _LOGGER.debug(
@@ -446,7 +447,7 @@ class BluetoothManager:
                     self._async_describe_source(old),
                     self._async_describe_source(new),
                     new.rssi,
-                    RSSI_SWITCH_THRESHOLD,
+                    ADV_RSSI_SWITCH_THRESHOLD,
                     old.rssi,
                 )
             return False


### PR DESCRIPTION
The switch threshold was previously 5 which meant switching happened too frequently and reduced update frequency for devices which need to get updates from the same scanner because it was flip-flopping

Note that this does not affect the connect rssi calculation as that always uses the best available path