### PR TITLE
feat: implement async context manager protocol in HaBleakScannerWrapper

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -153,6 +153,15 @@ class HaBleakScannerWrapper(BaseBleakScanner):
     async def start(self, *args: Any, **kwargs: Any) -> None:
         """Start scanning for devices."""
 
+    async def __aenter__(self) -> HaBleakScannerWrapper:
+        """Enter the context manager."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        """Exit the context manager."""
+        await self.stop()
+
     def _map_filters(self, *args: Any, **kwargs: Any) -> bool:
         """Map the filters."""
         mapped_filters = {}

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -614,6 +614,18 @@ async def test_find_device_by_name_no_match(
 
 
 @pytest.mark.asyncio
+async def test_async_context_manager(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure HaBleakScannerWrapper supports async context manager protocol."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    async with bleak.BleakScanner() as scanner:
+        assert scanner.discovered_devices
+
+
+@pytest.mark.asyncio
 async def test_discover(
     two_adapters: None,
     enable_bluetooth: None,


### PR DESCRIPTION
## Summary
- Adds `__aenter__` and `__aexit__` methods to `HaBleakScannerWrapper` to match the bleak `BleakScanner` async context manager API
- Enables `async with BleakScanner() as scanner:` usage pattern

Closes #386

## Test plan
- [x] `test_async_context_manager` — verifies the scanner works as an async context manager and discovered devices are accessible