### PR TITLE
feat: add debug logging for connection paths

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -388,7 +388,7 @@ class HaBleakClientWrapper(BleakClient):
 
         if sorted_devices and _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
-                "%s (%s): Found %s connection path(s), preferred order: %s",
+                "%s - %s: Found %s connection path(s), preferred order: %s",
                 address,
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -388,7 +388,7 @@ class HaBleakClientWrapper(BleakClient):
 
         if sorted_devices and _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
-                "%s (%s): Found %s connection paths, preferred order: %s",
+                "%s (%s): Found %s connection path(s), preferred order: %s",
                 address,
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -392,10 +392,8 @@ class HaBleakClientWrapper(BleakClient):
                 address,
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),
-                " ,".join(
-                    f"{ble_device_description(device.ble_device)} "
-                    f"with RSSI {device.advertisement.rssi} via "
-                    f"{device.scanner.name}"
+                ", ".join(
+                    f"RSSI {device.advertisement.rssi} via " f"{device.scanner.name}"
                     for device in sorted_devices
                 ),
             )

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -393,7 +393,7 @@ class HaBleakClientWrapper(BleakClient):
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),
                 ", ".join(
-                    f"RSSI {device.advertisement.rssi} via " f"{device.scanner.name}"
+                    f"RSSI {device.advertisement.rssi} via {device.scanner.name}"
                     for device in sorted_devices
                 ),
             )

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -393,7 +393,7 @@ class HaBleakClientWrapper(BleakClient):
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),
                 ", ".join(
-                    f"RSSI {device.advertisement.rssi} via {device.scanner.name}"
+                    f"{device.scanner.name} (RSSI {device.advertisement.rssi})"
                     for device in sorted_devices
                 ),
             )

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -393,7 +393,9 @@ class HaBleakClientWrapper(BleakClient):
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),
                 ", ".join(
-                    f"{device.scanner.name} (RSSI {device.advertisement.rssi})"
+                    f"{device.scanner.name} "
+                    f"(RSSI={device.advertisement.rssi}) "
+                    f"(attempts={self.__connect_failures.get(device.scanner, 0)})"
                     for device in sorted_devices
                 ),
             )

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -386,6 +386,20 @@ class HaBleakClientWrapper(BleakClient):
                 reverse=True,
             )
 
+        if sorted_devices and _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "%s (%s): Found %s connection paths, preferred order: %s",
+                address,
+                sorted_devices[0].ble_device.name,
+                len(sorted_devices),
+                " ,".join(
+                    f"{ble_device_description(device.ble_device)} "
+                    f"with RSSI {device.advertisement.rssi} via "
+                    f"{device.scanner.name}"
+                    for device in sorted_devices
+                ),
+            )
+
         for device in sorted_devices:
             if backend := self._async_get_backend_for_ble_device(
                 manager, device.scanner, device.ble_device

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -395,7 +395,7 @@ class HaBleakClientWrapper(BleakClient):
                 ", ".join(
                     f"{device.scanner.name} "
                     f"(RSSI={device.advertisement.rssi}) "
-                    f"(attempts={self.__connect_failures.get(device.scanner, 0)})"
+                    f"(failures={self.__connect_failures.get(device.scanner, 0)})"
                     for device in sorted_devices
                 ),
             )


### PR DESCRIPTION
2025-02-21 17:15:39.419 DEBUG (MainThread) [habluetooth.wrappers] 10:76:36:14:93:76 (TP393 (9376)): Found 2 connection paths, preferred order: kitchenalexproxy (24:4C:AB:03:63:A0) (RSSI=-92) (failures=0), masterbathalexproxy (24:4C:AB:03:0B:6C) (RSSI=-92) (failures=0)
2025-02-21 17:15:39.419 DEBUG (MainThread) [habluetooth.wrappers] 10:76:36:14:93:76 - TP393 (9376) -> 24:4C:AB:03:63:A0: Connecting via kitchenalexproxy (24:4C:AB:03:63:A0) (last rssi: -92)