### PR TITLE
test(bench): add BlueZ raw, Bleak, and MGMT end-to-end advertisement benchmarks

### DIFF
--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import MagicMock
+
 import pytest
 from bleak.backends.scanner import AdvertisementData
 from bluetooth_data_tools import monotonic_time_coarse
 from pytest_codspeed import BenchmarkFixture
 
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector, get_manager
+from habluetooth.channels.bluez import BluetoothMGMTProtocol
+from habluetooth.models import BluetoothScanningMode, BluetoothServiceInfoBleak
+from habluetooth.scanner import HaScanner
 
 from . import (
     MockBleakClient,
@@ -748,3 +754,272 @@ async def test_filter_wanted_apple_advs(benchmark: BenchmarkFixture) -> None:
 
     cancel()
     unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_raw_unchanged_advertisements(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test injecting 100 raw unchanged advertisements (BlueZ raw path)."""
+    manager = get_manager()
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = BaseHaRemoteScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    _address = "44:44:33:11:23:45"
+    _raw = b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04"
+    _details = {"scanner_specific_data": "test"}
+    _now = monotonic_time_coarse()
+
+    # Seed the first advertisement
+    scanner._async_on_raw_advertisement(_address, -100, _raw, _details, _now)
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            scanner._async_on_raw_advertisement(
+                _address,
+                -100,
+                _raw,
+                _details,
+                _now,
+            )
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bleak_unchanged_advertisements(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test injecting 100 unchanged advertisements via Bleak/HaScanner path."""
+    manager = get_manager()
+
+    device = generate_ble_device(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+    adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+        service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+        manufacturer_data={1: b"\x01"},
+        rssi=-100,
+    )
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = BaseHaRemoteScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    _now = monotonic_time_coarse()
+
+    # Seed the first advertisement through the manager
+    service_info = BluetoothServiceInfoBleak(
+        name=adv.local_name or device.name or device.address,
+        address=device.address,
+        rssi=adv.rssi,
+        manufacturer_data=adv.manufacturer_data,
+        service_data=adv.service_data,
+        service_uuids=adv.service_uuids,
+        source="esp32",
+        device=device,
+        advertisement=adv,
+        connectable=True,
+        time=_now,
+        tx_power=adv.tx_power,
+    )
+    manager.scanner_adv_received(service_info)
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            info = BluetoothServiceInfoBleak(
+                name=adv.local_name or device.name or device.address,
+                address=device.address,
+                rssi=adv.rssi,
+                manufacturer_data=adv.manufacturer_data,
+                service_data=adv.service_data,
+                service_uuids=adv.service_uuids,
+                source="esp32",
+                device=device,
+                advertisement=adv,
+                connectable=True,
+                time=_now,
+                tx_power=adv.tx_power,
+            )
+            manager.scanner_adv_received(info)
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bleak_changed_advertisements(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test injecting 100 changed advertisements via Bleak/HaScanner path."""
+    manager = get_manager()
+
+    device = generate_ble_device(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+
+    advs: list[AdvertisementData] = []
+    for i in range(100):
+        adv = generate_advertisement_data(
+            local_name="wohand",
+            service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+            service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+            manufacturer_data={1: bytes((i,))},
+            rssi=-100,
+        )
+        advs.append(adv)
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = BaseHaRemoteScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    _now = monotonic_time_coarse()
+
+    @benchmark
+    def run():
+        for adv in advs:
+            info = BluetoothServiceInfoBleak(
+                name=adv.local_name or device.name or device.address,
+                address=device.address,
+                rssi=adv.rssi,
+                manufacturer_data=adv.manufacturer_data,
+                service_data=adv.service_data,
+                service_uuids=adv.service_uuids,
+                source="esp32",
+                device=device,
+                advertisement=adv,
+                connectable=True,
+                time=_now,
+                tx_power=adv.tx_power,
+            )
+            manager.scanner_adv_received(info)
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bluez_raw_end_to_end_unchanged(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test 100 unchanged advertisements through full BlueZ MGMT protocol path."""
+    manager = get_manager()
+    loop = asyncio.get_running_loop()
+
+    scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
+    scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    scanners: dict[int, HaScanner] = {0: scanner}
+    future: asyncio.Future[None] = loop.create_future()
+    mock_sock = MagicMock()
+    protocol = BluetoothMGMTProtocol(
+        future, scanners, lambda: None, lambda: False, mock_sock
+    )
+
+    # Build a DEVICE_FOUND MGMT packet
+    # AD data: flags + local name + manufacturer data
+    ad_data = (
+        b"\x02\x01\x06"  # Flags
+        b"\x08\x09TestDev"  # Complete Local Name = "TestDev"
+        b"\x04\xff\x01\x00\xaa"  # Manufacturer data: company 0x0001, data 0xaa
+    )
+    param_len = 6 + 1 + 1 + 4 + 2 + len(ad_data)
+    packet = (
+        b"\x12\x00"  # DEVICE_FOUND event
+        b"\x00\x00"  # controller_idx = 0
+        + param_len.to_bytes(2, "little")
+        + b"\xaa\xbb\xcc\xdd\xee\xff"  # address
+        + b"\x01"  # address_type
+        + b"\xc4"  # rssi = -60
+        + b"\x00\x00\x00\x00"  # flags
+        + len(ad_data).to_bytes(2, "little")
+        + ad_data
+    )
+
+    # Seed first advertisement
+    protocol.data_received(packet)
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            protocol.data_received(packet)
+
+    cancel()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_inject_100_bluez_raw_end_to_end_changed(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Test 100 changed advertisements through full BlueZ MGMT protocol path."""
+    manager = get_manager()
+    loop = asyncio.get_running_loop()
+
+    scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
+    scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    scanners: dict[int, HaScanner] = {0: scanner}
+    future: asyncio.Future[None] = loop.create_future()
+    mock_sock = MagicMock()
+    protocol = BluetoothMGMTProtocol(
+        future, scanners, lambda: None, lambda: False, mock_sock
+    )
+
+    # Build 100 different DEVICE_FOUND MGMT packets with varying manufacturer data
+    packets: list[bytes] = []
+    for i in range(100):
+        ad_data = (
+            b"\x02\x01\x06"  # Flags
+            b"\x08\x09TestDev"  # Complete Local Name = "TestDev"
+            + b"\x04\xff\x01\x00"  # Manufacturer data header: company 0x0001
+            + bytes((i,))  # Varying data byte
+        )
+        param_len = 6 + 1 + 1 + 4 + 2 + len(ad_data)
+        packet = (
+            b"\x12\x00"  # DEVICE_FOUND event
+            b"\x00\x00"  # controller_idx = 0
+            + param_len.to_bytes(2, "little")
+            + b"\xaa\xbb\xcc\xdd\xee\xff"  # address
+            + b"\x01"  # address_type
+            + b"\xc4"  # rssi = -60
+            + b"\x00\x00\x00\x00"  # flags
+            + len(ad_data).to_bytes(2, "little")
+            + ad_data
+        )
+        packets.append(packet)
+
+    @benchmark
+    def run():
+        for packet in packets:
+            protocol.data_received(packet)
+
+    cancel()


### PR DESCRIPTION
## Summary
- Add benchmark for BlueZ raw path (`_async_on_raw_advertisement`) with unchanged data
- Add benchmarks for Bleak/HaScanner path (`scanner_adv_received`) with unchanged and changed data
- Add end-to-end BlueZ MGMT benchmarks that go through the full protocol parser → scanner → manager path with unchanged and changed data

These cover advertisement paths that previously had no benchmark coverage.

## Test plan
- [ ] Verify benchmarks run successfully