### PR TITLE
feat: implement discovered_devices_and_advertisement_data in HaBleakScannerWrapper

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -193,6 +193,16 @@ class HaBleakScannerWrapper(BaseBleakScanner):
         """Return a list of discovered devices."""
         return list(get_manager().async_discovered_devices(True))
 
+    @property
+    def discovered_devices_and_advertisement_data(
+        self,
+    ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
+        """Return a dict of discovered devices and their advertisement data."""
+        return {
+            info.address: (info.device, info.advertisement)
+            for info in get_manager().async_discovered_service_info(True)
+        }
+
     def register_detection_callback(
         self, callback: AdvertisementDataCallback | None
     ) -> Callable[[], None]:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -626,6 +626,22 @@ async def test_async_context_manager(
 
 
 @pytest.mark.asyncio
+async def test_discovered_devices_and_advertisement_data(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure discovered_devices_and_advertisement_data works."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    scanner = bleak.BleakScanner()
+    result = scanner.discovered_devices_and_advertisement_data
+    assert "00:00:00:00:00:01" in result
+    device, adv_data = result["00:00:00:00:00:01"]
+    assert device.address == "00:00:00:00:00:01"
+    assert adv_data is not None
+
+
+@pytest.mark.asyncio
 async def test_discover(
     two_adapters: None,
     enable_bluetooth: None,


### PR DESCRIPTION
## Summary
- Adds `discovered_devices_and_advertisement_data` property to `HaBleakScannerWrapper`
- Returns a dict mapping address to `(BLEDevice, AdvertisementData)` tuples, matching the bleak `BleakScanner` API

Closes #387

## Test plan
- [x] `test_discovered_devices_and_advertisement_data` — verifies the property returns devices with advertisement data keyed by address