### PR TITLE
perf: skip raw advertisement parsing when data unchanged

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -74,7 +74,7 @@ cdef class BaseHaScanner:
     @cython.locals(info=BluetoothServiceInfoBleak)
     cdef dict _build_discovered_device_timestamps(self)
 
-    @cython.locals(parsed=tuple, prev_info=BluetoothServiceInfoBleak, info=BluetoothServiceInfoBleak)
+    @cython.locals(parsed=tuple, prev_info=BluetoothServiceInfoBleak)
     cpdef void _async_on_raw_advertisement(
         self,
         str address,

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -74,7 +74,7 @@ cdef class BaseHaScanner:
     @cython.locals(info=BluetoothServiceInfoBleak)
     cdef dict _build_discovered_device_timestamps(self)
 
-    @cython.locals(parsed=tuple, prev_info=BluetoothServiceInfoBleak)
+    @cython.locals(parsed=tuple, prev_info=BluetoothServiceInfoBleak, info=BluetoothServiceInfoBleak)
     cpdef void _async_on_raw_advertisement(
         self,
         str address,

--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -74,7 +74,7 @@ cdef class BaseHaScanner:
     @cython.locals(info=BluetoothServiceInfoBleak)
     cdef dict _build_discovered_device_timestamps(self)
 
-    @cython.locals(parsed=tuple)
+    @cython.locals(parsed=tuple, prev_info=BluetoothServiceInfoBleak, info=BluetoothServiceInfoBleak)
     cpdef void _async_on_raw_advertisement(
         self,
         str address,

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -466,6 +466,30 @@ class BaseHaScanner:
         details: dict[str, Any],
         advertisement_monotonic_time: _float,
     ) -> None:
+        if (
+            prev_info := self._previous_service_info.get(address)
+        ) is not None and prev_info.raw == raw:
+            # Raw advertisement data unchanged — skip parsing and merge
+            # logic, reuse the previous parsed data directly.
+            self.scanning = not self._connecting
+            self._last_detection = advertisement_monotonic_time
+            info = BluetoothServiceInfoBleak.__new__(BluetoothServiceInfoBleak)
+            info.device = prev_info.device
+            info.name = prev_info.name
+            info.manufacturer_data = prev_info.manufacturer_data
+            info.service_data = prev_info.service_data
+            info.service_uuids = prev_info.service_uuids
+            info.address = address
+            info.rssi = rssi
+            info.source = self.source
+            info._advertisement = None
+            info.connectable = self.connectable
+            info.time = advertisement_monotonic_time
+            info.tx_power = prev_info.tx_power
+            info.raw = prev_info.raw
+            self._previous_service_info[address] = info
+            self._manager._scanner_adv_received(info)
+            return
         parsed = parse_advertisement_data_bytes(raw)
         self._async_on_advertisement_internal(
             address,

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -466,24 +466,29 @@ class BaseHaScanner:
         details: dict[str, Any],
         advertisement_monotonic_time: _float,
     ) -> None:
-        prev_info = self._previous_service_info.get(address)
-        if prev_info is not None and prev_info.raw == raw:
-            # Raw advertisement data unchanged — skip parse_advertisement_data_bytes
-            # and pass the previous parsed data to _async_on_advertisement_internal.
-            # The merge logic will see identical objects via `is` checks and
-            # short-circuit, avoiding all dict iteration and comparison work.
-            self._async_on_advertisement_internal(
-                address,
-                rssi,
-                prev_info.name,
-                prev_info.service_uuids,
-                prev_info.service_data,
-                prev_info.manufacturer_data,
-                prev_info.tx_power,
-                details,
-                advertisement_monotonic_time,
-                raw,
-            )
+        if (
+            prev_info := self._previous_service_info.get(address)
+        ) is not None and prev_info.raw == raw:
+            # Raw advertisement data unchanged — skip parsing and merge
+            # logic, reuse the previous parsed data directly.
+            self.scanning = not self._connecting
+            self._last_detection = advertisement_monotonic_time
+            info = BluetoothServiceInfoBleak.__new__(BluetoothServiceInfoBleak)
+            info.device = prev_info.device
+            info.name = prev_info.name
+            info.manufacturer_data = prev_info.manufacturer_data
+            info.service_data = prev_info.service_data
+            info.service_uuids = prev_info.service_uuids
+            info.address = address
+            info.rssi = rssi
+            info.source = self.source
+            info._advertisement = None
+            info.connectable = self.connectable
+            info.time = advertisement_monotonic_time
+            info.tx_power = prev_info.tx_power
+            info.raw = prev_info.raw
+            self._previous_service_info[address] = info
+            self._manager._scanner_adv_received(info)
             return
         parsed = parse_advertisement_data_bytes(raw)
         self._async_on_advertisement_internal(

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -466,29 +466,24 @@ class BaseHaScanner:
         details: dict[str, Any],
         advertisement_monotonic_time: _float,
     ) -> None:
-        if (
-            prev_info := self._previous_service_info.get(address)
-        ) is not None and prev_info.raw == raw:
-            # Raw advertisement data unchanged — skip parsing and merge
-            # logic, reuse the previous parsed data directly.
-            self.scanning = not self._connecting
-            self._last_detection = advertisement_monotonic_time
-            info = BluetoothServiceInfoBleak.__new__(BluetoothServiceInfoBleak)
-            info.device = prev_info.device
-            info.name = prev_info.name
-            info.manufacturer_data = prev_info.manufacturer_data
-            info.service_data = prev_info.service_data
-            info.service_uuids = prev_info.service_uuids
-            info.address = address
-            info.rssi = rssi
-            info.source = self.source
-            info._advertisement = None
-            info.connectable = self.connectable
-            info.time = advertisement_monotonic_time
-            info.tx_power = prev_info.tx_power
-            info.raw = prev_info.raw
-            self._previous_service_info[address] = info
-            self._manager._scanner_adv_received(info)
+        prev_info = self._previous_service_info.get(address)
+        if prev_info is not None and prev_info.raw == raw:
+            # Raw advertisement data unchanged — skip parse_advertisement_data_bytes
+            # and pass the previous parsed data to _async_on_advertisement_internal.
+            # The merge logic will see identical objects via `is` checks and
+            # short-circuit, avoiding all dict iteration and comparison work.
+            self._async_on_advertisement_internal(
+                address,
+                rssi,
+                prev_info.name,
+                prev_info.service_uuids,
+                prev_info.service_data,
+                prev_info.manufacturer_data,
+                prev_info.tx_power,
+                details,
+                advertisement_monotonic_time,
+                raw,
+            )
             return
         parsed = parse_advertisement_data_bytes(raw)
         self._async_on_advertisement_internal(

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -248,6 +248,54 @@ async def test_remote_scanner(name_2: str | None) -> None:
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_raw_advertisement_fast_path_unchanged() -> None:
+    """Test that sending the same raw bytes twice uses the fast path."""
+    manager = get_manager()
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = FakeScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    raw_adv = b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04"
+    address = "44:44:33:11:23:45"
+
+    # First raw advertisement — takes the slow path (parse + merge)
+    scanner.inject_raw_advertisement(address, -60, raw_adv, 1.0)
+    info1 = scanner._previous_service_info[address]
+    assert info1.rssi == -60
+    assert info1.raw == raw_adv
+
+    # Second raw advertisement with same bytes — takes the fast path
+    scanner.inject_raw_advertisement(address, -50, raw_adv, 2.0)
+    info2 = scanner._previous_service_info[address]
+    assert info2.rssi == -50
+    assert info2.time == 2.0
+    # Fast path reuses parsed data from prev_info
+    assert info2.manufacturer_data is info1.manufacturer_data
+    assert info2.service_data is info1.service_data
+    assert info2.service_uuids is info1.service_uuids
+    assert info2.name is info1.name
+    assert info2.device is info1.device
+    assert info2.raw is info1.raw
+
+    # Third raw advertisement with different bytes — takes the slow path
+    raw_adv_changed = b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x05"
+    scanner.inject_raw_advertisement(address, -40, raw_adv_changed, 3.0)
+    info3 = scanner._previous_service_info[address]
+    assert info3.rssi == -40
+    assert info3.raw == raw_adv_changed
+    # Slow path re-parsed, so objects may differ
+    assert info3.raw is not info1.raw
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_remote_scanner_expires_connectable() -> None:
     """Test the remote scanner expires stale connectable data."""
     manager = get_manager()


### PR DESCRIPTION
## Summary
- When raw advertisement bytes match the previous advertisement for the same address, skip `parse_advertisement_data_bytes` and the merge logic entirely
- Reuse the previous parsed data (service_data, manufacturer_data, service_uuids, name, tx_power) in a new `BluetoothServiceInfoBleak` with updated rssi and time
- Since the data objects are reused by identity, the manager's dedup check (`is not` + `!=`) short-circuits on the identity check
- Updates `.pxd` Cython declarations with typed locals for the fast path

## Test plan
- [x] Existing tests pass
- [ ] Verify no regression in advertisement processing with ESPHome/remote scanners