### PR TITLE
ci: cache poetry venv keyed on lockfile and cython sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -49,8 +52,6 @@ jobs:
           - "skip_cython"
           - "use_cython"
     runs-on: ${{ matrix.os }}
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install poetry
@@ -68,7 +69,7 @@ jobs:
           path: |
             .venv
             src/habluetooth/**/*.so
-          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -88,8 +89,6 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install poetry
@@ -107,7 +106,7 @@ jobs:
           path: |
             .venv
             src/habluetooth/**/*.so
-          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-benchmark-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-benchmark-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
           - "skip_cython"
           - "use_cython"
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install poetry
@@ -59,7 +61,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
           allow-prereleases: true
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .venv
+            src/habluetooth/**/*.so
+          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           if [ "${{ matrix.extension }}" = "skip_cython" ]; then
             SKIP_CYTHON=1 poetry install --only=main,dev
@@ -77,6 +88,8 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install poetry
@@ -87,7 +100,16 @@ jobs:
           python-version: "3.14"
           cache: "poetry"
           allow-prereleases: true
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .venv
+            src/habluetooth/**/*.so
+          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-benchmark-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev
         shell: bash


### PR DESCRIPTION
Caches the poetry-managed `.venv` plus built Cython `.so` artefacts in the test matrix and benchmark jobs, keyed on runner OS + python version + extension mode + the hashes of `poetry.lock`, `pyproject.toml`, `build_ext.py`, and all `src/habluetooth/**/*.py` / `*.pxd` files.

On a cache hit the `Install Dependencies` step is skipped. Pure-Python and Cython source changes both invalidate the cache, so we never run tests against stale `.so` files.

Ports https://github.com/Bluetooth-Devices/dbus-fast/pull/675 and the follow-up cleanup in https://github.com/Bluetooth-Devices/dbus-fast/pull/679 (which lands the squashed result: workflow-level `POETRY_VIRTUALENVS_IN_PROJECT`, single `hashFiles()` call, no broken `ImageOS`/`ImageVersion` interpolation).