### PR TITLE
feat: implement advertisement_data async iterator in HaBleakScannerWrapper

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final, Literal, overload
@@ -202,6 +202,21 @@ class HaBleakScannerWrapper(BaseBleakScanner):
             info.address: (info.device, info.advertisement)
             for info in get_manager().async_discovered_service_info(True)
         }
+
+    async def advertisement_data(
+        self,
+    ) -> AsyncGenerator[tuple[BLEDevice, AdvertisementData], None]:
+        """Yield devices and advertisement data as they are discovered."""
+        queue: asyncio.Queue[tuple[BLEDevice, AdvertisementData]] = asyncio.Queue()
+        cancel = get_manager().async_register_bleak_callback(
+            lambda bd, ad: queue.put_nowait((bd, ad)),
+            self._mapped_filters,
+        )
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            cancel()
 
     def register_detection_callback(
         self, callback: AdvertisementDataCallback | None

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -642,6 +642,24 @@ async def test_discovered_devices_and_advertisement_data(
 
 
 @pytest.mark.asyncio
+async def test_advertisement_data_iterator(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+) -> None:
+    """Ensure advertisement_data async iterator yields devices."""
+    _, _cancel_hci0, _cancel_hci1 = _generate_scanners_with_fake_devices()
+    scanner = bleak.BleakScanner()
+    devices_found: dict[str, tuple[BLEDevice, AdvertisementData]] = {}
+    async for device, adv_data in scanner.advertisement_data():
+        devices_found[device.address] = (device, adv_data)
+        if "00:00:00:00:00:01" in devices_found:
+            break
+    assert "00:00:00:00:00:01" in devices_found
+    assert devices_found["00:00:00:00:00:01"][1] is not None
+
+
+@pytest.mark.asyncio
 async def test_discover(
     two_adapters: None,
     enable_bluetooth: None,


### PR DESCRIPTION
## Summary
- Adds `advertisement_data()` async generator to `HaBleakScannerWrapper`
- Yields `(BLEDevice, AdvertisementData)` tuples as devices are discovered, matching the bleak `BleakScanner` API
- Uses the manager's bleak callback registration which replays connectable history on subscribe

Closes #380

## Test plan
- [x] `test_advertisement_data_iterator` — verifies the async iterator yields discovered devices with advertisement data