### PR TITLE
perf: split base_scanner cpdef methods into cpdef entry + cdef internal

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -74,8 +74,17 @@ cdef class BaseHaScanner:
     @cython.locals(info=BluetoothServiceInfoBleak)
     cdef dict _build_discovered_device_timestamps(self)
 
-    @cython.locals(parsed=tuple)
     cpdef void _async_on_raw_advertisement(
+        self,
+        str address,
+        int rssi,
+        bytes raw,
+        dict details,
+        double advertisement_monotonic_time
+    )
+
+    @cython.locals(parsed=tuple)
+    cdef void _async_on_raw_advertisement_cdef(
         self,
         str address,
         int rssi,
@@ -111,6 +120,19 @@ cdef class BaseHaScanner:
     )
 
     cpdef void _async_on_advertisement(
+        self,
+        str address,
+        int rssi,
+        str local_name,
+        list service_uuids,
+        dict service_data,
+        dict manufacturer_data,
+        object tx_power,
+        dict details,
+        double advertisement_monotonic_time
+    )
+
+    cdef void _async_on_advertisement_cdef(
         self,
         str address,
         int rssi,

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -466,6 +466,18 @@ class BaseHaScanner:
         details: dict[str, Any],
         advertisement_monotonic_time: _float,
     ) -> None:
+        self._async_on_raw_advertisement_cdef(
+            address, rssi, raw, details, advertisement_monotonic_time
+        )
+
+    def _async_on_raw_advertisement_cdef(
+        self,
+        address: _str,
+        rssi: _int,
+        raw: _bytes,
+        details: dict[str, Any],
+        advertisement_monotonic_time: _float,
+    ) -> None:
         parsed = parse_advertisement_data_bytes(raw)
         self._async_on_advertisement_internal(
             address,
@@ -481,6 +493,30 @@ class BaseHaScanner:
         )
 
     def _async_on_advertisement(
+        self,
+        address: _str,
+        rssi: _int,
+        local_name: _str | None,
+        service_uuids: list[str],
+        service_data: dict[str, bytes],
+        manufacturer_data: dict[int, bytes],
+        tx_power: _int | None,
+        details: dict[Any, Any],
+        advertisement_monotonic_time: _float,
+    ) -> None:
+        self._async_on_advertisement_cdef(
+            address,
+            rssi,
+            local_name,
+            service_uuids,
+            service_data,
+            manufacturer_data,
+            tx_power,
+            details,
+            advertisement_monotonic_time,
+        )
+
+    def _async_on_advertisement_cdef(
         self,
         address: _str,
         rssi: _int,

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -278,7 +278,7 @@ class HaScanner(BaseHaScanner):
     ) -> None:
         """Handle raw advertisement data."""
         address_str = bytes_mac_to_str(address)
-        self._async_on_raw_advertisement(
+        self._async_on_raw_advertisement_cdef(
             address_str,
             rssi,
             data,


### PR DESCRIPTION
## Summary
- Split `_async_on_raw_advertisement` and `_async_on_advertisement` into thin `cpdef` wrappers + `cdef` internal methods
- Internal callers (`scanner.py`) now call the `cdef` version directly, bypassing the ~50-instruction virtual dispatch check that Cython generates for `cpdef` methods
- External callers (HA subclasses, tests) continue using the `cpdef` entry point unchanged

## Test plan
- [ ] Verify existing tests pass
- [ ] Benchmark advertisement processing throughput