### PR TITLE
feat: include findmy packets in wanted adverts

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -60,11 +60,13 @@ APPLE_IBEACON_START_BYTE: Final = 0x02  # iBeacon (tilt_ble)
 APPLE_HOMEKIT_START_BYTE: Final = 0x06  # homekit_controller
 APPLE_DEVICE_ID_START_BYTE: Final = 0x10  # bluetooth_le_tracker
 APPLE_HOMEKIT_NOTIFY_START_BYTE: Final = 0x11  # homekit_controller
+APPLE_FINDMY_START_BYTE: Final = 0x12  # FindMy network advertisements
 APPLE_START_BYTES_WANTED: Final = {
     APPLE_IBEACON_START_BYTE,
     APPLE_HOMEKIT_START_BYTE,
     APPLE_HOMEKIT_NOTIFY_START_BYTE,
     APPLE_DEVICE_ID_START_BYTE,
+    APPLE_FINDMY_START_BYTE,
 }
 
 _str = str


### PR DESCRIPTION
Not filtering FindMy adverts provides more reliable detection of Apple products when using the "Private BLE Device" core integration and custom integrations such as Bermuda and in future the FindMy integration, particularly for OpenHaystack-derived devices.