### PR TITLE
feat: implement find_device_by_name in HaBleakScannerWrapper

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -101,6 +101,17 @@ class HaBleakScannerWrapper(BaseBleakScanner):
         ) or manager.async_ble_device_from_address(device_identifier, False)
 
     @classmethod
+    async def find_device_by_name(
+        cls, name: str, timeout: float = 10.0, **kwargs: Any
+    ) -> BLEDevice | None:
+        """Find a device by name."""
+        return await cls.find_device_by_filter(
+            lambda d, ad: ad.local_name == name,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    @classmethod
     async def find_device_by_filter(
         cls,
         filterfunc: AdvertisementDataFilter,

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -590,6 +590,30 @@ async def test_find_device_by_filter_no_match(
 
 
 @pytest.mark.asyncio
+async def test_find_device_by_name(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure find_device_by_name finds a device matching the name."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    device = await bleak.BleakScanner.find_device_by_name("any")
+    assert device is not None
+
+
+@pytest.mark.asyncio
+async def test_find_device_by_name_no_match(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure find_device_by_name returns None when no device matches."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    device = await bleak.BleakScanner.find_device_by_name("nonexistent")
+    assert device is None
+
+
+@pytest.mark.asyncio
 async def test_discover(
     two_adapters: None,
     enable_bluetooth: None,


### PR DESCRIPTION
## Summary
- Implements `find_device_by_name` classmethod on `HaBleakScannerWrapper` by delegating to `find_device_by_filter` with a name-matching lambda
- Matches the bleak `BleakScanner.find_device_by_name` API

Closes #388

## Test plan
- [x] `test_find_device_by_name` — verifies a device matching the name is returned
- [x] `test_find_device_by_name_no_match` — verifies `None` is returned when no device matches