### PR TITLE
perf: use dict[] + KeyError instead of dict.get() in hot path

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -583,9 +583,12 @@ class BluetoothManager:
                 return
 
         if service_info.connectable:
-            old_connectable_service_info = self._connectable_history.get(
-                service_info.address
-            )
+            try:
+                old_connectable_service_info = self._connectable_history[
+                    service_info.address
+                ]
+            except KeyError:
+                old_connectable_service_info = None
         else:
             old_connectable_service_info = None
         # This logic is complex due to the many combinations of scanners
@@ -604,9 +607,13 @@ class BluetoothManager:
         #                       scanners with the best advertisement from each
         #                       connectable scanner
         #
+        try:
+            old_service_info = self._all_history[service_info.address]
+        except KeyError:
+            old_service_info = None
+
         if (
-            (old_service_info := self._all_history.get(service_info.address))
-            is not None
+            old_service_info is not None
             and service_info.source is not old_service_info.source
             and service_info.source != old_service_info.source
             and (scanner := self._sources.get(old_service_info.source)) is not None


### PR DESCRIPTION
## Summary
- Replace `dict.get(key)` with `dict[key]` + `except KeyError` for `_all_history` and `_connectable_history` lookups in `scanner_adv_received`
- These dicts almost always contain the looked-up address (devices advertise repeatedly), so the try path is the fast path
- Cython compiles `dict[key]` to a more efficient code path than `dict.get(key)` which goes through `__Pyx_PyDict_GetItemDefault` with extra INCREF/error-check/default-value overhead

## Test plan
- [ ] Verify existing tests pass
- [ ] Benchmark advertisement processing throughput