### PR TITLE
fix: ensure allocations are available if the adapter never makes any connections

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -749,10 +749,10 @@ class BluetoothManager:
         self._sources[scanner.source] = scanner
         self._adapter_sources[scanner.adapter] = scanner.source
         if connection_slots:
+            self.slot_manager.register_adapter(scanner.adapter, connection_slots)
             self.async_on_allocation_changed(
                 self.slot_manager.get_allocations(scanner.adapter)
             )
-            self.slot_manager.register_adapter(scanner.adapter, connection_slots)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.ADDED)
         return partial(
             self._async_unregister_scanner_internal, scanners, scanner, connection_slots

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -749,6 +749,9 @@ class BluetoothManager:
         self._sources[scanner.source] = scanner
         self._adapter_sources[scanner.adapter] = scanner.source
         if connection_slots:
+            self.async_on_allocation_changed(
+                self.slot_manager.get_allocations(scanner.adapter)
+            )
             self.slot_manager.register_adapter(scanner.adapter, connection_slots)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.ADDED)
         return partial(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -381,6 +381,9 @@ async def test_async_register_scanner_registration_callback(
         HaScannerRegistrationEvent.ADDED, hci3_scanner
     )
     assert len(failed_scanner_callbacks) == 1
+    assert manager.async_current_allocations(hci3_scanner.source) == [
+        HaBluetoothSlotAllocations(hci3_scanner.source, 5, 5, [])
+    ]
 
     cancel()
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -267,7 +267,14 @@ async def test_async_register_allocation_callback(
         switchbot_device_signal_100, switchbot_adv_signal_100, "hci1"
     )
 
-    assert manager.async_current_allocations() == []
+    assert manager.async_current_allocations() == [
+        HaBluetoothSlotAllocations(
+            source="AA:BB:CC:DD:EE:00", slots=5, free=5, allocated=[]
+        ),
+        HaBluetoothSlotAllocations(
+            source="AA:BB:CC:DD:EE:11", slots=5, free=5, allocated=[]
+        ),
+    ]
     manager.async_on_allocation_changed(
         Allocations(
             "AA:BB:CC:DD:EE:00",
@@ -309,10 +316,13 @@ async def test_async_register_allocation_callback(
     assert len(ok_allocations) == 2
 
     assert manager.async_current_allocations() == [
-        HaBluetoothSlotAllocations("AA:BB:CC:DD:EE:00", 5, 4, ["44:44:33:11:23:12"])
+        HaBluetoothSlotAllocations("AA:BB:CC:DD:EE:00", 5, 4, ["44:44:33:11:23:12"]),
+        HaBluetoothSlotAllocations(
+            source="AA:BB:CC:DD:EE:11", slots=5, free=5, allocated=[]
+        ),
     ]
     assert manager.async_current_allocations("AA:BB:CC:DD:EE:00") == [
-        HaBluetoothSlotAllocations("AA:BB:CC:DD:EE:00", 5, 4, ["44:44:33:11:23:12"])
+        HaBluetoothSlotAllocations("AA:BB:CC:DD:EE:00", 5, 4, ["44:44:33:11:23:12"]),
     ]
     cancel1()
     cancel2()
@@ -393,16 +403,13 @@ async def test_async_register_scanner_registration_callback(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("enable_bluetooth")
 async def test_async_register_scanner_with_connection_slots() -> None:
     """Test registering a scanner with connection slots."""
     manager = get_manager()
     assert manager._loop is not None
 
     scanners = manager.async_current_scanners()
-    assert len(scanners) == 2
-    sources = {scanner.source for scanner in scanners}
-    assert sources == {"AA:BB:CC:DD:EE:00", "AA:BB:CC:DD:EE:11"}
+    assert len(scanners) == 0
 
     hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
     hci3_scanner.connectable = True

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -381,9 +381,6 @@ async def test_async_register_scanner_registration_callback(
         HaScannerRegistrationEvent.ADDED, hci3_scanner
     )
     assert len(failed_scanner_callbacks) == 1
-    assert manager.async_current_allocations(hci3_scanner.source) == [
-        HaBluetoothSlotAllocations(hci3_scanner.source, 5, 5, [])
-    ]
 
     cancel()
 
@@ -393,6 +390,29 @@ async def test_async_register_scanner_registration_callback(
     )
     cancel1()
     cancel2()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_async_register_scanner_with_connection_slots() -> None:
+    """Test registering a scanner with connection slots."""
+    manager = get_manager()
+    assert manager._loop is not None
+
+    scanners = manager.async_current_scanners()
+    assert len(scanners) == 2
+    sources = {scanner.source for scanner in scanners}
+    assert sources == {"AA:BB:CC:DD:EE:00", "AA:BB:CC:DD:EE:11"}
+
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    hci3_scanner.connectable = True
+    manager = get_manager()
+    cancel = manager.async_register_scanner(hci3_scanner, connection_slots=5)
+    assert manager.async_current_allocations(hci3_scanner.source) == [
+        HaBluetoothSlotAllocations(hci3_scanner.source, 5, 5, [])
+    ]
+
+    cancel()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allocations would not return anything if the adapter had never made any connections