### PR TITLE
chore(tests): patch restore_discoveries in disable_stop_discovery fixture

### DIFF
--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -79,7 +79,10 @@ NEED_RESET_ERRORS = [
 @pytest.fixture(autouse=True, scope="module")
 def disable_stop_discovery():
     """Disable stop discovery."""
-    with patch("habluetooth.scanner.stop_discovery"):
+    with (
+        patch("habluetooth.scanner.stop_discovery"),
+        patch("habluetooth.scanner.restore_discoveries"),
+    ):
         yield
 
 


### PR DESCRIPTION
Several scanner tests failed with AttributeError because MockBleakScanner does not define a _backend attribute, which restore_discoveries expects. Extend the disable_stop_discovery fixture to also patch restore_discoveries, preventing calls into Bleak internals during tests.

This resolves multiple failing tests in test_scanner.py that previously broke on _backend access.

Previous test failures which are fixed by this change:

```
================================================================== short test summary info ===================================================================
FAILED tests/test_scanner.py::test_adapter_needs_reset_at_start[org.bluez.Error.Failed] - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_needs_reset_at_start[org.bluez.Error.InProgress] - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_needs_reset_at_start[org.bluez.Error.NotReady] - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_needs_reset_at_start[not found] - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_recovery_from_dbus_restart - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_recovery - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_scanner_fails_to_start_first_time - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_fails_to_start_and_takes_a_bit_to_init - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_restart_takes_longer_than_watchdog_time - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_adapter_init_fails_fallback_to_passive - AttributeError: 'MockBleakScanner' object has no attribute '_backend'
FAILED tests/test_scanner.py::test_scanner_with_bluez_mgmt_side_channel - TypeError: object of type 'Mock' has no len()
FAILED tests/test_scanner.py::test_scanner_without_bluez_mgmt_side_channel - TypeError: object of type 'Mock' has no len()
FAILED tests/test_scanner.py::test_bluez_mgmt_protocol_data_flow - TypeError: object of type 'Mock' has no len()

Results (3.47s):
     182 passed
      13 failed
         - tests/test_scanner.py:292 test_adapter_needs_reset_at_start[org.bluez.Error.Failed]
         - tests/test_scanner.py:292 test_adapter_needs_reset_at_start[org.bluez.Error.InProgress]
         - tests/test_scanner.py:292 test_adapter_needs_reset_at_start[org.bluez.Error.NotReady]
         - tests/test_scanner.py:292 test_adapter_needs_reset_at_start[not found]
         - tests/test_scanner.py:346 test_recovery_from_dbus_restart
         - tests/test_scanner.py:428 test_adapter_recovery
         - tests/test_scanner.py:525 test_adapter_scanner_fails_to_start_first_time
         - tests/test_scanner.py:644 test_adapter_fails_to_start_and_takes_a_bit_to_init
         - tests/test_scanner.py:714 test_restart_takes_longer_than_watchdog_time
         - tests/test_scanner.py:825 test_adapter_init_fails_fallback_to_passive
         - tests/test_scanner.py:936 test_scanner_with_bluez_mgmt_side_channel
         - tests/test_scanner.py:1059 test_scanner_without_bluez_mgmt_side_channel
         - tests/test_scanner.py:1111 test_bluez_mgmt_protocol_data_flow
       1 skipped
```