### PR TITLE
feat: remove the need to call set_manager to set up

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -300,6 +300,10 @@ class BluetoothManager:
 
     async def async_setup(self) -> None:
         """Set up the bluetooth manager."""
+        from .central_manager import CentralBluetoothManager
+
+        if CentralBluetoothManager.manager is None:
+            CentralBluetoothManager.manager = self
         self._loop = asyncio.get_running_loop()
         await self._async_refresh_adapters()
         install_multiple_bleak_catcher()


### PR DESCRIPTION
This makes it a bit easier to use outside of ha since everything can be set up with

```
await habluetooth.BluetoothManager().async_setup()
``