### PR TITLE
ci: scope release concurrency group per ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,9 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: release
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Scopes the `release` job's concurrency group per ref instead of a single global `release` group. PRs / feature branches each get their own group (`release-refs/pull/N/merge`); `main` resolves to `release-refs/heads/main`, so actual releases still serialize.

The previous `concurrency: release` was global across every branch and PR, so the dry-run on a PR could cancel the dry-run on another PR (and historically did, on upstream `dbus-fast`). `cancel-in-progress: false` keeps queued jobs from killing each other; the workflow-level `concurrency` block already cancels stale runs per head_ref.

Ports https://github.com/Bluetooth-Devices/dbus-fast/pull/677.