### PR TITLE
feat: implement find_device_by_filter in HaBleakScannerWrapper

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -17,6 +17,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
+    AdvertisementDataFilter,
     BaseBleakScanner,
 )
 from bleak_retry_connector import (
@@ -98,6 +99,20 @@ class HaBleakScannerWrapper(BaseBleakScanner):
         return manager.async_ble_device_from_address(
             device_identifier, True
         ) or manager.async_ble_device_from_address(device_identifier, False)
+
+    @classmethod
+    async def find_device_by_filter(
+        cls,
+        filterfunc: AdvertisementDataFilter,
+        timeout: float = 10.0,
+        **kwargs: Any,
+    ) -> BLEDevice | None:
+        """Find a device by filter."""
+        manager = get_manager()
+        for info in manager.async_discovered_service_info(False):
+            if filterfunc(info.device, info.advertisement):
+                return info.device
+        return None
 
     @overload
     @classmethod

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -561,6 +561,35 @@ async def test_find_device_by_address(
 
 
 @pytest.mark.asyncio
+async def test_find_device_by_filter(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure find_device_by_filter finds a device matching the filter."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    device = await bleak.BleakScanner.find_device_by_filter(
+        lambda d, ad: d.address == "00:00:00:00:00:01"
+    )
+    assert device is not None
+    assert device.address == "00:00:00:00:00:01"
+
+
+@pytest.mark.asyncio
+async def test_find_device_by_filter_no_match(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure find_device_by_filter returns None when no device matches."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    device = await bleak.BleakScanner.find_device_by_filter(
+        lambda d, ad: d.address == "DE:AD:BE:EF:00:00"
+    )
+    assert device is None
+
+
+@pytest.mark.asyncio
 async def test_discover(
     two_adapters: None,
     enable_bluetooth: None,


### PR DESCRIPTION
## Summary
- Implements `find_device_by_filter` classmethod on `HaBleakScannerWrapper`, which was missing despite being part of the bleak scanner API
- Searches all discovered devices (connectable and non-connectable) using the provided filter function
- Adds tests for both match and no-match cases

Closes #389

## Test plan
- [x] `test_find_device_by_filter` — verifies a device matching the filter is returned
- [x] `test_find_device_by_filter_no_match` — verifies `None` is returned when no device matches