### PR TITLE
fix: increase RSSI switch value to 16

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -55,7 +55,7 @@ UNAVAILABLE_TRACK_SECONDS: Final = 60 * 5
 FAILED_ADAPTER_MAC = "00:00:00:00:00:00"
 
 
-ADV_RSSI_SWITCH_THRESHOLD: Final = 10
+ADV_RSSI_SWITCH_THRESHOLD: Final = 16
 # The switch threshold for the rssi value
 # to switch to a different adapter for advertisements
 # Note that this does not affect the connection


### PR DESCRIPTION
followup to #110

Even at 10 we still see it switch too often in high density environments

It make make sense not to even switch at all anymore since we have a timeout when the data we have is stale.