### PR TITLE
feat: log slots when connecting

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -460,11 +460,18 @@ class HaBleakClientWrapper(BleakClient):
                 sorted_devices[0].ble_device.name,
                 len(sorted_devices),
                 ", ".join(
-                    f"{device.scanner.name} "
-                    f"(RSSI={device.advertisement.rssi}) "
-                    f"(failures={device.scanner._connection_failures(address)}) "
-                    f"(in_progress={device.scanner._connections_in_progress()}) "
-                    f"(score={device.score_connection_path(0)})"
+                    (
+                        f"{device.scanner.name} "
+                        f"(RSSI={device.advertisement.rssi}) "
+                        f"(failures={device.scanner._connection_failures(address)}) "
+                        f"(in_progress={device.scanner._connections_in_progress()}) "
+                        + (
+                            f"(slots={allocations.free}/{allocations.slots} free) "
+                            if (allocations := device.scanner.get_allocations())
+                            else ""
+                        )
+                        + f"(score={device.score_connection_path(0)})"
+                    )
                     for device in sorted_devices
                 ),
             )


### PR DESCRIPTION
```
2025-09-08 11:18:04.485 INFO (MainThread) [habluetooth.wrappers] D9:1F:31:6F:2F:B1 - VOC: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-90) (failures=1) (in_progress=2) (slots=0/3 free) (score=-127)
2025-09-08 11:18:08.486 INFO (MainThread) [habluetooth.wrappers] D9:1F:31:6F:2F:B1 - VOC: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-90) (failures=1) (in_progress=2) (slots=0/3 free) (score=-127)
2025-09-08 11:18:09.101 INFO (MainThread) [habluetooth.wrappers] 49:22:03:25:01:46 - None: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-82) (failures=1) (in_progress=1) (slots=1/3 free) (score=-82.0)
2025-09-08 11:18:12.487 INFO (MainThread) [habluetooth.wrappers] D9:1F:31:6F:2F:B1 - VOC: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-90) (failures=1) (in_progress=2) (slots=0/3 free) (score=-127)
2025-09-08 11:18:16.489 INFO (MainThread) [habluetooth.wrappers] D9:1F:31:6F:2F:B1 - VOC: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-90) (failures=1) (in_progress=1) (slots=0/3 free) (score=-127)
2025-09-08 11:18:20.491 INFO (MainThread) [habluetooth.wrappers] D9:1F:31:6F:2F:B1 - VOC: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-90) (failures=1) (in_progress=1) (slots=0/3 free) (score=-127)
2025-09-08 11:18:23.140 INFO (MainThread) [habluetooth.wrappers] 49:21:09:09:65:49 - None: Found 1 connection path(s), preferred order: masterbathalexproxy (24:4C:AB:03:0B:6E) (RSSI=-99) (failures=1) (in_progress=0) (slots=3/3 free) (score=-99.0)
2025-09-08 11:18:24.492 INFO (MainThread) [habluetooth.wrappers] D9:1F:31:6F:2F:B1 - VOC: Found 1 connection path(s), preferred order: livingroomalexproxy (D4:8A:FC:90:20:D6) (RSSI=-90) (failures=1) (in_progress=1) (slots=0/3 free) (score=-127)
```