### PR TITLE
perf(build): parallelize cython extension compilation

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -38,7 +38,7 @@ class BuildExt(build_ext):
 
     def build_extensions(self) -> None:
         """Build extensions."""
-        if self.parallel is None:
+        if self.parallel is None:  # type: ignore[has-type, unused-ignore]
             self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()

--- a/build_ext.py
+++ b/build_ext.py
@@ -38,6 +38,8 @@ class BuildExt(build_ext):
 
     def build_extensions(self) -> None:
         """Build extensions."""
+        if self.parallel is None:
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
         except Exception as ex:  # nosec


### PR DESCRIPTION
Default `BuildExt.parallel` to `os.cpu_count()` so per-module `gcc` compilations run in parallel instead of one at a time; the QEMU emulated wheel jobs are the biggest beneficiary.

Mirrors python-zeroconf/python-zeroconf#1689.