### PR TITLE
feat: add BLE connection parameters API

### DIFF
--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -542,3 +542,72 @@ class MGMTBluetoothCtl:
         except Exception:
             _LOGGER.exception("Failed to load conn params")
             return False
+
+    def load_conn_params_explicit(
+        self,
+        adapter_idx: int,
+        address: str,
+        address_type: int,
+        min_interval: int,
+        max_interval: int,
+        latency: int,
+        timeout: int,
+    ) -> bool:
+        """
+        Load explicit connection parameters for a specific device.
+
+        Args:
+            adapter_idx: Adapter index (e.g., 0 for hci0)
+            address: Device MAC address (e.g., "AA:BB:CC:DD:EE:FF")
+            address_type: BDADDR_LE_PUBLIC (1) or BDADDR_LE_RANDOM (2)
+            min_interval: Minimum connection interval (units of 1.25ms)
+            max_interval: Maximum connection interval (units of 1.25ms)
+            latency: Connection latency (number of events)
+            timeout: Supervision timeout (units of 10ms)
+
+        Returns:
+            True if command was sent successfully
+
+        """
+        if not self.protocol or not self.protocol.transport:
+            _LOGGER.error("Cannot load conn params: no connection")
+            return False
+
+        # Parse MAC address
+        addr_bytes = bytes.fromhex(address.replace(":", ""))
+        if len(addr_bytes) != 6:
+            _LOGGER.error("Invalid MAC address: %s", address)
+            return False
+
+        # Pack the command
+        cmd_data = CONN_PARAM_PACK(
+            1,  # param_count = 1
+            addr_bytes[::-1],  # bdaddr (reversed for little endian)
+            address_type,  # address type
+            min_interval,
+            max_interval,
+            latency,
+            timeout,
+        )
+
+        # Send the command
+        try:
+            header = COMMAND_HEADER_PACK(
+                MGMT_OP_LOAD_CONN_PARAM,  # opcode
+                adapter_idx,  # controller index
+                len(cmd_data),  # parameter length
+            )
+            self.protocol._write_to_socket(header + cmd_data)
+            _LOGGER.debug(
+                "Loaded explicit conn params for %s:"
+                " interval=%d-%d, latency=%d, timeout=%d",
+                address,
+                min_interval,
+                max_interval,
+                latency,
+                timeout,
+            )
+            return True
+        except Exception:
+            _LOGGER.exception("Failed to load conn params")
+            return False

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -240,6 +240,8 @@ class HaBleakClientWrapper(BleakClient):
         self.__timeout = timeout
         self.__services = services
         self._backend: BaseBleakClient | None = None
+        self._connected_scanner: BaseHaScanner | None = None
+        self._connected_device: BLEDevice | None = None
         self._pair_before_connect = pair
         # Check if this client is being created through establish_connection
         # by checking for the '_is_retry_client' marker in kwargs
@@ -255,6 +257,39 @@ class HaBleakClientWrapper(BleakClient):
         if self._backend is not None and hasattr(self._backend, "clear_cache"):
             return await self._backend.clear_cache()
         return await clear_cache(self.__address)
+
+    async def set_connection_params(
+        self,
+        min_interval: int,
+        max_interval: int,
+        latency: int,
+        timeout: int,
+    ) -> None:
+        """Set BLE connection parameters on a connected device."""
+        if self._backend is not None and hasattr(
+            self._backend, "set_connection_params"
+        ):
+            # ESPHome path - delegate to backend
+            await self._backend.set_connection_params(
+                min_interval, max_interval, latency, timeout
+            )
+            return
+        # BlueZ local path - use mgmt API
+        if (
+            self._connected_scanner is not None
+            and self._connected_device is not None
+            and (adapter_idx := self._connected_scanner.adapter_idx) is not None
+            and (mgmt_ctl := self.__manager.get_bluez_mgmt_ctl())
+        ):
+            mgmt_ctl.load_conn_params_explicit(
+                adapter_idx,
+                self._connected_device.address,
+                _get_device_address_type(self._connected_device),
+                min_interval,
+                max_interval,
+                latency,
+                timeout,
+            )
 
     def set_disconnected_callback(
         self,
@@ -376,6 +411,8 @@ class HaBleakClientWrapper(BleakClient):
 
         # Load medium connection parameters after successful connection
         if connected:
+            self._connected_scanner = scanner
+            self._connected_device = device
             self._load_conn_params(
                 scanner,
                 device,

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -894,6 +894,102 @@ def test_load_conn_params_transport_error(caplog: pytest.LogCaptureFixture) -> N
     assert "Failed to load conn params" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_load_conn_params_explicit() -> None:
+    """Test loading explicit connection parameters."""
+    mock_sock = Mock()
+    mock_protocol = Mock(spec=BluetoothMGMTProtocol)
+    mock_transport = Mock()
+    mock_protocol.transport = mock_transport
+    mock_protocol._write_to_socket = Mock()
+
+    ctl = MGMTBluetoothCtl(5.0, {})
+    ctl.protocol = mock_protocol
+    ctl.sock = mock_sock
+
+    result = ctl.load_conn_params_explicit(
+        0,  # adapter_idx
+        "AA:BB:CC:DD:EE:FF",  # address
+        BDADDR_LE_PUBLIC,  # address_type
+        800,  # min_interval
+        800,  # max_interval
+        0,  # latency
+        300,  # timeout
+    )
+
+    assert result is True
+
+    mock_protocol._write_to_socket.assert_called_once()
+    call_args = mock_protocol._write_to_socket.call_args[0][0]
+
+    # Check header (6 bytes)
+    assert call_args[0:2] == b"\x35\x00"  # MGMT_OP_LOAD_CONN_PARAM
+    assert call_args[2:4] == b"\x00\x00"  # adapter_idx = 0
+    assert call_args[4:6] == b"\x11\x00"  # param_len = 17 (2 + 15)
+
+    # Check command data
+    assert call_args[6:8] == b"\x01\x00"  # param_count = 1
+    assert call_args[8:14] == b"\xff\xee\xdd\xcc\xbb\xaa"  # address (reversed)
+    assert call_args[14] == BDADDR_LE_PUBLIC  # address_type
+    assert call_args[15:17] == (800).to_bytes(2, "little")  # min_interval
+    assert call_args[17:19] == (800).to_bytes(2, "little")  # max_interval
+    assert call_args[19:21] == (0).to_bytes(2, "little")  # latency
+    assert call_args[21:23] == (300).to_bytes(2, "little")  # timeout
+
+
+def test_load_conn_params_explicit_no_protocol(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test load_conn_params_explicit when protocol is not connected."""
+    ctl = MGMTBluetoothCtl(5.0, {})
+
+    result = ctl.load_conn_params_explicit(
+        0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC, 800, 800, 0, 300
+    )
+
+    assert result is False
+    assert "Cannot load conn params: no connection" in caplog.text
+
+
+def test_load_conn_params_explicit_invalid_address(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test load_conn_params_explicit with invalid MAC address."""
+    mock_protocol = Mock(spec=BluetoothMGMTProtocol)
+    mock_transport = Mock()
+    mock_protocol.transport = mock_transport
+
+    ctl = MGMTBluetoothCtl(5.0, {})
+    ctl.protocol = mock_protocol
+
+    result = ctl.load_conn_params_explicit(
+        0, "AA:BB", BDADDR_LE_PUBLIC, 800, 800, 0, 300
+    )
+
+    assert result is False
+    assert "Invalid MAC address: AA:BB" in caplog.text
+
+
+def test_load_conn_params_explicit_transport_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test load_conn_params_explicit with transport write error."""
+    mock_protocol = Mock(spec=BluetoothMGMTProtocol)
+    mock_transport = Mock()
+    mock_protocol.transport = mock_transport
+    mock_protocol._write_to_socket = Mock(side_effect=Exception("Transport error"))
+
+    ctl = MGMTBluetoothCtl(5.0, {})
+    ctl.protocol = mock_protocol
+
+    result = ctl.load_conn_params_explicit(
+        0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC, 800, 800, 0, 300
+    )
+
+    assert result is False
+    assert "Failed to load conn params" in caplog.text
+
+
 def test_kernel_bug_workaround_send_returns_zero(
     event_loop: asyncio.AbstractEventLoop, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import bleak
 import pytest
@@ -2044,3 +2044,147 @@ async def test_backend_name_in_logs(
         await client.disconnect()
 
     cancel_hci0()
+
+
+@pytest.mark.asyncio
+async def test_set_connection_params_with_backend(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that set_connection_params delegates to backend when it has the method."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    class FakeBleakClientWithConnParams(BaseFakeBleakClient):
+        """Fake bleak client that supports set_connection_params."""
+
+        connected = False
+        set_connection_params = AsyncMock()
+
+        async def connect(self, *args, **kwargs):
+            """Connect."""
+            self.connected = True
+            await asyncio.sleep(0)
+
+        @property
+        def is_connected(self) -> bool:
+            return self.connected
+
+    with patch(
+        "habluetooth.wrappers.get_platform_client_backend_type",
+        return_value=FakeBleakClientWithConnParams,
+    ):
+        ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+
+        await client.set_connection_params(800, 800, 0, 300)
+
+        FakeBleakClientWithConnParams.set_connection_params.assert_called_once_with(
+            800, 800, 0, 300
+        )
+
+    cancel_hci0()
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
+async def test_set_connection_params_with_bluez_mgmt(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that set_connection_params routes to mgmt_ctl when no backend method."""
+    manager = _get_manager()
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    mock_mgmt_ctl = Mock()
+    mock_mgmt_ctl.load_conn_params.return_value = True
+
+    class FakeBleakClientTracksConnect(BaseFakeBleakClient):
+        """Fake bleak client that tracks connect."""
+
+        connected = False
+
+        async def connect(self, *args, **kwargs):
+            """Connect."""
+            self.connected = True
+            await asyncio.sleep(0)
+
+        @property
+        def is_connected(self) -> bool:
+            return self.connected
+
+    with (
+        patch.object(manager, "get_bluez_mgmt_ctl", return_value=mock_mgmt_ctl),
+        patch(
+            "habluetooth.wrappers.get_platform_client_backend_type",
+            return_value=FakeBleakClientTracksConnect,
+        ),
+    ):
+        ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+
+        # Reset mock to isolate set_connection_params call from connect-time calls
+        mock_mgmt_ctl.reset_mock()
+
+        await client.set_connection_params(800, 800, 0, 300)
+
+        mock_mgmt_ctl.load_conn_params_explicit.assert_called_once_with(
+            0,  # adapter_idx for hci0
+            "00:00:00:00:00:01",  # address
+            1,  # BDADDR_LE_PUBLIC (default)
+            800,
+            800,
+            0,
+            300,
+        )
+
+    cancel_hci0()
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
+async def test_set_connection_params_no_mgmt_no_backend(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test set_connection_params no-ops without mgmt or backend."""
+    manager = _get_manager()
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    class FakeBleakClientTracksConnect(BaseFakeBleakClient):
+        """Fake bleak client that tracks connect."""
+
+        connected = False
+
+        async def connect(self, *args, **kwargs):
+            """Connect."""
+            self.connected = True
+            await asyncio.sleep(0)
+
+        @property
+        def is_connected(self) -> bool:
+            return self.connected
+
+    with (
+        patch.object(manager, "get_bluez_mgmt_ctl", return_value=None),
+        patch(
+            "habluetooth.wrappers.get_platform_client_backend_type",
+            return_value=FakeBleakClientTracksConnect,
+        ),
+    ):
+        ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+
+        # Should not raise any error
+        await client.set_connection_params(800, 800, 0, 300)
+
+    cancel_hci0()
+    cancel_hci1()


### PR DESCRIPTION
## Summary

- Add `set_connection_params()` to `HaBleakClientWrapper` for setting BLE connection parameters (min/max interval, latency, supervision timeout) on connected devices
- Add `load_conn_params_explicit()` to `MGMTBluetoothCtl` for setting explicit connection parameter values via the BlueZ MGMT API
- Routes to ESPHome backend when available, otherwise uses local BlueZ MGMT socket

This enables integrations like yalexs-ble to reduce battery drain on "Always Connected" BLE devices (e.g., Yale/August locks) by switching from fast connection intervals (~7.5-11ms) to slower ones after connection is established.

Related: home-assistant/core#153977

**Companion pull requests:**

- esphome/esphome#14577
- esphome/aioesphomeapi#1518
- Bluetooth-Devices/bleak-retry-connector#238
- Bluetooth-Devices/bleak-esphome#273

## Test plan

- [ ] Test `set_connection_params()` routes to backend when backend has the method (ESPHome path)
- [ ] Test `set_connection_params()` routes to BlueZ MGMT when no backend
- [ ] Test `load_conn_params_explicit()` sends correct MGMT command bytes