### PR TITLE
feat: improve manager performance

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -71,3 +71,9 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
 
     @cython.locals(info=BluetoothServiceInfoBleak)
     cpdef tuple get_discovered_device_advertisement_data(self, str address)
+
+    @cython.locals(info=BluetoothServiceInfoBleak)
+    cdef dict _build_discovered_device_advertisement_datas(self)
+
+    @cython.locals(info=BluetoothServiceInfoBleak)
+    cdef dict _build_discovered_device_timestamps(self)

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Final, Iterable, final
@@ -285,29 +286,40 @@ class BaseHaRemoteScanner(BaseHaScanner):
         return DiscoveredDeviceAdvertisementData(
             self.connectable,
             self._expire_seconds,
-            self._discovered_device_advertisement_datas,
-            self._discovered_device_timestamps,
+            self._build_discovered_device_advertisement_datas(),
+            self._build_discovered_device_timestamps(),
         )
-
-    @property
-    def _discovered_device_advertisement_datas(
-        self,
-    ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
-        """Return a list of discovered devices and advertisement data."""
-        return {
-            address: (
-                service_info.device,
-                service_info._advertisement_internal(),
-            )
-            for address, service_info in self._previous_service_info.items()
-        }
 
     @property
     def _discovered_device_timestamps(self) -> dict[str, float]:
         """Return a dict of discovered device timestamps."""
+        warnings.warn(
+            "BaseHaRemoteScanner._discovered_device_timestamps is deprecated "
+            "and will be removed in a future version of habluetooth, use "
+            "BaseHaRemoteScanner.discovered_device_timestamps instead",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._build_discovered_device_timestamps()
+
+    @property
+    def discovered_device_timestamps(self) -> dict[str, float]:
+        """Return a dict of discovered device timestamps."""
+        return self._build_discovered_device_timestamps()
+
+    def _build_discovered_device_advertisement_datas(
+        self,
+    ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
+        """Return a list of discovered devices and advertisement data."""
         return {
-            address: service_info.time
-            for address, service_info in self._previous_service_info.items()
+            address: (info.device, info._advertisement_internal())
+            for address, info in self._previous_service_info.items()
+        }
+
+    def _build_discovered_device_timestamps(self) -> dict[str, float]:
+        """Return a dict of discovered device timestamps."""
+        return {
+            address: info.time for address, info in self._previous_service_info.items()
         }
 
     def _cancel_expire_devices(self) -> None:
@@ -368,7 +380,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
         self,
     ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
         """Return a list of discovered devices and advertisement data."""
-        return self._discovered_device_advertisement_datas
+        return self._build_discovered_device_advertisement_datas()
 
     @property
     def discovered_addresses(self) -> Iterable[str]:
@@ -488,7 +500,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
     async def async_diagnostics(self) -> dict[str, Any]:
         """Return diagnostic information about the scanner."""
         now = monotonic_time_coarse()
-        discovered_device_timestamps = self._discovered_device_timestamps
+        discovered_device_timestamps = self._build_discovered_device_timestamps()
         return await super().async_diagnostics() | {
             "discovered_device_timestamps": discovered_device_timestamps,
             "time_since_last_device_detection": {

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -297,7 +297,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
         return {
             address: (
                 service_info.device,
-                service_info.advertisement,
+                service_info._advertisement_internal(),
             )
             for address, service_info in self._previous_service_info.items()
         }

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -595,6 +595,10 @@ class BluetoothManager:
             not (service_info.connectable and old_connectable_service_info is None)
             # Than check if advertisement data is the same
             and old_service_info is not None
+            # This is a bit complex because we want to skip all the
+            # PyObject_RichCompare overhead as its can be upwards of
+            # 65% of the time spent in this method. The common case
+            # is that its the same object for remote scanners.
             and not (
                 (
                     service_info.manufacturer_data

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -626,7 +626,7 @@ class BluetoothManager:
             self._bleak_callbacks is not None
         ):
             # Bleak callbacks must get a connectable device
-            advertisement_data = service_info.advertisement
+            advertisement_data = service_info._advertisement_internal()
             for bleak_callback in self._bleak_callbacks:
                 _dispatch_bleak_callback(
                     bleak_callback, service_info.device, advertisement_data

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -34,5 +34,4 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     @cython.locals(new_obj=BluetoothServiceInfoBleak)
     cpdef BluetoothServiceInfoBleak _as_connectable(self)
 
-    @property
-    cpdef object advertisement(self)
+    cdef object _advertisement_internal(self)

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -33,3 +33,6 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
 
     @cython.locals(new_obj=BluetoothServiceInfoBleak)
     cpdef BluetoothServiceInfoBleak _as_connectable(self)
+
+    @property
+    cpdef object advertisement(self)

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -208,9 +208,12 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
             f"tx_power={self.tx_power}>"
         )
 
-    @property
-    def advertisement(self) -> AdvertisementData:
-        """Get the advertisement data."""
+    def _advertisement_internal(self) -> AdvertisementData:
+        """
+        Get the advertisement data.
+
+        Internal method only to be used by this library.
+        """
         if self._advertisement is None:
             self._advertisement = tuple.__new__(
                 AdvertisementData,
@@ -225,6 +228,11 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
                 ),
             )
         return self._advertisement
+
+    @property
+    def advertisement(self) -> AdvertisementData:
+        """Get the advertisement data."""
+        return self._advertisement_internal()
 
     def as_dict(self) -> dict[str, Any]:
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,9 @@ from habluetooth.models import BluetoothServiceInfoBleak
 
 utcnow = partial(datetime.now, timezone.utc)
 
+HCI0_SOURCE_ADDRESS = "AA:BB:CC:DD:EE:00"
+HCI1_SOURCE_ADDRESS = "AA:BB:CC:DD:EE:11"
+NON_CONNECTABLE_REMOTE_SOURCE_ADDRESS = "AA:BB:CC:DD:EE:FF"
 
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from functools import partial
 from typing import Any, Generator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 
@@ -153,3 +153,20 @@ def inject_advertisement_with_time_and_source_connectable(
             tx_power=adv.tx_power,
         )
     )
+
+
+@contextmanager
+def patch_discovered_devices(
+    mock_discovered: list[BLEDevice],
+) -> Generator[None, None, None]:
+    """Mock the combined best path to discovered devices from all the scanners."""
+    manager = get_manager()
+    original_all_history = manager._all_history
+    original_connectable_history = manager._connectable_history
+    manager._connectable_history = {}
+    manager._all_history = {
+        device.address: MagicMock(device=device) for device in mock_discovered
+    }
+    yield
+    manager._all_history = original_all_history
+    manager._connectable_history = original_connectable_history

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,19 @@ async def mock_enable_bluetooth(
     assert manager._bluetooth_adapters is not None
     await manager.async_setup()
     yield
+    manager._all_history.clear()
+    manager._connectable_history.clear()
+    manager._unavailable_callbacks.clear()
+    manager._connectable_unavailable_callbacks.clear()
+    manager._bleak_callbacks.clear()
+    manager._fallback_intervals.clear()
+    manager._intervals.clear()
+    manager._adapter_sources.clear()
+    manager._adapters.clear()
+    manager._sources.clear()
+    manager._allocations.clear()
+    manager._non_connectable_scanners.clear()
+    manager._connectable_scanners.clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,7 +172,7 @@ def two_adapters_fixture():
 
 
 @pytest.fixture(name="macos_adapter")
-def macos_adapter() -> Generator[None]:
+def macos_adapter() -> Generator[None, None, None]:
     """Fixture that mocks the macos adapter."""
     with (
         patch("bleak.get_platform_scanner_backend_type"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,24 @@ def two_adapters_fixture():
         yield
 
 
+@pytest.fixture(name="macos_adapter")
+def macos_adapter() -> Generator[None]:
+    """Fixture that mocks the macos adapter."""
+    with (
+        patch("bleak.get_platform_scanner_backend_type"),
+        patch(
+            "habluetooth.scanner.platform.system",
+            return_value="Darwin",
+        ),
+        patch(
+            "bluetooth_adapters.systems.platform.system",
+            return_value="Darwin",
+        ),
+        patch("habluetooth.scanner.SYSTEM", "Darwin"),
+    ):
+        yield
+
+
 @pytest.fixture
 def register_hci0_scanner() -> Generator[None, None, None]:
     """Register an hci0 scanner."""

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -247,6 +247,12 @@ async def test_remote_scanner_expires_non_connectable() -> None:
     assert len(scanner.discovered_devices_and_advertisement_data) == 1
     assert len(scanner.discovered_device_timestamps) == 1
     assert len(scanner._discovered_device_timestamps) == 1
+    dev_adv = scanner.get_discovered_device_advertisement_data(switchbot_device.address)
+    assert dev_adv is not None
+    dev, adv = dev_adv
+    assert dev.name == "wohand"
+    assert adv.local_name == "wohand"
+    assert adv.manufacturer_data == switchbot_device_adv.manufacturer_data
     assert devices[0].name == "wohand"
 
     assert (
@@ -273,6 +279,10 @@ async def test_remote_scanner_expires_non_connectable() -> None:
     assert len(scanner.discovered_devices_and_advertisement_data) == 0
     assert len(scanner.discovered_device_timestamps) == 0
     assert len(scanner._discovered_device_timestamps) == 0
+    assert (
+        scanner.get_discovered_device_advertisement_data(switchbot_device.address)
+        is None
+    )
 
     expire_monotonic = (
         start_time_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1
@@ -288,6 +298,10 @@ async def test_remote_scanner_expires_non_connectable() -> None:
     assert len(scanner.discovered_devices_and_advertisement_data) == 0
     assert len(scanner.discovered_device_timestamps) == 0
     assert len(scanner._discovered_device_timestamps) == 0
+    assert (
+        scanner.get_discovered_device_advertisement_data(switchbot_device.address)
+        is None
+    )
 
     cancel()
     unsetup()

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -245,6 +245,8 @@ async def test_remote_scanner_expires_non_connectable() -> None:
     devices = scanner.discovered_devices
     assert len(scanner.discovered_devices) == 1
     assert len(scanner.discovered_devices_and_advertisement_data) == 1
+    assert len(scanner.discovered_device_timestamps) == 1
+    assert len(scanner._discovered_device_timestamps) == 1
     assert devices[0].name == "wohand"
 
     assert (
@@ -269,6 +271,8 @@ async def test_remote_scanner_expires_non_connectable() -> None:
 
     assert len(scanner.discovered_devices) == 0
     assert len(scanner.discovered_devices_and_advertisement_data) == 0
+    assert len(scanner.discovered_device_timestamps) == 0
+    assert len(scanner._discovered_device_timestamps) == 0
 
     expire_monotonic = (
         start_time_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1
@@ -282,6 +286,8 @@ async def test_remote_scanner_expires_non_connectable() -> None:
 
     assert len(scanner.discovered_devices) == 0
     assert len(scanner.discovered_devices_and_advertisement_data) == 0
+    assert len(scanner.discovered_device_timestamps) == 0
+    assert len(scanner._discovered_device_timestamps) == 0
 
     cancel()
     unsetup()


### PR DESCRIPTION
Most of the time was spent doing `PyObject_RichCompare` on the previous advertisement data when it was the same object. We can switch this to be an `is` check instead.