### PR TITLE
ci: benchmark with Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install poetry
         run: pipx install poetry
-      - name: Setup Python 3.13
+      - name: Setup Python 3.14
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
-          python-version: 3.13
+          python-version: "3.14"
           cache: "poetry"
+          allow-prereleases: true
       - name: Install Dependencies
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev


### PR DESCRIPTION
## Summary
- Switch CI benchmarks from Python 3.13 to 3.14 to track performance
- 
## Test plan
- [ ] Verify benchmark job runs successfully with Python 3.14