### PR TITLE
feat: restore register_detection_callback as a deprecated shim

### DIFF
--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
+import warnings
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from functools import partial
@@ -202,6 +203,35 @@ class HaBleakScannerWrapper:
             info.address: (info.device, info.advertisement)
             for info in get_manager().async_discovered_service_info(True)
         }
+
+    def register_detection_callback(
+        self, callback: AdvertisementDataCallback | None
+    ) -> Callable[[], None]:
+        """
+        Register a detection callback (deprecated).
+
+        bleak removed this method from ``BleakScanner``; it remains here only
+        so integrations that have not yet migrated keep working. Pass
+        ``detection_callback`` to the constructor instead. This shim will be
+        removed in a future habluetooth release.
+        """
+        warnings.warn(
+            "HaBleakScannerWrapper.register_detection_callback() is deprecated "
+            "and will be removed in a future release; bleak already removed "
+            "this method from BleakScanner. Pass detection_callback to the "
+            "HaBleakScannerWrapper constructor instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _LOGGER.warning(
+            "HaBleakScannerWrapper.register_detection_callback() is deprecated "
+            "and will be removed in a future release; bleak already removed "
+            "this method from BleakScanner. Pass detection_callback to the "
+            "HaBleakScannerWrapper constructor instead."
+        )
+        self._advertisement_data_callback = callback
+        self._setup_detection_callback()
+        return self._cancel_callback
 
     async def advertisement_data(
         self,

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -774,6 +774,46 @@ async def test_wrapped_instance_with_filter(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_register_detection_callback_deprecated(
+    register_hci0_scanner: None,
+) -> None:
+    """Test the deprecated register_detection_callback still works and warns."""
+    detected: list[tuple[BLEDevice, AdvertisementData]] = []
+
+    def _device_detected(
+        device: BLEDevice, advertisement_data: AdvertisementData
+    ) -> None:
+        """Handle a detected device."""
+        detected.append((device, advertisement_data))
+
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        manufacturer_data={89: b"\xd8.\xad\xcd\r\x85"},
+        service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
+    )
+
+    assert _get_manager() is not None
+    scanner = HaBleakScannerWrapper(
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    )
+
+    with pytest.warns(DeprecationWarning, match="register_detection_callback"):
+        cancel = scanner.register_detection_callback(_device_detected)
+
+    inject_advertisement(switchbot_device, switchbot_adv)
+    await asyncio.sleep(0)
+    assert len(detected) == 1
+
+    cancel()
+    inject_advertisement(switchbot_device, switchbot_adv)
+    await asyncio.sleep(0)
+    assert len(detected) == 1
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_wrapped_instance_with_service_uuids(
     register_hci0_scanner: None,
 ) -> None:


### PR DESCRIPTION
## Summary
- Restores `HaBleakScannerWrapper.register_detection_callback()` so integrations still calling it (e.g. `aiohomekit` and others) keep working after the 6.0 bump.
- Emits a loud `DeprecationWarning` and logger warning noting bleak already removed this method from `BleakScanner`; the shim is backcompat only and will be removed in a future release.

## Test plan
- [x] `test_register_detection_callback_deprecated` asserts the warning fires, callbacks still deliver, and the returned cancel unregisters.
- [x] All 47 existing wrapper tests pass.