### PR TITLE
fix: resolve crash when compiled with cython 3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools>=77.0', 'Cython>=3,<3.1', "poetry-core>=2.0.0"]
+requires = ['setuptools>=77.0', 'Cython>=3', "poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [project]

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -1,4 +1,3 @@
-# cython: profile=True
 """A local bleak scanner."""
 
 from __future__ import annotations


### PR DESCRIPTION
Profile was on in scanner.py which was causing a segfault in Cython 3.1.  This worked fine with Cython 3.0 but best to ship it with it off anyways.