### PR TITLE
feat: add support for connection allocations for non-connectable scanners

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -720,6 +720,9 @@ class BluetoothManager:
             scanners = self._connectable_scanners
         else:
             scanners = self._non_connectable_scanners
+            self._allocations[scanner.source] = HaBluetoothSlotAllocations(
+                source=scanner.source, slots=0, free=0, allocated=[]
+            )
         scanners.add(scanner)
         self._sources[scanner.source] = scanner
         self._adapter_sources[scanner.adapter] = scanner.source

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -47,7 +47,7 @@ def set_manager(manager: BluetoothManager) -> None:
     CentralBluetoothManager.manager = manager
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, frozen=True)
 class HaBluetoothSlotAllocations:
     """Data for how to allocate slots for BLEDevice connections."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from bleak_retry_connector import BleakSlotManager
 from bluetooth_adapters import AdapterDetails, BluetoothAdapters
 
 from habluetooth import (
+    BaseHaRemoteScanner,
     BaseHaScanner,
     BluetoothManager,
     get_manager,
@@ -161,6 +162,7 @@ def two_adapters_fixture():
 def register_hci0_scanner() -> Generator[None, None, None]:
     """Register an hci0 scanner."""
     hci0_scanner = FakeScanner("AA:BB:CC:DD:EE:00", "hci0")
+    hci0_scanner.connectable = True
     manager = get_manager()
     cancel = manager.async_register_scanner(hci0_scanner, connection_slots=5)
     yield
@@ -171,7 +173,20 @@ def register_hci0_scanner() -> Generator[None, None, None]:
 def register_hci1_scanner() -> Generator[None, None, None]:
     """Register an hci1 scanner."""
     hci1_scanner = FakeScanner("AA:BB:CC:DD:EE:11", "hci1")
+    hci1_scanner.connectable = True
     manager = get_manager()
     cancel = manager.async_register_scanner(hci1_scanner, connection_slots=5)
+    yield
+    cancel()
+
+
+@pytest.fixture
+def register_non_connectable_scanner() -> Generator[None, None, None]:
+    """Register an non connectable remote scanner."""
+    remote_scanner = BaseHaRemoteScanner(
+        "AA:BB:CC:DD:EE:FF", "non connectable", None, False
+    )
+    manager = get_manager()
+    cancel = manager.async_register_scanner(remote_scanner)
     yield
     cancel()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -314,3 +314,21 @@ async def test_async_register_allocation_callback(
     ]
     cancel1()
     cancel2()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_async_register_allocation_callback_non_connectable(
+    register_non_connectable_scanner: None,
+) -> None:
+    """Test async_current_allocations for a non-connectable scanner."""
+    manager = get_manager()
+    assert manager._loop is not None
+    assert manager.async_current_allocations() == [
+        HaBluetoothSlotAllocations(
+            source="AA:BB:CC:DD:EE:FF",
+            slots=0,
+            free=0,
+            allocated=[],
+        ),
+    ]


### PR DESCRIPTION
These should always be fixed to 0 free, 0 slots