### PR TITLE
feat!: remove BaseBleakScanner inheritance and register_detection_callback

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -18,7 +18,6 @@ from bleak.backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
     AdvertisementDataFilter,
-    BaseBleakScanner,
 )
 from bleak_retry_connector import (
     ble_device_description,
@@ -65,7 +64,7 @@ class _HaWrappedBleakBackend:
     backend_name: str | None = None
 
 
-class HaBleakScannerWrapper(BaseBleakScanner):
+class HaBleakScannerWrapper:
     """A wrapper that uses the single instance."""
 
     def __init__(
@@ -86,9 +85,9 @@ class HaBleakScannerWrapper(BaseBleakScanner):
             **kwargs,
         }
         self._map_filters(*args, **remapped_kwargs)
-        super().__init__(
-            detection_callback=detection_callback, service_uuids=service_uuids or []
-        )
+        if detection_callback is not None:
+            self._advertisement_data_callback = detection_callback
+            self._setup_detection_callback()
 
     @classmethod
     async def find_device_by_address(
@@ -218,27 +217,12 @@ class HaBleakScannerWrapper(BaseBleakScanner):
         finally:
             cancel()
 
-    def register_detection_callback(
-        self, callback: AdvertisementDataCallback | None
-    ) -> Callable[[], None]:
-        """
-        Register a detection callback.
-
-        The callback is called when a device is discovered or has a property changed.
-
-        This method takes the callback and registers it with the long running scanner.
-        """
-        self._advertisement_data_callback = callback
-        self._setup_detection_callback()
-        return self._cancel_callback
-
     def _setup_detection_callback(self) -> None:
         """Set up the detection callback."""
         if self._advertisement_data_callback is None:
             return
         callback = self._advertisement_data_callback
         self._cancel_callback()
-        super().register_detection_callback(self._advertisement_data_callback)
         manager = get_manager()
 
         if not inspect.iscoroutinefunction(callback):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -725,9 +725,9 @@ async def test_wrapped_instance_with_filter(
 
     assert _get_manager() is not None
     scanner = HaBleakScannerWrapper(
-        filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]}
+        detection_callback=_device_detected,
+        filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]},
     )
-    scanner.register_detection_callback(_device_detected)
 
     inject_advertisement(switchbot_device, switchbot_adv_2)
     await asyncio.sleep(0)
@@ -737,25 +737,18 @@ async def test_wrapped_instance_with_filter(
     assert discovered == [switchbot_device]
     assert len(detected) == 1
 
-    scanner.register_detection_callback(_device_detected)
-    # We should get a reply from the history when we register again
-    assert len(detected) == 2
-    scanner.register_detection_callback(_device_detected)
-    # We should get a reply from the history when we register again
-    assert len(detected) == 3
-
     with patch_discovered_devices([]):
         discovered = await scanner.discover(timeout=0)
         assert len(discovered) == 0
         assert discovered == []
 
     inject_advertisement(switchbot_device, switchbot_adv)
-    assert len(detected) == 4
+    assert len(detected) == 2
 
     # The filter we created in the wrapped scanner with should be respected
     # and we should not get another callback
     inject_advertisement(empty_device, empty_adv)
-    assert len(detected) == 4
+    assert len(detected) == 2
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -789,10 +782,10 @@ async def test_wrapped_instance_with_service_uuids(
     empty_adv = generate_advertisement_data(local_name="empty")
 
     assert _get_manager() is not None
-    scanner = HaBleakScannerWrapper(
-        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    _scanner = HaBleakScannerWrapper(
+        detection_callback=_device_detected,
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     )
-    scanner.register_detection_callback(_device_detected)
 
     inject_advertisement(switchbot_device, switchbot_adv)
     inject_advertisement(switchbot_device, switchbot_adv_2)
@@ -842,10 +835,10 @@ async def test_wrapped_instance_with_service_uuids_with_coro_callback(
     empty_adv = generate_advertisement_data(local_name="empty")
 
     assert _get_manager() is not None
-    scanner = HaBleakScannerWrapper(
-        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    _scanner = HaBleakScannerWrapper(
+        detection_callback=_device_detected,
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     )
-    scanner.register_detection_callback(_device_detected)
 
     inject_advertisement(switchbot_device, switchbot_adv)
     inject_advertisement(switchbot_device, switchbot_adv_2)
@@ -885,10 +878,10 @@ async def test_wrapped_instance_with_broken_callbacks(
     )
 
     assert _get_manager() is not None
-    scanner = HaBleakScannerWrapper(
-        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    _scanner = HaBleakScannerWrapper(
+        detection_callback=_device_detected,
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     )
-    scanner.register_detection_callback(_device_detected)
 
     inject_advertisement(switchbot_device, switchbot_adv)
     await asyncio.sleep(0)
@@ -928,9 +921,10 @@ async def test_wrapped_instance_changes_uuids(
     empty_adv = generate_advertisement_data(local_name="empty")
 
     assert _get_manager() is not None
-    scanner = HaBleakScannerWrapper()
-    scanner.set_scanning_filter(service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"])
-    scanner.register_detection_callback(_device_detected)
+    _scanner = HaBleakScannerWrapper(
+        detection_callback=_device_detected,
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    )
 
     inject_advertisement(switchbot_device, switchbot_adv)
     inject_advertisement(switchbot_device, switchbot_adv_2)
@@ -975,11 +969,10 @@ async def test_wrapped_instance_changes_filters(
     empty_adv = generate_advertisement_data(local_name="empty")
 
     assert _get_manager() is not None
-    scanner = HaBleakScannerWrapper()
-    scanner.set_scanning_filter(
-        filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]}
+    _scanner = HaBleakScannerWrapper(
+        detection_callback=_device_detected,
+        filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]},
     )
-    scanner.register_detection_callback(_device_detected)
 
     inject_advertisement(switchbot_device, switchbot_adv)
     inject_advertisement(switchbot_device, switchbot_adv_2)


### PR DESCRIPTION
## Summary
- **Breaking:** `HaBleakScannerWrapper` no longer inherits from `BaseBleakScanner` — it is a standalone class that duck-types `BleakScanner`
- **Breaking:** Removed `register_detection_callback()` method which was a backend (`BaseBleakScanner`) API, not part of the top-level `BleakScanner` API
- The `detection_callback` constructor parameter and `advertisement_data()` async iterator remain as the supported ways to receive callbacks

Closes #385
Closes #390

## Test plan
- [x] All 45 existing wrapper tests pass
- [x] Tests updated to use `detection_callback` constructor parameter instead of `register_detection_callback()`