### PR TITLE
feat: improve performance of _async_on_advertisement_internal

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -58,7 +58,6 @@ cdef class BaseHaRemoteScanner(BaseHaScanner):
         has_manufacturer_data=bint,
         has_service_data=bint,
         has_service_uuids=bint,
-        prev_details=dict,
         sub_value=bytes,
         super_value=bytes,
         info=BluetoothServiceInfoBleak,

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -494,8 +494,6 @@ class BaseHaRemoteScanner(BaseHaScanner):
             #
             # https://github.com/hbldh/bleak/blob/222618b7747f0467dbb32bd3679f8cfaa19b1668/bleak/backends/scanner.py#L203
             #
-            prev_details: dict[str, Any] = info.device.details
-            prev_details.update(details)
             # _rssi is deprecated, will be removed in newer bleak
             # pylint: disable-next=protected-access
             info.device._rssi = rssi


### PR DESCRIPTION
skip details merge if the BLEDevice already exists.

We only need to merge details when we create the BLEDevice since details will never change.

Noticed while building https://github.com/Bluetooth-Devices/habluetooth/pull/219 that the data never changes