### PR TITLE
Avoid bleak 1.0.0 until breaking changes have been handled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ script = "build_ext.py"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
-bleak = ">=0.21.1"
+bleak = ">=0.21.1,<1.0.0"
 bleak-retry-connector = ">=3.9.0"
 bluetooth-data-tools = ">=1.28.0"
 bluetooth-adapters = ">=0.16.1"


### PR DESCRIPTION
Temporary workaround for https://github.com/Bluetooth-Devices/habluetooth/issues/248