### PR TITLE
perf: use dict[] + KeyError for _previous_service_info lookup

### DIFF
--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -523,7 +523,9 @@ class BaseHaScanner:
         self._last_detection = advertisement_monotonic_time
         info = BluetoothServiceInfoBleak.__new__(BluetoothServiceInfoBleak)
 
-        if (prev_info := self._previous_service_info.get(address)) is None:
+        try:
+            prev_info = self._previous_service_info[address]
+        except KeyError:
             # We expect this is the rare case and since py3.11+ has
             # near zero cost try on success, and we can avoid .get()
             # which is slower than [] we use the try/except pattern.


### PR DESCRIPTION
## Summary
- Replace `_previous_service_info.get(address)` with `_previous_service_info[address]` + `except KeyError` in `_async_on_advertisement_internal`
- The existing comment already describes this intent but the implementation still used `.get()`
- The miss case is rare (only first advertisement per device), so try/except is the optimal pattern
- `dict[key]` compiles to a more efficient Cython code path than `dict.get(key)` which goes through `__Pyx_PyDict_GetItemDefault` with extra INCREF/error-check/default-value overhead plus a `__Pyx_TypeTest` MRO walk

## Test plan
- [ ] Verify existing tests pass
- [ ] Benchmark advertisement processing throughput