### PR TITLE
fix: warn when connection params cannot be set

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -269,7 +269,6 @@ class HaBleakClientWrapper(BleakClient):
         if self._backend is not None and hasattr(
             self._backend, "set_connection_params"
         ):
-            # ESPHome path - delegate to backend
             await self._backend.set_connection_params(
                 min_interval, max_interval, latency, timeout
             )
@@ -289,6 +288,14 @@ class HaBleakClientWrapper(BleakClient):
                 max_interval,
                 latency,
                 timeout,
+            )
+            return
+        if self._backend is not None:
+            _LOGGER.warning(
+                "%s: Backend %s does not support setting connection"
+                " parameters; Upgrade the backend library",
+                self.__address,
+                type(self._backend).__name__,
             )
 
     def set_disconnected_callback(

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -2186,5 +2186,7 @@ async def test_set_connection_params_no_mgmt_no_backend(
         # Should not raise any error
         await client.set_connection_params(800, 800, 0, 300)
 
+    assert "does not support setting connection parameters" in caplog.text
+
     cancel_hci0()
     cancel_hci1()


### PR DESCRIPTION
## Summary

- Add a warning when `set_connection_params` cannot be fulfilled by either the ESPHome backend or the BlueZ MGMT path
- Previously it silently did nothing when the backend didn't support the method

## Test plan

- [x] All 7 existing `connection_params` tests pass
- [x] Warning appears when neither path can handle the request
- [x] BlueZ MGMT path still works without warning
- [x] ESPHome backend path still works without warning