### PR TITLE
fix: project.license in pyproject.toml to allow package to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "habluetooth"
 version = "3.38.0"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 description = "High availability Bluetooth"
 authors = [{ name = "J. Nick Koston", email = "bluetooth@koston.org" }]
 readme = "README.md"


### PR DESCRIPTION
Fix for recent change to pyproject.toml that prevented the package from building.

```
configuration error: `project.license` must be valid exactly by one definition (2 matches found):
    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
DESCRIPTION:
    `Project license <https://peps.python.org/pep-0621/#license>`_.
GIVEN VALUE:
    "Apache-2.0"
OFFENDING RULE: 'oneOf'
DEFINITION:
    {
        "oneOf": [
            {
                "properties": {
                    "file": {
                        "type": "string",
                        "$$description": [
                            "Relative path to the file (UTF-8) which contains the license for the",
                            "project."
                        ]
                    }
                },
                "required": [
                    "file"
                ]
            },
            {
                "properties": {
                    "text": {
                        "type": "string",
                        "$$description": [
                            "The license of the project whose meaning is that of the",
                            "`License field from the core metadata",
                            "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                        ]
                    }
                },
                "required": [
                    "text"
                ]
            }
        ]
    }
```