### PR TITLE
perf: use len() for dict truthiness check in hot path

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -568,7 +568,7 @@ class BluetoothManager:
         # Pre-filter noisy apple devices as they can account for 20-35% of the
         # traffic on a typical network.
         if (
-            not service_info.service_data
+            len(service_info.service_data) == 0
             and len(service_info.manufacturer_data) == 1
             and (apple_data := service_info.manufacturer_data.get(APPLE_MFR_ID))
         ):


### PR DESCRIPTION
## Summary
- Replace `not service_info.service_data` with `len(service_info.service_data) == 0` in `scanner_adv_received`
- Cython compiles `len(dict)` directly to `PyDict_Size()`, skipping the generic `PyObject_IsTrue` protocol which goes through singleton checks (True/False/None) before falling through to `dict.__len__`

## Test plan
- [ ] Verify existing tests pass
- [ ] Benchmark advertisement processing throughput