### PR TITLE
perf: type APPLE_MFR_ID as int instead of object

### DIFF
--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -20,7 +20,7 @@ cdef unsigned char APPLE_HOMEKIT_NOTIFY_START_BYTE
 cdef unsigned char APPLE_DEVICE_ID_START_BYTE
 cdef unsigned char APPLE_FINDMY_START_BYTE
 
-cdef object APPLE_MFR_ID
+cdef int APPLE_MFR_ID
 
 @cython.locals(uuids=set)
 cdef _dispatch_bleak_callback(


### PR DESCRIPTION
## Summary
- Change `APPLE_MFR_ID` declaration in `.pxd` from `cdef object` to `cdef int`
- Allows Cython to use integer-optimized dict lookup when checking `manufacturer_data.get(APPLE_MFR_ID)` in the Apple device pre-filter

## Test plan
- [ ] Verify existing tests pass
- [ ] Benchmark advertisement processing throughput