### PR TITLE
fix: solve performance regression while connecting in Linux

### DIFF
--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -240,6 +240,12 @@ class HaScanner(BaseHaScanner):
         """Return a list of discovered devices and advertisement data."""
         if not self.scanner:
             return {}
+        if IS_LINUX:
+            # Only Linux, seen_devices is already a dict
+            # of address -> (device, advertisement_data)
+            # so we can avoid the dict comp on every scanner
+            # when connecting.
+            return self.scanner._backend.seen_devices
         return self.scanner.discovered_devices_and_advertisement_data
 
     @property

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -24,8 +24,6 @@ from habluetooth import (
     set_manager,
 )
 from habluetooth.channels.bluez import (
-    ADV_MONITOR_DEVICE_FOUND,
-    DEVICE_FOUND,
     BluetoothMGMTProtocol,
     MGMTBluetoothCtl,
 )
@@ -44,6 +42,8 @@ from . import (
 )
 from .conftest import FakeBluetoothAdapters
 
+ADV_MONITOR_DEVICE_FOUND = 0x002F
+DEVICE_FOUND = 0x0012
 IS_WINDOWS = 'os.name == "nt"'
 IS_POSIX = 'os.name == "posix"'
 NOT_POSIX = 'os.name != "posix"'
@@ -831,6 +831,9 @@ async def test_adapter_init_fails_fallback_to_passive(
     mock_discovered: list[Any] = []
 
     class MockBleakScanner:
+        _backend: "MockBleakScanner"
+        seen_devices = {}  # type: ignore[var-annotated] # noqa: RUF012
+
         async def start(self, *args, **kwargs):
             """Mock Start."""
             nonlocal called_start
@@ -866,6 +869,7 @@ async def test_adapter_init_fails_fallback_to_passive(
             return {}
 
     mock_scanner = MockBleakScanner()
+    mock_scanner._backend = mock_scanner
     start_time_monotonic = time.monotonic()
 
     with (


### PR DESCRIPTION
When bleak put the backends behind the bleak scanner, all the backends now have to make a copy of discovered devices every time we connect. Since linux is already in the right forward we can bypass that and look at seen_devices directly. Since we already rely on scanner._backend this is no less safe than the other place we have to do it anyways.