### PR TITLE
fix: remove macos-13 from wheel build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,14 +152,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          [
-            windows-latest,
-            ubuntu-24.04-arm,
-            ubuntu-latest,
-            macos-13,
-            macos-latest,
-          ]
+        os: [windows-latest, ubuntu-24.04-arm, ubuntu-latest, macos-latest]
         qemu: [""]
         musl: [""]
         pyver: [""]


### PR DESCRIPTION
## Summary
- Remove `macos-13` from the wheel build matrix since GitHub Actions has retired macOS 13 runners, which blocks releases

## Test plan
- [ ] Verify wheel build workflow runs successfully on next release