### PR TITLE
feat: warn when connections are established without bleak-retry-connector

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -148,14 +148,14 @@ pythonista = ["bleak-pythonista (>=0.1.1)"]
 
 [[package]]
 name = "bleak-retry-connector"
-version = "4.0.1"
+version = "4.2.0"
 description = "A connector for Bleak Clients that handles transient connection failures"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bleak_retry_connector-4.0.1-py3-none-any.whl", hash = "sha256:8eac9452cf24a271d81e448462a815e2cacf672da14f1e6485ebec47cc9a2df0"},
-    {file = "bleak_retry_connector-4.0.1.tar.gz", hash = "sha256:63c4d654bd10e5a882759be5a54c3d8454ebd4fadb25c28882023f9ae97cc48f"},
+    {file = "bleak_retry_connector-4.2.0-py3-none-any.whl", hash = "sha256:02f83c8389f06e8f4253b8da270a63299d050da4663bc7436cceac8554814a37"},
+    {file = "bleak_retry_connector-4.2.0.tar.gz", hash = "sha256:09831e8070454a7127cb89e6dcc7930c2c7a655a06fc7bb4f9e7e64a2302ecb5"},
 ]
 
 [package.dependencies]
@@ -2144,4 +2144,4 @@ all = ["winrt-Windows.Foundation.Collections[all] (>=3.2.1.0,<3.3.0.0)", "winrt-
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "c1896b9009aeb880fef933556baf387018d37b3808e0ac4606d6a042b7444636"
+content-hash = "97e8b97463f2ae04f99dfaf2e6d92a1a682b2da2aa116e50a245c5c7276b51db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ script = "build_ext.py"
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 bleak = ">=1.0.1"
-bleak-retry-connector = ">=4"
+bleak-retry-connector = ">=4.2.0"
 bluetooth-data-tools = ">=1.28.0"
 bluetooth-adapters = ">=2"
 bluetooth-auto-recovery = ">=1.5.1"


### PR DESCRIPTION
## Summary

This PR adds detection and warning messages when BLE connections are established directly through `BleakClient.connect()` instead of using `bleak-retry-connector`'s `establish_connection()` function. This helps guide users toward more reliable connection establishment patterns.

## Changes

### habluetooth
- **Added `_is_retry_client` flag tracking** in `HaBleakClientWrapper.__init__()` to detect if a client was created through `establish_connection`
- **Added warning message** in `connect()` method that triggers when connections are made without bleak-retry-connector
- Warning message includes a link to the bleak-retry-connector documentation for user guidance

### bleak-retry-connector  
- **Modified `establish_connection()`** to pass `_is_retry_client=True` when creating client instances
- **Added test** `test_establish_connection_passes_retry_client_flag()` to verify the flag is correctly passed

## Motivation

Many connection issues in BLE applications can be avoided by using `bleak-retry-connector`'s retry logic, which handles:
- Transient connection failures
- Platform-specific BLE quirks  
- Connection slot management
- Intelligent backoff strategies
- Better error messages

By warning users when they're not using this recommended pattern, we can help them avoid common pitfalls and improve the reliability of their BLE applications.

## Testing

- Added new test in bleak-retry-connector to verify `_is_retry_client` flag is passed
- All existing tests pass in both repositories
- Warning appears correctly when using direct `BleakClient.connect()`
- No warning appears when using `establish_connection()`

## Example Warning

When a connection is established without bleak-retry-connector, users will see:
```
WARNING - AA:BB:CC:DD:EE:FF: BleakClient.connect() called without bleak-retry-connector. For reliable connection establishment, use bleak_retry_connector.establish_connection(). See https://github.com/Bluetooth-Devices/bleak-retry-connector
```
