### PR TITLE
perf: propagate _adv_data_changed flag to skip dedup in _scanner_adv_received

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -2,6 +2,9 @@
 import cython
 
 from .models cimport BluetoothServiceInfoBleak
+
+cdef int _ADV_DATA_CHANGED
+cdef int _ADV_DATA_UNCHANGED
 from .manager cimport BluetoothManager
 
 cdef object parse_advertisement_data_bytes

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -23,6 +23,8 @@ from .const import (
     SCANNER_WATCHDOG_TIMEOUT,
 )
 from .models import (
+    ADV_DATA_CHANGED,
+    ADV_DATA_UNCHANGED,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     HaBluetoothConnector,
@@ -618,15 +620,15 @@ class BaseHaScanner:
         info.time = advertisement_monotonic_time
         info.tx_power = tx_power
         info.raw = raw
-        if prev_info is None:
-            info._adv_data_changed = 1
+        if prev_info is None or (
+            info.manufacturer_data is not prev_info.manufacturer_data
+            or info.service_data is not prev_info.service_data
+            or info.service_uuids is not prev_info.service_uuids
+            or info.name is not prev_info.name
+        ):
+            info._adv_data_changed = ADV_DATA_CHANGED
         else:
-            info._adv_data_changed = (
-                info.manufacturer_data is not prev_info.manufacturer_data
-                or info.service_data is not prev_info.service_data
-                or info.service_uuids is not prev_info.service_uuids
-                or info.name is not prev_info.name
-            )
+            info._adv_data_changed = ADV_DATA_UNCHANGED
         self._previous_service_info[address] = info
         self._manager._scanner_adv_received(info)
 

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -557,7 +557,7 @@ class BaseHaScanner:
             if prev_name is not None and (
                 prev_name is local_name
                 or not local_name
-                or len(prev_name) > len(local_name)
+                or len(prev_name) >= len(local_name)
             ):
                 info.name = prev_name
             else:

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -619,7 +619,7 @@ class BaseHaScanner:
         info.tx_power = tx_power
         info.raw = raw
         if prev_info is None:
-            info._adv_data_changed = True
+            info._adv_data_changed = 1
         else:
             info._adv_data_changed = (
                 info.manufacturer_data is not prev_info.manufacturer_data

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -492,6 +492,7 @@ class BaseHaScanner:
             info.time = advertisement_monotonic_time
             info.tx_power = prev_info.tx_power
             info.raw = prev_info.raw
+            info._adv_data_changed = _ADV_DATA_UNCHANGED
             self._previous_service_info[address] = info
             self._manager._scanner_adv_received(info)
             return

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -618,6 +618,15 @@ class BaseHaScanner:
         info.time = advertisement_monotonic_time
         info.tx_power = tx_power
         info.raw = raw
+        if prev_info is None:
+            info.adv_data_changed = True
+        else:
+            info.adv_data_changed = (
+                info.manufacturer_data is not prev_info.manufacturer_data
+                or info.service_data is not prev_info.service_data
+                or info.service_uuids is not prev_info.service_uuids
+                or info.name is not prev_info.name
+            )
         self._previous_service_info[address] = info
         self._manager._scanner_adv_received(info)
 

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -573,8 +573,7 @@ class BaseHaScanner:
             else:
                 info.service_uuids = prev_info.service_uuids
 
-            has_service_data = bool(service_data)
-            if has_service_data and service_data is not prev_info.service_data:
+            if service_data and service_data is not prev_info.service_data:
                 for uuid, sub_value in service_data.items():
                     if (
                         super_value := prev_info.service_data.get(uuid)
@@ -586,14 +585,11 @@ class BaseHaScanner:
                         break
                 else:
                     info.service_data = prev_info.service_data
-            elif not has_service_data:
-                info.service_data = prev_info.service_data
             else:
-                info.service_data = service_data
+                info.service_data = prev_info.service_data
 
-            has_manufacturer_data = bool(manufacturer_data)
             if (
-                has_manufacturer_data
+                manufacturer_data
                 and manufacturer_data is not prev_info.manufacturer_data
             ):
                 for id_, sub_value in manufacturer_data.items():
@@ -607,10 +603,8 @@ class BaseHaScanner:
                         break
                 else:
                     info.manufacturer_data = prev_info.manufacturer_data
-            elif not has_manufacturer_data:
-                info.manufacturer_data = prev_info.manufacturer_data
             else:
-                info.manufacturer_data = manufacturer_data
+                info.manufacturer_data = prev_info.manufacturer_data
 
         info.address = address
         info.rssi = rssi

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -574,7 +574,9 @@ class BaseHaScanner:
             elif not has_service_uuids:
                 info.service_uuids = prev_info.service_uuids
             else:
-                info.service_uuids = service_uuids
+                # Content is the same — reuse prev_info's object to
+                # preserve identity for downstream dedup checks.
+                info.service_uuids = prev_info.service_uuids
 
             has_service_data = bool(service_data)
             if has_service_data and service_data is not prev_info.service_data:

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -23,8 +23,8 @@ from .const import (
     SCANNER_WATCHDOG_TIMEOUT,
 )
 from .models import (
-    _ADV_DATA_CHANGED,
-    _ADV_DATA_UNCHANGED,
+    ADV_DATA_CHANGED,
+    ADV_DATA_UNCHANGED,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     HaBluetoothConnector,
@@ -36,6 +36,9 @@ from .storage import DiscoveredDeviceAdvertisementData
 
 SCANNER_WATCHDOG_INTERVAL_SECONDS: Final = SCANNER_WATCHDOG_INTERVAL.total_seconds()
 _LOGGER = logging.getLogger(__name__)
+
+_ADV_DATA_CHANGED = ADV_DATA_CHANGED
+_ADV_DATA_UNCHANGED = ADV_DATA_UNCHANGED
 
 
 _bytes = bytes

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -564,18 +564,13 @@ class BaseHaScanner:
                 info.device.name = local_name
                 info.name = local_name if local_name else address
 
-            has_service_uuids = bool(service_uuids)
             if (
-                has_service_uuids
+                service_uuids
                 and service_uuids is not prev_info.service_uuids
                 and service_uuids != prev_info.service_uuids
             ):
                 info.service_uuids = list({*service_uuids, *prev_info.service_uuids})
-            elif not has_service_uuids:
-                info.service_uuids = prev_info.service_uuids
             else:
-                # Content is the same — reuse prev_info's object to
-                # preserve identity for downstream dedup checks.
                 info.service_uuids = prev_info.service_uuids
 
             has_service_data = bool(service_data)

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -619,9 +619,9 @@ class BaseHaScanner:
         info.tx_power = tx_power
         info.raw = raw
         if prev_info is None:
-            info.adv_data_changed = True
+            info._adv_data_changed = True
         else:
-            info.adv_data_changed = (
+            info._adv_data_changed = (
                 info.manufacturer_data is not prev_info.manufacturer_data
                 or info.service_data is not prev_info.service_data
                 or info.service_uuids is not prev_info.service_uuids

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -23,8 +23,8 @@ from .const import (
     SCANNER_WATCHDOG_TIMEOUT,
 )
 from .models import (
-    ADV_DATA_CHANGED,
-    ADV_DATA_UNCHANGED,
+    _ADV_DATA_CHANGED,
+    _ADV_DATA_UNCHANGED,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     HaBluetoothConnector,
@@ -626,9 +626,9 @@ class BaseHaScanner:
             or info.service_uuids is not prev_info.service_uuids
             or info.name is not prev_info.name
         ):
-            info._adv_data_changed = ADV_DATA_CHANGED
+            info._adv_data_changed = _ADV_DATA_CHANGED
         else:
-            info._adv_data_changed = ADV_DATA_UNCHANGED
+            info._adv_data_changed = _ADV_DATA_UNCHANGED
         self._previous_service_info[address] = info
         self._manager._scanner_adv_received(info)
 

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -4,6 +4,9 @@ from .advertisement_tracker cimport AdvertisementTracker
 from .base_scanner cimport BaseHaScanner
 from .models cimport BluetoothServiceInfoBleak
 
+cdef int _ADV_DATA_UNCHANGED
+cdef int _ADV_DATA_UNKNOWN
+
 cdef int NO_RSSI_VALUE
 cdef int ADV_RSSI_SWITCH_THRESHOLD
 cdef double TRACKER_BUFFERING_WOBBLE_SECONDS

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -40,8 +40,8 @@ from .const import (
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .models import (
-    _ADV_DATA_UNCHANGED,
-    _ADV_DATA_UNKNOWN,
+    ADV_DATA_UNCHANGED,
+    ADV_DATA_UNKNOWN,
     BluetoothServiceInfoBleak,
     HaBluetoothSlotAllocations,
     HaScannerModeChange,
@@ -59,6 +59,9 @@ if TYPE_CHECKING:
     from .base_scanner import BaseHaScanner
     from .scanner import HaScanner
 
+
+_ADV_DATA_UNCHANGED = ADV_DATA_UNCHANGED
+_ADV_DATA_UNKNOWN = ADV_DATA_UNKNOWN
 
 SYSTEM = platform.system()
 IS_LINUX = SYSTEM == "Linux"

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -692,8 +692,44 @@ class BluetoothManager:
             not (service_info.connectable and old_connectable_service_info is None)
             # Than check if advertisement data is the same
             and old_service_info is not None
-            and not service_info.adv_data_changed
-            and old_service_info.source is service_info.source
+            # If the base scanner already determined data hasn't changed
+            # and the source is the same, we can skip the comparison.
+            and (
+                (
+                    not service_info.adv_data_changed
+                    and old_service_info.source is service_info.source
+                )
+                or (
+                    # Fallback to field-by-field comparison for paths that
+                    # don't go through base_scanner merge (e.g. Bleak/HaScanner).
+                    # The common case is that its the same object for remote
+                    # scanners so the identity check short-circuits.
+                    not (
+                        (
+                            service_info.manufacturer_data
+                            is not old_service_info.manufacturer_data
+                            and service_info.manufacturer_data
+                            != old_service_info.manufacturer_data
+                        )
+                        or (
+                            service_info.service_data
+                            is not old_service_info.service_data
+                            and service_info.service_data
+                            != old_service_info.service_data
+                        )
+                        or (
+                            service_info.service_uuids
+                            is not old_service_info.service_uuids
+                            and service_info.service_uuids
+                            != old_service_info.service_uuids
+                        )
+                        or (
+                            service_info.name is not old_service_info.name
+                            and service_info.name != old_service_info.name
+                        )
+                    )
+                )
+            )
         ):
             return
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -692,30 +692,8 @@ class BluetoothManager:
             not (service_info.connectable and old_connectable_service_info is None)
             # Than check if advertisement data is the same
             and old_service_info is not None
-            # This is a bit complex because we want to skip all the
-            # PyObject_RichCompare overhead as its can be upwards of
-            # 65% of the time spent in this method. The common case
-            # is that its the same object for remote scanners.
-            and not (
-                (
-                    service_info.manufacturer_data
-                    is not old_service_info.manufacturer_data
-                    and service_info.manufacturer_data
-                    != old_service_info.manufacturer_data
-                )
-                or (
-                    service_info.service_data is not old_service_info.service_data
-                    and service_info.service_data != old_service_info.service_data
-                )
-                or (
-                    service_info.service_uuids is not old_service_info.service_uuids
-                    and service_info.service_uuids != old_service_info.service_uuids
-                )
-                or (
-                    service_info.name is not old_service_info.name
-                    and service_info.name != old_service_info.name
-                )
-            )
+            and not service_info.adv_data_changed
+            and old_service_info.source is service_info.source
         ):
             return
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -40,8 +40,8 @@ from .const import (
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .models import (
-    ADV_DATA_UNCHANGED,
-    ADV_DATA_UNKNOWN,
+    _ADV_DATA_UNCHANGED,
+    _ADV_DATA_UNKNOWN,
     BluetoothServiceInfoBleak,
     HaBluetoothSlotAllocations,
     HaScannerModeChange,
@@ -695,12 +695,12 @@ class BluetoothManager:
             # Than check if advertisement data is the same
             and old_service_info is not None
         ):
-            if service_info._adv_data_changed == ADV_DATA_UNCHANGED:
+            if service_info._adv_data_changed == _ADV_DATA_UNCHANGED:
                 # Base scanner merge determined data hasn't changed.
                 # Only skip if same source — different source means scanner switch.
                 if old_service_info.source is service_info.source:
                     return
-            elif service_info._adv_data_changed == ADV_DATA_UNKNOWN and not (
+            elif service_info._adv_data_changed == _ADV_DATA_UNKNOWN and not (
                 # Unknown (Bleak/external path) — do field comparison.
                 # The common case for remote scanners is that its the same
                 # object so the identity check short-circuits.

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -696,7 +696,7 @@ class BluetoothManager:
             # and the source is the same, we can skip the comparison.
             and (
                 (
-                    not service_info.adv_data_changed
+                    not service_info._adv_data_changed
                     and old_service_info.source is service_info.source
                 )
                 or (

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -692,46 +692,37 @@ class BluetoothManager:
             not (service_info.connectable and old_connectable_service_info is None)
             # Than check if advertisement data is the same
             and old_service_info is not None
-            # If the base scanner already determined data hasn't changed
-            # and the source is the same, we can skip the comparison.
-            and (
+        ):
+            if service_info._adv_data_changed == 0:
+                # Base scanner merge determined data hasn't changed.
+                # Only skip if same source — different source means scanner switch.
+                if old_service_info.source is service_info.source:
+                    return
+            elif service_info._adv_data_changed == -1 and not (
+                # Unknown (Bleak/external path) — do field comparison.
+                # The common case for remote scanners is that its the same
+                # object so the identity check short-circuits.
                 (
-                    not service_info._adv_data_changed
-                    and old_service_info.source is service_info.source
+                    service_info.manufacturer_data
+                    is not old_service_info.manufacturer_data
+                    and service_info.manufacturer_data
+                    != old_service_info.manufacturer_data
                 )
                 or (
-                    # Fallback to field-by-field comparison for paths that
-                    # don't go through base_scanner merge (e.g. Bleak/HaScanner).
-                    # The common case is that its the same object for remote
-                    # scanners so the identity check short-circuits.
-                    not (
-                        (
-                            service_info.manufacturer_data
-                            is not old_service_info.manufacturer_data
-                            and service_info.manufacturer_data
-                            != old_service_info.manufacturer_data
-                        )
-                        or (
-                            service_info.service_data
-                            is not old_service_info.service_data
-                            and service_info.service_data
-                            != old_service_info.service_data
-                        )
-                        or (
-                            service_info.service_uuids
-                            is not old_service_info.service_uuids
-                            and service_info.service_uuids
-                            != old_service_info.service_uuids
-                        )
-                        or (
-                            service_info.name is not old_service_info.name
-                            and service_info.name != old_service_info.name
-                        )
-                    )
+                    service_info.service_data is not old_service_info.service_data
+                    and service_info.service_data != old_service_info.service_data
                 )
-            )
-        ):
-            return
+                or (
+                    service_info.service_uuids is not old_service_info.service_uuids
+                    and service_info.service_uuids != old_service_info.service_uuids
+                )
+                or (
+                    service_info.name is not old_service_info.name
+                    and service_info.name != old_service_info.name
+                )
+            ):
+                return
+            # _adv_data_changed == 1: data changed, continue to dispatch
 
         if not service_info.connectable and old_connectable_service_info is not None:
             # Since we have a connectable path and our BleakClient will

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -691,7 +691,8 @@ class BluetoothManager:
         # If the advertisement data is the same as the last time we saw it, we
         # don't need to do anything else unless its connectable and we are missing
         # connectable history for the device so we can make it available again
-        # after unavailable callbacks.
+        # after unavailable callbacks. When the source changes, we still need
+        # to dispatch so callbacks see the new source even if data is unchanged.
         if (
             # Ensure its not a connectable device missing from connectable history
             not (service_info.connectable and old_connectable_service_info is None)
@@ -701,7 +702,10 @@ class BluetoothManager:
             if service_info._adv_data_changed == _ADV_DATA_UNCHANGED:
                 # Base scanner merge determined data hasn't changed.
                 # Only skip if same source — different source means scanner switch.
-                if old_service_info.source is service_info.source:
+                if (
+                    old_service_info.source is service_info.source
+                    or old_service_info.source == service_info.source
+                ):
                     return
             elif service_info._adv_data_changed == _ADV_DATA_UNKNOWN and not (
                 # Unknown (Bleak/external path) — do field comparison.

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -40,6 +40,8 @@ from .const import (
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .models import (
+    ADV_DATA_UNCHANGED,
+    ADV_DATA_UNKNOWN,
     BluetoothServiceInfoBleak,
     HaBluetoothSlotAllocations,
     HaScannerModeChange,
@@ -693,12 +695,12 @@ class BluetoothManager:
             # Than check if advertisement data is the same
             and old_service_info is not None
         ):
-            if service_info._adv_data_changed == 0:
+            if service_info._adv_data_changed == ADV_DATA_UNCHANGED:
                 # Base scanner merge determined data hasn't changed.
                 # Only skip if same source — different source means scanner switch.
                 if old_service_info.source is service_info.source:
                     return
-            elif service_info._adv_data_changed == -1 and not (
+            elif service_info._adv_data_changed == ADV_DATA_UNKNOWN and not (
                 # Unknown (Bleak/external path) — do field comparison.
                 # The common case for remote scanners is that its the same
                 # object so the identity check short-circuits.

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -12,6 +12,10 @@ cdef object NO_RSSI_VALUE
 
 cdef object TUPLE_NEW
 
+cdef int ADV_DATA_UNKNOWN
+cdef int ADV_DATA_UNCHANGED
+cdef int ADV_DATA_CHANGED
+
 cdef class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""
 

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -12,10 +12,6 @@ cdef object NO_RSSI_VALUE
 
 cdef object TUPLE_NEW
 
-cdef int _ADV_DATA_UNKNOWN
-cdef int _ADV_DATA_UNCHANGED
-cdef int _ADV_DATA_CHANGED
-
 cdef class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""
 

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -33,7 +33,7 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public double time
     cdef public object tx_power
     cdef public bytes raw
-    cdef public bint _adv_data_changed
+    cdef public int _adv_data_changed
 
     @cython.locals(new_obj=BluetoothServiceInfoBleak)
     cpdef BluetoothServiceInfoBleak _as_connectable(self)

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -12,6 +12,10 @@ cdef object NO_RSSI_VALUE
 
 cdef object TUPLE_NEW
 
+cdef int _ADV_DATA_UNKNOWN
+cdef int _ADV_DATA_UNCHANGED
+cdef int _ADV_DATA_CHANGED
+
 cdef class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""
 

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -33,6 +33,7 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public double time
     cdef public object tx_power
     cdef public bytes raw
+    cdef public bint adv_data_changed
 
     @cython.locals(new_obj=BluetoothServiceInfoBleak)
     cpdef BluetoothServiceInfoBleak _as_connectable(self)

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -12,9 +12,9 @@ cdef object NO_RSSI_VALUE
 
 cdef object TUPLE_NEW
 
-cdef int ADV_DATA_UNKNOWN
-cdef int ADV_DATA_UNCHANGED
-cdef int ADV_DATA_CHANGED
+cdef int _ADV_DATA_UNKNOWN
+cdef int _ADV_DATA_UNCHANGED
+cdef int _ADV_DATA_CHANGED
 
 cdef class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""

--- a/src/habluetooth/models.pxd
+++ b/src/habluetooth/models.pxd
@@ -33,7 +33,7 @@ cdef class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     cdef public double time
     cdef public object tx_power
     cdef public bytes raw
-    cdef public bint adv_data_changed
+    cdef public bint _adv_data_changed
 
     @cython.locals(new_obj=BluetoothServiceInfoBleak)
     cpdef BluetoothServiceInfoBleak _as_connectable(self)

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -182,7 +182,15 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     internal details.
     """
 
-    __slots__ = ("_advertisement", "connectable", "device", "raw", "time", "tx_power")
+    __slots__ = (
+        "_advertisement",
+        "adv_data_changed",
+        "connectable",
+        "device",
+        "raw",
+        "time",
+        "tx_power",
+    )
 
     def __init__(
         self,
@@ -213,6 +221,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.time = time
         self.tx_power = tx_power
         self.raw = raw
+        self.adv_data_changed = True
 
     def __repr__(self) -> str:
         """Return the representation of the object."""
@@ -346,4 +355,5 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         new_obj.time = self.time
         new_obj.tx_power = self.tx_power
         new_obj.raw = self.raw
+        new_obj.adv_data_changed = self.adv_data_changed
         return new_obj

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -229,7 +229,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.time = time
         self.tx_power = tx_power
         self.raw = raw
-        self._adv_data_changed = _ADV_DATA_CHANGED
+        self._adv_data_changed = _ADV_DATA_UNKNOWN
 
     def __repr__(self) -> str:
         """Return the representation of the object."""

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -25,6 +25,10 @@ _BluetoothServiceInfoBleakSelfT = TypeVar(
 SOURCE_LOCAL: Final = "local"
 TUPLE_NEW: Final = tuple.__new__
 
+ADV_DATA_UNKNOWN: Final = -1
+ADV_DATA_UNCHANGED: Final = 0
+ADV_DATA_CHANGED: Final = 1
+
 _float = float  # avoid cython conversion since we always want a pyfloat
 _str = str  # avoid cython conversion since we always want a pystr
 _int = int  # avoid cython conversion since we always want a pyint
@@ -221,7 +225,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.time = time
         self.tx_power = tx_power
         self.raw = raw
-        self._adv_data_changed = 1
+        self._adv_data_changed = ADV_DATA_CHANGED
 
     def __repr__(self) -> str:
         """Return the representation of the object."""

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -183,8 +183,8 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
     """
 
     __slots__ = (
+        "_adv_data_changed",
         "_advertisement",
-        "adv_data_changed",
         "connectable",
         "device",
         "raw",
@@ -221,7 +221,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.time = time
         self.tx_power = tx_power
         self.raw = raw
-        self.adv_data_changed = True
+        self._adv_data_changed = True
 
     def __repr__(self) -> str:
         """Return the representation of the object."""
@@ -355,5 +355,5 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         new_obj.time = self.time
         new_obj.tx_power = self.tx_power
         new_obj.raw = self.raw
-        new_obj.adv_data_changed = self.adv_data_changed
+        new_obj._adv_data_changed = self._adv_data_changed
         return new_obj

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -25,9 +25,13 @@ _BluetoothServiceInfoBleakSelfT = TypeVar(
 SOURCE_LOCAL: Final = "local"
 TUPLE_NEW: Final = tuple.__new__
 
-ADV_DATA_UNKNOWN: Final = -1
-ADV_DATA_UNCHANGED: Final = 0
-ADV_DATA_CHANGED: Final = 1
+_ADV_DATA_UNKNOWN: Final = -1
+_ADV_DATA_UNCHANGED: Final = 0
+_ADV_DATA_CHANGED: Final = 1
+
+ADV_DATA_UNKNOWN = _ADV_DATA_UNKNOWN
+ADV_DATA_UNCHANGED = _ADV_DATA_UNCHANGED
+ADV_DATA_CHANGED = _ADV_DATA_CHANGED
 
 _float = float  # avoid cython conversion since we always want a pyfloat
 _str = str  # avoid cython conversion since we always want a pystr
@@ -225,7 +229,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.time = time
         self.tx_power = tx_power
         self.raw = raw
-        self._adv_data_changed = ADV_DATA_CHANGED
+        self._adv_data_changed = _ADV_DATA_CHANGED
 
     def __repr__(self) -> str:
         """Return the representation of the object."""

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -221,7 +221,7 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
         self.time = time
         self.tx_power = tx_power
         self.raw = raw
-        self._adv_data_changed = True
+        self._adv_data_changed = 1
 
     def __repr__(self) -> str:
         """Return the representation of the object."""

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -25,13 +25,13 @@ _BluetoothServiceInfoBleakSelfT = TypeVar(
 SOURCE_LOCAL: Final = "local"
 TUPLE_NEW: Final = tuple.__new__
 
-_ADV_DATA_UNKNOWN: Final = -1
-_ADV_DATA_UNCHANGED: Final = 0
-_ADV_DATA_CHANGED: Final = 1
+ADV_DATA_UNKNOWN: Final = -1
+ADV_DATA_UNCHANGED: Final = 0
+ADV_DATA_CHANGED: Final = 1
 
-ADV_DATA_UNKNOWN = _ADV_DATA_UNKNOWN
-ADV_DATA_UNCHANGED = _ADV_DATA_UNCHANGED
-ADV_DATA_CHANGED = _ADV_DATA_CHANGED
+_ADV_DATA_UNKNOWN = ADV_DATA_UNKNOWN
+_ADV_DATA_UNCHANGED = ADV_DATA_UNCHANGED
+_ADV_DATA_CHANGED = ADV_DATA_CHANGED
 
 _float = float  # avoid cython conversion since we always want a pyfloat
 _str = str  # avoid cython conversion since we always want a pystr

--- a/src/habluetooth/scanner.pxd
+++ b/src/habluetooth/scanner.pxd
@@ -4,6 +4,8 @@ import cython
 from .base_scanner cimport BaseHaScanner
 from .models cimport BluetoothServiceInfoBleak
 
+cdef int _ADV_DATA_UNKNOWN
+
 cdef object NO_RSSI_VALUE
 cdef object AdvertisementData
 cdef object BLEDevice

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -29,7 +29,7 @@ from .const import (
     START_TIMEOUT,
     STOP_TIMEOUT,
 )
-from .models import BluetoothScanningMode, BluetoothServiceInfoBleak
+from .models import ADV_DATA_UNKNOWN, BluetoothScanningMode, BluetoothServiceInfoBleak
 from .util import async_reset_adapter, is_docker_env
 
 int_ = int
@@ -328,7 +328,7 @@ class HaScanner(BaseHaScanner):
         service_info.time = callback_time
         service_info.tx_power = tx_power
         service_info.raw = None  # not available in bleak.
-        service_info._adv_data_changed = -1
+        service_info._adv_data_changed = ADV_DATA_UNKNOWN
         self._manager._scanner_adv_received(service_info)
 
     async def async_start(self) -> None:

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -29,8 +29,10 @@ from .const import (
     START_TIMEOUT,
     STOP_TIMEOUT,
 )
-from .models import _ADV_DATA_UNKNOWN, BluetoothScanningMode, BluetoothServiceInfoBleak
+from .models import ADV_DATA_UNKNOWN, BluetoothScanningMode, BluetoothServiceInfoBleak
 from .util import async_reset_adapter, is_docker_env
+
+_ADV_DATA_UNKNOWN = ADV_DATA_UNKNOWN
 
 int_ = int
 

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -328,7 +328,7 @@ class HaScanner(BaseHaScanner):
         service_info.time = callback_time
         service_info.tx_power = tx_power
         service_info.raw = None  # not available in bleak.
-        service_info.adv_data_changed = True
+        service_info._adv_data_changed = True
         self._manager._scanner_adv_received(service_info)
 
     async def async_start(self) -> None:

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -29,7 +29,7 @@ from .const import (
     START_TIMEOUT,
     STOP_TIMEOUT,
 )
-from .models import ADV_DATA_UNKNOWN, BluetoothScanningMode, BluetoothServiceInfoBleak
+from .models import _ADV_DATA_UNKNOWN, BluetoothScanningMode, BluetoothServiceInfoBleak
 from .util import async_reset_adapter, is_docker_env
 
 int_ = int
@@ -328,7 +328,7 @@ class HaScanner(BaseHaScanner):
         service_info.time = callback_time
         service_info.tx_power = tx_power
         service_info.raw = None  # not available in bleak.
-        service_info._adv_data_changed = ADV_DATA_UNKNOWN
+        service_info._adv_data_changed = _ADV_DATA_UNKNOWN
         self._manager._scanner_adv_received(service_info)
 
     async def async_start(self) -> None:

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -328,6 +328,7 @@ class HaScanner(BaseHaScanner):
         service_info.time = callback_time
         service_info.tx_power = tx_power
         service_info.raw = None  # not available in bleak.
+        service_info.adv_data_changed = True
         self._manager._scanner_adv_received(service_info)
 
     async def async_start(self) -> None:

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -328,7 +328,7 @@ class HaScanner(BaseHaScanner):
         service_info.time = callback_time
         service_info.tx_power = tx_power
         service_info.raw = None  # not available in bleak.
-        service_info._adv_data_changed = True
+        service_info._adv_data_changed = -1
         self._manager._scanner_adv_received(service_info)
 
     async def async_start(self) -> None:

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -8,6 +8,7 @@ from bluetooth_data_tools import monotonic_time_coarse
 from pytest_codspeed import BenchmarkFixture
 
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector, get_manager
+from habluetooth.models import BluetoothServiceInfoBleak
 
 from . import (
     MockBleakClient,
@@ -745,6 +746,173 @@ async def test_filter_wanted_apple_advs(benchmark: BenchmarkFixture) -> None:
                 _details,
                 _now,
             )
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_raw_unchanged_advertisements(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test injecting 100 raw unchanged advertisements (BlueZ raw path)."""
+    manager = get_manager()
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = BaseHaRemoteScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    _address = "44:44:33:11:23:45"
+    _raw = b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04"
+    _details = {"scanner_specific_data": "test"}
+    _now = monotonic_time_coarse()
+
+    # Seed the first advertisement
+    scanner._async_on_raw_advertisement(_address, -100, _raw, _details, _now)
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            scanner._async_on_raw_advertisement(
+                _address,
+                -100,
+                _raw,
+                _details,
+                _now,
+            )
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bleak_unchanged_advertisements(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test injecting 100 unchanged advertisements via Bleak/HaScanner path."""
+    manager = get_manager()
+
+    device = generate_ble_device(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+    adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+        service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+        manufacturer_data={1: b"\x01"},
+        rssi=-100,
+    )
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = BaseHaRemoteScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    _now = monotonic_time_coarse()
+
+    # Seed the first advertisement through the manager
+    service_info = BluetoothServiceInfoBleak(
+        name=adv.local_name or device.name or device.address,
+        address=device.address,
+        rssi=adv.rssi,
+        manufacturer_data=adv.manufacturer_data,
+        service_data=adv.service_data,
+        service_uuids=adv.service_uuids,
+        source="esp32",
+        device=device,
+        advertisement=adv,
+        connectable=True,
+        time=_now,
+        tx_power=adv.tx_power,
+    )
+    manager.scanner_adv_received(service_info)
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            info = BluetoothServiceInfoBleak(
+                name=adv.local_name or device.name or device.address,
+                address=device.address,
+                rssi=adv.rssi,
+                manufacturer_data=adv.manufacturer_data,
+                service_data=adv.service_data,
+                service_uuids=adv.service_uuids,
+                source="esp32",
+                device=device,
+                advertisement=adv,
+                connectable=True,
+                time=_now,
+                tx_power=adv.tx_power,
+            )
+            manager.scanner_adv_received(info)
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bleak_changed_advertisements(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test injecting 100 changed advertisements via Bleak/HaScanner path."""
+    manager = get_manager()
+
+    device = generate_ble_device(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+
+    advs: list[AdvertisementData] = []
+    for i in range(100):
+        adv = generate_advertisement_data(
+            local_name="wohand",
+            service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+            service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+            manufacturer_data={1: bytes((i,))},
+            rssi=-100,
+        )
+        advs.append(adv)
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = BaseHaRemoteScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    _now = monotonic_time_coarse()
+
+    @benchmark
+    def run():
+        for adv in advs:
+            info = BluetoothServiceInfoBleak(
+                name=adv.local_name or device.name or device.address,
+                address=device.address,
+                rssi=adv.rssi,
+                manufacturer_data=adv.manufacturer_data,
+                service_data=adv.service_data,
+                service_uuids=adv.service_uuids,
+                source="esp32",
+                device=device,
+                advertisement=adv,
+                connectable=True,
+                time=_now,
+                tx_power=adv.tx_power,
+            )
+            manager.scanner_adv_received(info)
 
     cancel()
     unsetup()

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import MagicMock
+
 import pytest
 from bleak.backends.scanner import AdvertisementData
 from bluetooth_data_tools import monotonic_time_coarse
 from pytest_codspeed import BenchmarkFixture
 
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector, get_manager
-from habluetooth.models import BluetoothServiceInfoBleak
+from habluetooth.channels.bluez import BluetoothMGMTProtocol
+from habluetooth.models import BluetoothScanningMode, BluetoothServiceInfoBleak
+from habluetooth.scanner import HaScanner
 
 from . import (
     MockBleakClient,
@@ -916,3 +921,105 @@ async def test_inject_100_bleak_changed_advertisements(
 
     cancel()
     unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bluez_raw_end_to_end_unchanged(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test 100 unchanged advertisements through full BlueZ MGMT protocol path."""
+    manager = get_manager()
+    loop = asyncio.get_running_loop()
+
+    scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
+    scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    scanners: dict[int, HaScanner] = {0: scanner}
+    future: asyncio.Future[None] = loop.create_future()
+    mock_sock = MagicMock()
+    protocol = BluetoothMGMTProtocol(
+        future, scanners, lambda: None, lambda: False, mock_sock
+    )
+
+    # Build a DEVICE_FOUND MGMT packet
+    # AD data: flags + local name + manufacturer data
+    ad_data = (
+        b"\x02\x01\x06"  # Flags
+        b"\x08\x09TestDev"  # Complete Local Name = "TestDev"
+        b"\x04\xff\x01\x00\xaa"  # Manufacturer data: company 0x0001, data 0xaa
+    )
+    param_len = 6 + 1 + 1 + 4 + 2 + len(ad_data)
+    packet = (
+        b"\x12\x00"  # DEVICE_FOUND event
+        b"\x00\x00"  # controller_idx = 0
+        + param_len.to_bytes(2, "little")
+        + b"\xaa\xbb\xcc\xdd\xee\xff"  # address
+        + b"\x01"  # address_type
+        + b"\xc4"  # rssi = -60
+        + b"\x00\x00\x00\x00"  # flags
+        + len(ad_data).to_bytes(2, "little")
+        + ad_data
+    )
+
+    # Seed first advertisement
+    protocol.data_received(packet)
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            protocol.data_received(packet)
+
+    cancel()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bluez_raw_end_to_end_changed(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test 100 changed advertisements through full BlueZ MGMT protocol path."""
+    manager = get_manager()
+    loop = asyncio.get_running_loop()
+
+    scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
+    scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    scanners: dict[int, HaScanner] = {0: scanner}
+    future: asyncio.Future[None] = loop.create_future()
+    mock_sock = MagicMock()
+    protocol = BluetoothMGMTProtocol(
+        future, scanners, lambda: None, lambda: False, mock_sock
+    )
+
+    # Build 100 different DEVICE_FOUND MGMT packets with varying manufacturer data
+    packets: list[bytes] = []
+    for i in range(100):
+        ad_data = (
+            b"\x02\x01\x06"  # Flags
+            b"\x08\x09TestDev"  # Complete Local Name = "TestDev"
+            + b"\x04\xff\x01\x00"  # Manufacturer data header: company 0x0001
+            + bytes((i,))  # Varying data byte
+        )
+        param_len = 6 + 1 + 1 + 4 + 2 + len(ad_data)
+        packet = (
+            b"\x12\x00"  # DEVICE_FOUND event
+            b"\x00\x00"  # controller_idx = 0
+            + param_len.to_bytes(2, "little")
+            + b"\xaa\xbb\xcc\xdd\xee\xff"  # address
+            + b"\x01"  # address_type
+            + b"\xc4"  # rssi = -60
+            + b"\x00\x00\x00\x00"  # flags
+            + len(ad_data).to_bytes(2, "little")
+            + ad_data
+        )
+        packets.append(packet)
+
+    @benchmark
+    def run():
+        for packet in packets:
+            protocol.data_received(packet)
+
+    cancel()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
+import pytest
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
@@ -216,10 +217,13 @@ def test_create_ha_scanner():
     assert isinstance(scanner, HaScanner)
 
 
-def test_adv_data_unchanged_dedup_same_source():
+@pytest.mark.asyncio
+async def test_adv_data_unchanged_dedup_same_source():
     """Test that _adv_data_changed=UNCHANGED skips dedup when source matches."""
+    manager = get_manager()
     connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
     scanner = BaseHaRemoteScanner("source1", "source1", connector, True)
+    cancel = manager.async_register_scanner(scanner)
     details = scanner._details | {}
 
     # First advertisement — seeds _all_history
@@ -234,7 +238,11 @@ def test_adv_data_unchanged_dedup_same_source():
         details,
         1.0,
     )
+    mock_discover = MagicMock()
+    manager._subclass_discover_info = mock_discover
+
     # Second identical advertisement — _adv_data_changed will be UNCHANGED
+    # and same source, so dedup should skip dispatch
     scanner._async_on_advertisement(
         "AA:BB:CC:DD:EE:FF",
         -88,
@@ -246,9 +254,14 @@ def test_adv_data_unchanged_dedup_same_source():
         details,
         2.0,
     )
+    # Dedup should have returned early — _subclass_discover_info not called
+    mock_discover.assert_not_called()
+
+    cancel()
 
 
-def test_adv_data_unchanged_different_source():
+@pytest.mark.asyncio
+async def test_adv_data_unchanged_different_source():
     """Test _adv_data_changed=UNCHANGED with different source falls through."""
     manager = get_manager()
     connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
@@ -273,6 +286,9 @@ def test_adv_data_unchanged_different_source():
         details,
         1.0,
     )
+    mock_discover = MagicMock()
+    manager._subclass_discover_info = mock_discover
+
     # Scanner 2 sends same data — _adv_data_changed=UNCHANGED from scanner2's
     # perspective, but _all_history has source1's info. The stale time check
     # will prefer the new source since old is stale (time diff > fallback max).
@@ -288,11 +304,17 @@ def test_adv_data_unchanged_different_source():
         1000.0,
     )
 
+    # Different source with stale old data — should dispatch (source switch)
+    mock_discover.assert_called_once()
+    # _all_history should now have source2's info
+    assert manager._all_history["AA:BB:CC:DD:EE:FF"].source == "source2"
+
     cancel1()
     cancel2()
 
 
-def test_adv_data_unknown_dedup():
+@pytest.mark.asyncio
+async def test_adv_data_unknown_dedup():
     """Test that _adv_data_changed=UNKNOWN falls back to field comparison."""
     manager = get_manager()
     connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
@@ -338,6 +360,14 @@ def test_adv_data_unknown_dedup():
         tx_power=-88,
     )
     info2._adv_data_changed = ADV_DATA_UNKNOWN
+
+    mock_discover = MagicMock()
+    manager._subclass_discover_info = mock_discover
+
     manager.scanner_adv_received(info2)
+
+    # Same data with ADV_DATA_UNKNOWN — field comparison should detect
+    # no change and dedup (return early)
+    mock_discover.assert_not_called()
 
     cancel()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -286,12 +286,9 @@ async def test_adv_data_unchanged_different_source():
         details,
         1.0,
     )
-    mock_discover = MagicMock()
-    manager._subclass_discover_info = mock_discover
 
-    # Scanner 2 sends same data — _adv_data_changed=UNCHANGED from scanner2's
-    # perspective, but _all_history has source1's info. The stale time check
-    # will prefer the new source since old is stale (time diff > fallback max).
+    # Scanner 2 sends first adv — seeds scanner2's _previous_service_info.
+    # _all_history switches to source2 (stale time diff).
     scanner2._async_on_advertisement(
         "AA:BB:CC:DD:EE:FF",
         -40,
@@ -303,10 +300,61 @@ async def test_adv_data_unchanged_different_source():
         details,
         1000.0,
     )
+    assert manager._all_history["AA:BB:CC:DD:EE:FF"].source == "source2"
 
-    # Different source with stale old data — should dispatch (source switch)
+    # Scanner 1 sends again — seeds scanner1's _previous_service_info with
+    # same data. _all_history now has source2.
+    scanner1._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -50,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        2001.0,
+    )
+    # _all_history switches back to source1 (stale time diff)
+    assert manager._all_history["AA:BB:CC:DD:EE:FF"].source == "source1"
+
+    mock_discover = MagicMock()
+    manager._subclass_discover_info = mock_discover
+
+    # Scanner 1 sends SAME data again — _adv_data_changed=UNCHANGED from
+    # scanner1's perspective, but _all_history has source1 now, so
+    # old_service_info.source IS service_info.source → dedup returns early.
+    scanner1._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -50,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        2002.0,
+    )
+    # Same source, unchanged — dedup should skip dispatch
+    mock_discover.assert_not_called()
+
+    # Now scanner 2 sends same data again — _adv_data_changed=UNCHANGED from
+    # scanner2's perspective, but _all_history has source1.
+    # old_service_info.source (source1) is NOT service_info.source (source2).
+    # This covers line 704 being False.
+    scanner2._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -40,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        3001.0,
+    )
+    # Different source — should dispatch despite _adv_data_changed=UNCHANGED
     mock_discover.assert_called_once()
-    # _all_history should now have source2's info
     assert manager._all_history["AA:BB:CC:DD:EE:FF"].source == "source2"
 
     cancel1()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,7 +12,12 @@ from habluetooth import (
     HaScanner,
     get_manager,
 )
-from habluetooth.models import ADV_DATA_UNKNOWN, BluetoothServiceInfoBleak
+from habluetooth.models import (
+    ADV_DATA_CHANGED,
+    ADV_DATA_UNCHANGED,
+    ADV_DATA_UNKNOWN,
+    BluetoothServiceInfoBleak,
+)
 
 
 class MockBleakClient:
@@ -420,3 +425,122 @@ async def test_adv_data_unknown_dedup():
     mock_discover.assert_not_called()
 
     cancel()
+
+
+def test_adv_data_changed_set_by_init():
+    """Test that __init__ sets _adv_data_changed to ADV_DATA_UNKNOWN."""
+    device = BLEDevice("AA:BB:CC:DD:EE:FF", "name", {})
+    info = BluetoothServiceInfoBleak(
+        name="name",
+        address="AA:BB:CC:DD:EE:FF",
+        rssi=-88,
+        manufacturer_data={1: b"\x01"},
+        service_data={"svc": b"\x01"},
+        service_uuids=["svc"],
+        source="source1",
+        device=device,
+        advertisement=None,
+        connectable=True,
+        time=1.0,
+        tx_power=-88,
+    )
+    assert info._adv_data_changed == ADV_DATA_UNKNOWN
+
+
+def test_adv_data_changed_set_by_as_connectable():
+    """Test that _as_connectable copies _adv_data_changed from source."""
+    device = BLEDevice("AA:BB:CC:DD:EE:FF", "name", {})
+    info = BluetoothServiceInfoBleak(
+        name="name",
+        address="AA:BB:CC:DD:EE:FF",
+        rssi=-88,
+        manufacturer_data={1: b"\x01"},
+        service_data={"svc": b"\x01"},
+        service_uuids=["svc"],
+        source="source1",
+        device=device,
+        advertisement=None,
+        connectable=False,
+        time=1.0,
+        tx_power=-88,
+    )
+    assert info._adv_data_changed == ADV_DATA_UNKNOWN
+    connectable = info._as_connectable()
+    assert connectable._adv_data_changed == ADV_DATA_UNKNOWN
+
+    info._adv_data_changed = ADV_DATA_UNCHANGED
+    connectable2 = info._as_connectable()
+    assert connectable2._adv_data_changed == ADV_DATA_UNCHANGED
+
+
+@pytest.mark.asyncio
+async def test_adv_data_changed_set_by_advertisement_internal():
+    """Test _async_on_advertisement_internal sets _adv_data_changed correctly."""
+    connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
+    scanner = BaseHaRemoteScanner("source1", "source1", connector, True)
+    details = scanner._details | {}
+
+    # First advertisement — new device, should be CHANGED
+    scanner._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -88,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        1.0,
+    )
+    info1 = scanner._previous_service_info["AA:BB:CC:DD:EE:FF"]
+    assert info1._adv_data_changed == ADV_DATA_CHANGED
+
+    # Second identical advertisement — should be UNCHANGED
+    scanner._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -88,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        2.0,
+    )
+    info2 = scanner._previous_service_info["AA:BB:CC:DD:EE:FF"]
+    assert info2._adv_data_changed == ADV_DATA_UNCHANGED
+
+    # Third advertisement with changed data — should be CHANGED
+    scanner._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -88,
+        "name",
+        ["svc"],
+        {"svc": b"\x02"},
+        {1: b"\x01"},
+        -88,
+        details,
+        3.0,
+    )
+    info3 = scanner._previous_service_info["AA:BB:CC:DD:EE:FF"]
+    assert info3._adv_data_changed == ADV_DATA_CHANGED
+
+
+@pytest.mark.asyncio
+async def test_adv_data_changed_set_by_raw_fast_path():
+    """Test raw fast path sets _adv_data_changed to ADV_DATA_UNCHANGED."""
+    connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
+    scanner = BaseHaRemoteScanner("source1", "source1", connector, True)
+
+    raw = b"\x02\x01\x06\x04\xff\x01\x00\xaa"
+    address = "AA:BB:CC:DD:EE:FF"
+
+    # First raw — slow path, CHANGED
+    scanner._async_on_raw_advertisement(address, -60, raw, {}, 1.0)
+    info1 = scanner._previous_service_info[address]
+    assert info1._adv_data_changed == ADV_DATA_CHANGED
+
+    # Second same raw — fast path, UNCHANGED
+    scanner._async_on_raw_advertisement(address, -50, raw, {}, 2.0)
+    info2 = scanner._previous_service_info[address]
+    assert info2._adv_data_changed == ADV_DATA_UNCHANGED

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -242,13 +242,14 @@ async def test_adv_data_unchanged_dedup_same_source():
     manager._subclass_discover_info = mock_discover
 
     # Second identical advertisement — _adv_data_changed will be UNCHANGED
-    # and same source, so dedup should skip dispatch
+    # and same source, so dedup should skip dispatch.
+    # Use dynamically constructed strings to avoid CPython interning.
     scanner._async_on_advertisement(
-        "AA:BB:CC:DD:EE:FF",
+        "".join(["AA:BB:CC:DD:EE:FF"]),
         -88,
-        "name",
-        ["service_uuid"],
-        {"service_uuid": b"\x01"},
+        "".join(["name"]),
+        ["".join(["service_uuid"])],
+        {"".join(["service_uuid"]): b"\x01"},
         {1: b"\x01"},
         -88,
         details,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,7 +9,9 @@ from habluetooth import (
     BluetoothScanningMode,
     HaBluetoothConnector,
     HaScanner,
+    get_manager,
 )
+from habluetooth.models import ADV_DATA_UNKNOWN, BluetoothServiceInfoBleak
 
 
 class MockBleakClient:
@@ -212,3 +214,130 @@ def test__async_on_advertisement_prefers_longest_local_name():
 def test_create_ha_scanner():
     scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
     assert isinstance(scanner, HaScanner)
+
+
+def test_adv_data_unchanged_dedup_same_source():
+    """Test that _adv_data_changed=UNCHANGED skips dedup when source matches."""
+    connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
+    scanner = BaseHaRemoteScanner("source1", "source1", connector, True)
+    details = scanner._details | {}
+
+    # First advertisement — seeds _all_history
+    scanner._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -88,
+        "name",
+        ["service_uuid"],
+        {"service_uuid": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        1.0,
+    )
+    # Second identical advertisement — _adv_data_changed will be UNCHANGED
+    scanner._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -88,
+        "name",
+        ["service_uuid"],
+        {"service_uuid": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        2.0,
+    )
+
+
+def test_adv_data_unchanged_different_source():
+    """Test _adv_data_changed=UNCHANGED with different source falls through."""
+    manager = get_manager()
+    connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
+
+    scanner1 = BaseHaRemoteScanner("source1", "source1", connector, True)
+    cancel1 = manager.async_register_scanner(scanner1)
+
+    scanner2 = BaseHaRemoteScanner("source2", "source2", connector, True)
+    cancel2 = manager.async_register_scanner(scanner2)
+
+    details: dict[str, str] = {}
+
+    # Scanner 1 sends advertisement — seeds _all_history with source1
+    scanner1._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -50,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        1.0,
+    )
+    # Scanner 2 sends same data — _adv_data_changed=UNCHANGED from scanner2's
+    # perspective, but _all_history has source1's info. The stale time check
+    # will prefer the new source since old is stale (time diff > fallback max).
+    scanner2._async_on_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        -40,
+        "name",
+        ["svc"],
+        {"svc": b"\x01"},
+        {1: b"\x01"},
+        -88,
+        details,
+        1000.0,
+    )
+
+    cancel1()
+    cancel2()
+
+
+def test_adv_data_unknown_dedup():
+    """Test that _adv_data_changed=UNKNOWN falls back to field comparison."""
+    manager = get_manager()
+    connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
+    scanner = BaseHaRemoteScanner("source1", "source1", connector, True)
+    cancel = manager.async_register_scanner(scanner)
+
+    device = BLEDevice("AA:BB:CC:DD:EE:FF", "name", {})
+    mfr_data = {1: b"\x01"}
+    svc_data = {"service_uuid": b"\x01"}
+    svc_uuids = ["service_uuid"]
+
+    # First advertisement — seeds _all_history
+    info1 = BluetoothServiceInfoBleak(
+        name="name",
+        address="AA:BB:CC:DD:EE:FF",
+        rssi=-88,
+        manufacturer_data=mfr_data,
+        service_data=svc_data,
+        service_uuids=svc_uuids,
+        source="source1",
+        device=device,
+        advertisement=None,
+        connectable=True,
+        time=1.0,
+        tx_power=-88,
+    )
+    manager.scanner_adv_received(info1)
+
+    # Second advertisement with same data but _adv_data_changed=UNKNOWN
+    # (simulates Bleak/HaScanner path)
+    info2 = BluetoothServiceInfoBleak(
+        name="name",
+        address="AA:BB:CC:DD:EE:FF",
+        rssi=-88,
+        manufacturer_data=mfr_data,
+        service_data=svc_data,
+        service_uuids=svc_uuids,
+        source="source1",
+        device=device,
+        advertisement=None,
+        connectable=True,
+        time=2.0,
+        tx_power=-88,
+    )
+    info2._adv_data_changed = ADV_DATA_UNKNOWN
+    manager.scanner_adv_received(info2)
+
+    cancel()


### PR DESCRIPTION
## Summary
- Add `_adv_data_changed` tri-state int field to `BluetoothServiceInfoBleak` that tracks whether advertisement data actually changed
- `_async_on_advertisement_internal` (base_scanner) sets the flag using cheap pointer identity checks after the merge logic — the merge already reuses the same Python objects when data hasn't changed
- `_scanner_adv_received` (manager) uses the flag to skip the 4-field dedup comparison entirely when data hasn't changed and the source is the same
- Three states declared as `cdef int` in each consumer's `.pxd` for C-level comparison:
  - `ADV_DATA_UNCHANGED` (0) = data definitely unchanged, skip dedup
  - `ADV_DATA_CHANGED` (1) = data definitely changed, skip dedup and dispatch
  - `ADV_DATA_UNKNOWN` (-1) = unknown, fall back to field-by-field comparison
- Default is `ADV_DATA_UNKNOWN` so external callers constructing `BluetoothServiceInfoBleak(...)` directly get the existing dedup behavior
- For the Bleak/HaScanner path (scanner.py), `_adv_data_changed` is `ADV_DATA_UNKNOWN` since fresh objects are created per advertisement — the existing field-by-field dedup handles this path
- For remote scanners (ESPHome/BlueZ raw), the merge in base_scanner detects no change → flag is `ADV_DATA_UNCHANGED` → manager skips the dedup block
- The raw advertisement fast path (from #369) also explicitly sets `ADV_DATA_UNCHANGED`
- Simplifies `service_uuids`, `service_data`, and `manufacturer_data` merge logic by collapsing duplicate branches that assigned `prev_info`'s object
- Fixes name identity preservation by using `>=` instead of `>` in length comparison, so equal-length names reuse the previous object
- Source comparison in dedup uses both `is` and `==` for correctness with non-interned strings

## Test plan
- [x] All existing tests pass
- [x] Tests verify `_adv_data_changed` is set correctly at every construction site (`__init__`, `_as_connectable`, `_async_on_advertisement_internal`, raw fast path)
- [x] Tests assert observable dedup outcomes via `_subclass_discover_info` mock
- [x] Tests cover: unchanged same source (skips), unchanged different source (dispatches), ADV_DATA_UNKNOWN fallback (field comparison dedup)
- [x] Tests use non-interned strings to avoid CPython string interning masking bugs
- [x] CodSpeed shows +7.63% improvement on `test_inject_100_different_manufacturer_data`