### PR TITLE
fix(build): ensure bluez helper is cython compiled

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -57,6 +57,7 @@ def build(setup_kwargs: Any) -> None:
                 "ext_modules": cythonize(
                     EXTENSIONS,
                     compiler_directives={"language_level": "3"},  # Python 3
+                    annotate=bool(os.environ.get("CYTHON_ANNOTATE")),
                 ),
                 "cmdclass": {"build_ext": BuildExt},
             }

--- a/src/habluetooth/channels/bluez.pxd
+++ b/src/habluetooth/channels/bluez.pxd
@@ -22,6 +22,7 @@ cdef class BluetoothMGMTProtocol:
     cdef object _on_connection_lost
     cdef object _is_shutting_down
     cdef dict _pending_commands
+    cdef public object _sock
 
     @cython.locals(bytes_data=bytes)
     cdef void _add_to_buffer(self, object data) except *


### PR DESCRIPTION
## Summary
- Add `CYTHON_ANNOTATE` environment variable to control generation of Cython annotation HTML files during build
- Add missing `__init__.py` for channels subpackage (needed for proper Cython cdef class resolution)

## Usage
```
CYTHON_ANNOTATE=1 python setup.py build_ext --inplace
```