### PR TITLE
feat(perf): split scanner_adv_received into cpdef entry + cdef internal

### DIFF
--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -619,7 +619,7 @@ class BaseHaScanner:
         info.tx_power = tx_power
         info.raw = raw
         self._previous_service_info[address] = info
-        self._manager.scanner_adv_received(info)
+        self._manager._scanner_adv_received(info)
 
     def _async_expire_devices(self) -> None:
         """Expire old devices."""

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -76,6 +76,8 @@ cdef class BluetoothManager:
         BluetoothServiceInfoBleak new
     )
 
+    cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
+
     @cython.locals(
         old_service_info=BluetoothServiceInfoBleak,
         old_connectable_service_info=BluetoothServiceInfoBleak,
@@ -86,6 +88,6 @@ cdef class BluetoothManager:
         apple_cstr="const unsigned char *",
         bleak_callback=BleakCallback
     )
-    cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
+    cdef void _scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
 
     cpdef _async_describe_source(self, BluetoothServiceInfoBleak service_info)

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -564,6 +564,18 @@ class BluetoothManager:
         Handle a new advertisement from any scanner.
 
         Callbacks from all the scanners arrive here.
+
+        This is the cpdef entry point for external callers.
+        Internal callers should use _scanner_adv_received directly
+        to avoid cpdef virtual dispatch overhead.
+        """
+        self._scanner_adv_received(service_info)
+
+    def _scanner_adv_received(self, service_info: BluetoothServiceInfoBleak) -> None:
+        """
+        Handle a new advertisement from any scanner (internal cdef path).
+
+        Callbacks from all the scanners arrive here.
         """
         # Pre-filter noisy apple devices as they can account for 20-35% of the
         # traffic on a typical network.

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -328,7 +328,7 @@ class HaScanner(BaseHaScanner):
         service_info.time = callback_time
         service_info.tx_power = tx_power
         service_info.raw = None  # not available in bleak.
-        self._manager.scanner_adv_received(service_info)
+        self._manager._scanner_adv_received(service_info)
 
     async def async_start(self) -> None:
         """Start bluetooth scanner."""


### PR DESCRIPTION
## Summary
- Split `scanner_adv_received` into a thin `cpdef` wrapper + `cdef _scanner_adv_received` internal method
- Internal callers (`base_scanner`, `scanner`) now call the `cdef` version directly, bypassing the ~50-instruction virtual dispatch check that Cython generates for `cpdef` methods
- External callers (Home Assistant callback) continue using the `cpdef` entry point unchanged

## Test plan
- [x] Verify existing tests pass
- [x] Benchmark advertisement processing throughput