### PR TITLE
fix: remove duplicate _connecting slot from BaseHaScanner

### DIFF
--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -49,7 +49,6 @@ class BaseHaScanner:
         "_connect_failures",
         "_connect_in_progress",
         "_connecting",
-        "_connecting",
         "_last_detection",
         "_loop",
         "_manager",


### PR DESCRIPTION
This was a bad merge conflict resolution, but it
did not cause any production issues