### PR TITLE
feat: share device name cache across scanners

### DIFF
--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -429,7 +429,7 @@ class BaseHaScanner:
         # available to passive scanners on restart, before any active scanner
         # has had a chance to re-observe them.
         for address, info in self._previous_service_info.items():
-            self._manager._update_name_cache(address, info.name)
+            self._manager.seed_name_cache(address, info.name)
 
     def serialize_discovered_devices(
         self,

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -424,6 +424,12 @@ class BaseHaScanner:
         }
         # Expire anything that is too old
         self._async_expire_devices()
+        # Seed the cross-scanner name cache with each restored entry so that
+        # names learned by an active scanner in a previous run are immediately
+        # available to passive scanners on restart, before any active scanner
+        # has had a chance to re-observe them.
+        for address, info in self._previous_service_info.items():
+            self._manager._update_name_cache(address, info.name)
 
     def serialize_discovered_devices(
         self,

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -84,7 +84,13 @@ cdef class BluetoothManager:
         cached_len=Py_ssize_t,
         name_len=Py_ssize_t,
     )
-    cpdef void _update_name_cache(self, str address, str name)
+    cdef void _update_name_cache(self, str address, str name)
+
+    cdef void _handle_name_cache_miss(
+        self,
+        BluetoothServiceInfoBleak service_info,
+        str cached_name,
+    )
 
     cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
 

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -46,6 +46,7 @@ cdef class BluetoothManager:
     cdef public set _bleak_callbacks
     cdef public dict _all_history
     cdef public dict _connectable_history
+    cdef public dict _name_cache
     cdef public set _non_connectable_scanners
     cdef public set _connectable_scanners
     cdef public dict _adapters
@@ -76,6 +77,15 @@ cdef class BluetoothManager:
         BluetoothServiceInfoBleak new
     )
 
+    @cython.locals(
+        cached=str,
+        cached_cf=str,
+        name_cf=str,
+        cached_len=Py_ssize_t,
+        name_len=Py_ssize_t,
+    )
+    cpdef void _update_name_cache(self, str address, str name)
+
     cpdef void scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
 
     @cython.locals(
@@ -86,7 +96,8 @@ cdef class BluetoothManager:
         scanner=BaseHaScanner,
         connectable_scanner=BaseHaScanner,
         apple_cstr="const unsigned char *",
-        bleak_callback=BleakCallback
+        bleak_callback=BleakCallback,
+        cached_name=str
     )
     cdef void _scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -593,10 +593,26 @@ class BluetoothManager:
            prefix rule via _update_name_cache and patch service_info
            with whatever the cache settled on.
         """
-        if not service_info.name or service_info.name is service_info.address:
+        # When we patch service_info.name and service_info.device.name,
+        # we also clear service_info._advertisement so the lazy rebuild
+        # in BluetoothServiceInfoBleak._advertisement_internal picks up
+        # the canonical name and propagates it to bleak callbacks via
+        # advertisement.local_name. Remote scanners arrive with
+        # _advertisement = None (see base_scanner.py:657), but
+        # HaScanner.on_advertisement (scanner.py:331) pre-sets it to
+        # bleak's AdvertisementData, so without this invalidation a
+        # local passive scanner whose dispatched view we patch would
+        # still hand bleak callbacks an AdvertisementData with the
+        # original (missing) local_name.
+        if (
+            not service_info.name
+            or service_info.name is service_info.address
+            or service_info.name == service_info.address
+        ):
             if cached_name is not None:
                 service_info.name = cached_name
                 service_info.device.name = cached_name
+                service_info._advertisement = None
             return
         if cached_name is None:
             self._name_cache[service_info.address] = service_info.name
@@ -608,6 +624,7 @@ class BluetoothManager:
         if cached_name is not service_info.name and cached_name != service_info.name:
             service_info.name = cached_name
             service_info.device.name = cached_name
+            service_info._advertisement = None
 
     def seed_name_cache(self, address: str, name: str) -> None:
         """

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -570,6 +570,57 @@ class BluetoothManager:
         """
         return self._mgmt_ctl
 
+    def _handle_name_cache_miss(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        cached_name: str | None,
+    ) -> None:
+        """
+        Handle the cold path when cached_name is not service_info.name.
+
+        Called from _scanner_adv_received only when the cached name and
+        the incoming name are different str objects (steady-state
+        identity match is filtered out at the call site). Walks through
+        three cases:
+
+        1. The incoming ad has no real name (empty or the MAC fallback
+           set by base_scanner): patch service_info from the cache if we
+           have one; this is the path that lets passive scanners inherit
+           a name learned by an active scanner.
+        2. No cached name yet: store the incoming name directly if it is
+           real; no patch needed since the cache now matches.
+        3. Cached and incoming are both real but differ: apply the
+           prefix rule via _update_name_cache and patch service_info
+           with whatever the cache settled on.
+        """
+        if not service_info.name or service_info.name is service_info.address:
+            if cached_name is not None:
+                service_info.name = cached_name
+                service_info.device.name = cached_name
+            return
+        if cached_name is None:
+            self._name_cache[service_info.address] = service_info.name
+            return
+        if cached_name == service_info.name:
+            return
+        self._update_name_cache(service_info.address, service_info.name)
+        cached_name = self._name_cache[service_info.address]
+        if cached_name is not service_info.name and cached_name != service_info.name:
+            service_info.name = cached_name
+            service_info.device.name = cached_name
+
+    def seed_name_cache(self, address: str, name: str) -> None:
+        """
+        Apply the prefix rule to the cross-scanner name cache.
+
+        Python-visible entry point intended for cold paths such as
+        BaseHaScanner.restore_discovered_devices (called once per scanner
+        at startup). The hot per-advertisement path does not use this
+        method; it inlines the steady-state checks and calls the internal
+        cdef _update_name_cache directly.
+        """
+        self._update_name_cache(address, name)
+
     def _update_name_cache(self, address: str, name: str) -> None:
         """
         Update the cross-scanner name cache for an address.
@@ -658,21 +709,17 @@ class BluetoothManager:
             }:
                 return
 
-        # Cross-scanner name cache. Update before the fast-path comparison
-        # below so that a rename (cached name differs from the new one) is
-        # not masked by the change-detection guard, and so the patched name
-        # is what reaches _all_history / _connectable_history / bleak
-        # callbacks. The cache update is a near-no-op (single dict.get +
-        # identity check) when the same name is broadcast repeatedly.
-        self._update_name_cache(service_info.address, service_info.name)
+        # Cross-scanner name cache. Only the steady-state identity check
+        # is inlined here because this code runs on every advertisement
+        # after the Apple pre-filter; the rest is handled in a cdef
+        # helper to keep this method readable. The hot path is a single
+        # dict.get plus a pointer compare; the function call to the
+        # helper only fires when the cached name and the incoming name
+        # are different str objects, which excludes the dominant case of
+        # the same scanner re-broadcasting the same name.
         cached_name = self._name_cache.get(service_info.address)
-        if (
-            cached_name is not None
-            and cached_name is not service_info.name
-            and cached_name != service_info.name
-        ):
-            service_info.name = cached_name
-            service_info.device.name = cached_name
+        if cached_name is not service_info.name:
+            self._handle_name_cache_miss(service_info, cached_name)
 
         if service_info.connectable:
             old_connectable_service_info = self._connectable_history.get(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -132,6 +132,7 @@ class BluetoothManager:
         "_intervals",
         "_loop",
         "_mgmt_ctl",
+        "_name_cache",
         "_non_connectable_scanners",
         "_recovery_lock",
         "_scanner_mode_change_callbacks",
@@ -167,6 +168,15 @@ class BluetoothManager:
         self._bleak_callbacks: set[BleakCallback] = set()
         self._all_history: dict[str, BluetoothServiceInfoBleak] = {}
         self._connectable_history: dict[str, BluetoothServiceInfoBleak] = {}
+        # Cross-scanner name cache: address -> best name seen across all
+        # scanners. Passive scanners typically miss the device name because
+        # it lives in SCAN_RSP (active-only); the cache lets a name learned
+        # by an active scanner flow to passive scanners' service_info on
+        # dispatch. Updates use the case-folded prefix-extension rule: a
+        # longer name only replaces a shorter cached one when the cached
+        # one is a case-folded prefix; otherwise the new name is treated
+        # as a rename and replaces unconditionally.
+        self._name_cache: dict[str, str] = {}
         self._non_connectable_scanners: set[BaseHaScanner] = set()
         self._connectable_scanners: set[BaseHaScanner] = set()
         self._adapters: dict[str, AdapterDetails] = {}
@@ -476,6 +486,7 @@ class BluetoothManager:
                     # available for both connectable and non-connectable
                     tracker.async_remove_fallback_interval(address)
                     tracker.async_remove_address(address)
+                    self._name_cache.pop(address, None)
                     for disappear_callback in self._disappeared_callbacks:
                         try:
                             disappear_callback(address)
@@ -559,6 +570,59 @@ class BluetoothManager:
         """
         return self._mgmt_ctl
 
+    def _update_name_cache(self, address: str, name: str) -> None:
+        """
+        Update the cross-scanner name cache for an address.
+
+        Applies the case-folded prefix-extension rule:
+        - identical name -> no-op (fastest path; identity check first)
+        - empty name or name == address -> no-op (never pollute the cache
+          with the address fallback used by base_scanner)
+        - cached is None -> store new
+        - new is a case-folded extension of cached -> store new
+          (e.g. "Onv" -> "Onvis XXX")
+        - cached is a case-folded extension of new -> keep cached
+          (e.g. "Onvis XXX" -> "Onv" is a truncation)
+        - neither is a case-folded prefix of the other -> rename, store new
+          (e.g. "Onv" -> "Donkey")
+
+        Performance note: after the steady-state identity / equality short
+        circuits, length-based dispatch ensures we do at most ONE
+        str.startswith per call (instead of up to two), since a prefix
+        relationship is only possible when the shorter string could be a
+        prefix of the longer. Compares casefolded lengths because casefold
+        can change length for some characters (e.g. German "ß" -> "ss").
+        """
+        cached = self._name_cache.get(address)
+        if cached is name:
+            return
+        if not name or name == address:
+            return
+        if cached is None:
+            self._name_cache[address] = name
+            return
+        if cached == name:
+            return
+        cached_cf = cached.casefold()
+        name_cf = name.casefold()
+        cached_len = len(cached_cf)
+        name_len = len(name_cf)
+        if name_len > cached_len:
+            # New is longer -> only "extension" or "rename" are possible.
+            # Either way the new name wins (extension upgrades, rename replaces).
+            self._name_cache[address] = name
+            return
+        if name_len < cached_len:
+            # New is shorter -> "truncation" (keep cached) or "rename" (replace).
+            if cached_cf.startswith(name_cf):
+                return
+            self._name_cache[address] = name
+            return
+        # Equal casefolded length, raw not equal -> case-only diff or rename.
+        if cached_cf == name_cf:
+            return
+        self._name_cache[address] = name
+
     def scanner_adv_received(self, service_info: BluetoothServiceInfoBleak) -> None:
         """
         Handle a new advertisement from any scanner.
@@ -593,6 +657,22 @@ class BluetoothManager:
                 APPLE_FINDMY_START_BYTE,
             }:
                 return
+
+        # Cross-scanner name cache. Update before the fast-path comparison
+        # below so that a rename (cached name differs from the new one) is
+        # not masked by the change-detection guard, and so the patched name
+        # is what reaches _all_history / _connectable_history / bleak
+        # callbacks. The cache update is a near-no-op (single dict.get +
+        # identity check) when the same name is broadcast repeatedly.
+        self._update_name_cache(service_info.address, service_info.name)
+        cached_name = self._name_cache.get(service_info.address)
+        if (
+            cached_name is not None
+            and cached_name is not service_info.name
+            and cached_name != service_info.name
+        ):
+            service_info.name = cached_name
+            service_info.device.name = cached_name
 
         if service_info.connectable:
             old_connectable_service_info = self._connectable_history.get(
@@ -749,6 +829,7 @@ class BluetoothManager:
         """
         self._all_history.pop(address, None)
         self._connectable_history.pop(address, None)
+        self._name_cache.pop(address, None)
         for scanner in self._sources.values():
             scanner._previous_service_info.pop(address, None)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ async def mock_enable_bluetooth(
     yield
     manager._all_history.clear()
     manager._connectable_history.clear()
+    manager._name_cache.clear()
     manager._unavailable_callbacks.clear()
     manager._connectable_unavailable_callbacks.clear()
     manager._bleak_callbacks.clear()

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -1023,3 +1023,104 @@ async def test_inject_100_bluez_raw_end_to_end_changed(
             protocol.data_received(packet)
 
     cancel()
+
+
+# ---------------------------------------------------------------------------
+# _update_name_cache hot-path benchmarks
+#
+# _update_name_cache runs on every advertisement from every scanner after the
+# Apple pre-filter, so its cost matters. These benchmarks isolate the four
+# distinct paths so a regression in any one shows up clearly:
+#   1. identity   - same Python str object as cached (typical steady state)
+#   2. equality   - cached and incoming compare equal but are different objects
+#                   (e.g. names rebuilt by different deserialization paths)
+#   3. cold       - address not yet in cache (first ad for a device)
+#   4. fallback   - name equals the address (the no-op for nameless ads)
+# A fifth benchmark exercises the actual prefix-rule write paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+def test_update_name_cache_steady_state_identity(benchmark: BenchmarkFixture) -> None:
+    """Hot path: same name object as cached. Should be a dict.get + pointer compare."""
+    manager = get_manager()
+    address = "44:44:33:11:23:60"
+    name = "Onvis XXX"
+    manager._update_name_cache(address, name)
+    assert manager._name_cache[address] is name
+
+    @benchmark
+    def run():
+        for _ in range(1000):
+            manager._update_name_cache(address, name)
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+def test_update_name_cache_steady_state_equality(benchmark: BenchmarkFixture) -> None:
+    """Hot path: cached name equals incoming but different str objects (no identity)."""
+    manager = get_manager()
+    address = "44:44:33:11:23:61"
+    cached = b"Onvis XXX".decode()
+    manager._update_name_cache(address, cached)
+    # Force a different object with the same value via a separate bytes.decode.
+    incoming = b"Onvis XXX".decode()
+    assert incoming is not cached
+    assert incoming == cached
+
+    @benchmark
+    def run():
+        for _ in range(1000):
+            manager._update_name_cache(address, incoming)
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+def test_update_name_cache_address_fallback(benchmark: BenchmarkFixture) -> None:
+    """Hot path: passive scanner with no name (name == address). Must short-circuit."""
+    manager = get_manager()
+    address = "44:44:33:11:23:62"
+
+    @benchmark
+    def run():
+        for _ in range(1000):
+            manager._update_name_cache(address, address)
+
+    assert address not in manager._name_cache
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+def test_update_name_cache_cold_first_name(benchmark: BenchmarkFixture) -> None:
+    """First name observed for an address. Pops the entry every iteration."""
+    manager = get_manager()
+    address = "44:44:33:11:23:63"
+    name = "Onvis XXX"
+
+    @benchmark
+    def run():
+        for _ in range(1000):
+            manager._name_cache.pop(address, None)
+            manager._update_name_cache(address, name)
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+def test_update_name_cache_prefix_rule_paths(benchmark: BenchmarkFixture) -> None:
+    """
+    Mixed write paths: extension, truncation, and rename.
+
+    Each iteration exercises the casefold and length-dispatch logic.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:64"
+    short = "Onv"
+    long = "Onvis XXX"
+    other = "Donkey XX"  # same length as long, not a prefix-extension
+    manager._update_name_cache(address, long)  # seed
+
+    @benchmark
+    def run():
+        for _ in range(1000):
+            # rename: same length, different -> replace
+            manager._update_name_cache(address, other)
+            # extension: name is longer than cached -> replace
+            manager._update_name_cache(address, long)
+            # truncation: name shorter than cached, prefix match -> keep
+            manager._update_name_cache(address, short)

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -1046,13 +1046,13 @@ def test_update_name_cache_steady_state_identity(benchmark: BenchmarkFixture) ->
     manager = get_manager()
     address = "44:44:33:11:23:60"
     name = "Onvis XXX"
-    manager._update_name_cache(address, name)
+    manager.seed_name_cache(address, name)
     assert manager._name_cache[address] is name
 
     @benchmark
     def run():
         for _ in range(1000):
-            manager._update_name_cache(address, name)
+            manager.seed_name_cache(address, name)
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -1061,7 +1061,7 @@ def test_update_name_cache_steady_state_equality(benchmark: BenchmarkFixture) ->
     manager = get_manager()
     address = "44:44:33:11:23:61"
     cached = b"Onvis XXX".decode()
-    manager._update_name_cache(address, cached)
+    manager.seed_name_cache(address, cached)
     # Force a different object with the same value via a separate bytes.decode.
     incoming = b"Onvis XXX".decode()
     assert incoming is not cached
@@ -1070,7 +1070,7 @@ def test_update_name_cache_steady_state_equality(benchmark: BenchmarkFixture) ->
     @benchmark
     def run():
         for _ in range(1000):
-            manager._update_name_cache(address, incoming)
+            manager.seed_name_cache(address, incoming)
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -1082,7 +1082,7 @@ def test_update_name_cache_address_fallback(benchmark: BenchmarkFixture) -> None
     @benchmark
     def run():
         for _ in range(1000):
-            manager._update_name_cache(address, address)
+            manager.seed_name_cache(address, address)
 
     assert address not in manager._name_cache
 
@@ -1098,7 +1098,7 @@ def test_update_name_cache_cold_first_name(benchmark: BenchmarkFixture) -> None:
     def run():
         for _ in range(1000):
             manager._name_cache.pop(address, None)
-            manager._update_name_cache(address, name)
+            manager.seed_name_cache(address, name)
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -1113,14 +1113,14 @@ def test_update_name_cache_prefix_rule_paths(benchmark: BenchmarkFixture) -> Non
     short = "Onv"
     long = "Onvis XXX"
     other = "Donkey XX"  # same length as long, not a prefix-extension
-    manager._update_name_cache(address, long)  # seed
+    manager.seed_name_cache(address, long)  # seed
 
     @benchmark
     def run():
         for _ in range(1000):
             # rename: same length, different -> replace
-            manager._update_name_cache(address, other)
+            manager.seed_name_cache(address, other)
             # extension: name is longer than cached -> replace
-            manager._update_name_cache(address, long)
+            manager.seed_name_cache(address, long)
             # truncation: name shorter than cached, prefix match -> keep
-            manager._update_name_cache(address, short)
+            manager.seed_name_cache(address, short)

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -1,0 +1,361 @@
+"""Tests for the cross-scanner name cache on BluetoothManager."""
+
+import time
+
+import pytest
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+from bluetooth_data_tools import monotonic_time_coarse
+
+from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector, get_manager
+
+from . import (
+    MockBleakClient,
+    generate_advertisement_data,
+    generate_ble_device,
+    inject_advertisement_with_source,
+)
+
+
+class _SeedFakeScanner(BaseHaRemoteScanner):
+    """Minimal remote scanner that exposes inject_advertisement for tests."""
+
+    def inject_advertisement(
+        self,
+        device: BLEDevice,
+        advertisement_data: AdvertisementData,
+        now: float | None = None,
+    ) -> None:
+        """Inject an advertisement through the scanner's normal entry point."""
+        self._async_on_advertisement(
+            device.address,
+            advertisement_data.rssi,
+            device.name,
+            advertisement_data.service_uuids,
+            advertisement_data.service_data,
+            advertisement_data.manufacturer_data,
+            advertisement_data.tx_power,
+            {"scanner_specific_data": "test"},
+            now or monotonic_time_coarse(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the prefix-extension policy
+# ---------------------------------------------------------------------------
+
+
+def test_name_cache_empty_to_name() -> None:
+    """First non-empty name observed is stored."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:01"
+    manager._update_name_cache(address, "Onv")
+    assert manager._name_cache[address] == "Onv"
+
+
+def test_name_cache_extension_replaces_truncation() -> None:
+    """A new name that extends the cached short name replaces it."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:02"
+    manager._update_name_cache(address, "Onv")
+    manager._update_name_cache(address, "Onvis XXX")
+    assert manager._name_cache[address] == "Onvis XXX"
+
+
+def test_name_cache_truncation_keeps_cached() -> None:
+    """A new name that is a truncation of the cached complete name is rejected."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:03"
+    manager._update_name_cache(address, "Onvis XXX")
+    manager._update_name_cache(address, "Onv")
+    assert manager._name_cache[address] == "Onvis XXX"
+
+
+def test_name_cache_rename_replaces() -> None:
+    """A completely different name (not prefix-related) replaces the cached name."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:04"
+    manager._update_name_cache(address, "Onv")
+    manager._update_name_cache(address, "Donkey")
+    assert manager._name_cache[address] == "Donkey"
+
+
+def test_name_cache_same_name_noop() -> None:
+    """Re-broadcasting the same name does not allocate a new cache entry."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:05"
+    manager._update_name_cache(address, "Onv")
+    cached_first = manager._name_cache[address]
+    manager._update_name_cache(address, "Onv")
+    # Same string compares equal; identity may or may not match depending on
+    # interning but the value must be unchanged.
+    assert manager._name_cache[address] == cached_first
+
+
+def test_name_cache_empty_name_noop() -> None:
+    """An empty name never overwrites the cached value."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:06"
+    manager._update_name_cache(address, "Onv")
+    manager._update_name_cache(address, "")
+    assert manager._name_cache[address] == "Onv"
+
+
+def test_name_cache_address_fallback_not_stored() -> None:
+    """
+    Address fallback (name == address) must not pollute the cache.
+
+    base_scanner sets info.name = address when no local_name is present.
+    """
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:07"
+    manager._update_name_cache(address, address)
+    assert address not in manager._name_cache
+
+
+def test_name_cache_address_fallback_does_not_overwrite() -> None:
+    """The address-fallback no-op must not replace an existing cached name."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:08"
+    manager._update_name_cache(address, "Onv")
+    manager._update_name_cache(address, address)
+    assert manager._name_cache[address] == "Onv"
+
+
+def test_name_cache_case_folded_extension() -> None:
+    """The extension rule is case-folded: 'onv' is a prefix of 'ONVIS XXX'."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:09"
+    manager._update_name_cache(address, "onv")
+    manager._update_name_cache(address, "ONVIS XXX")
+    assert manager._name_cache[address] == "ONVIS XXX"
+
+
+def test_name_cache_case_folded_truncation_keeps_cached() -> None:
+    """Case-folded truncation: 'ONV' is a truncation of 'Onvis XXX'."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:0A"
+    manager._update_name_cache(address, "Onvis XXX")
+    manager._update_name_cache(address, "ONV")
+    assert manager._name_cache[address] == "Onvis XXX"
+
+
+# ---------------------------------------------------------------------------
+# Cross-scanner integration: passive scanner gains name from active scanner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_passive_scanner_gains_name_from_active_scanner() -> None:
+    """
+    Passive scanner inherits the name learned by an active scanner.
+
+    Uses real BaseHaRemoteScanner injection so the lazy AdvertisementData
+    construction path in models._advertisement_internal is exercised.
+    """
+    manager = get_manager()
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+
+    active_scanner = _SeedFakeScanner("esp32-active", "esp32-active", connector, True)
+    active_unsetup = active_scanner.async_setup()
+    active_cancel = manager.async_register_scanner(active_scanner)
+
+    passive_scanner = _SeedFakeScanner(
+        "esp32-passive", "esp32-passive", connector, True
+    )
+    passive_unsetup = passive_scanner.async_setup()
+    passive_cancel = manager.async_register_scanner(passive_scanner)
+
+    address = "44:44:33:11:23:50"
+
+    # Active scanner reports the device with its full SCAN_RSP-derived name.
+    active_device = generate_ble_device(address, "Onvis XXX", {}, rssi=-60)
+    active_adv = generate_advertisement_data(local_name="Onvis XXX", rssi=-60)
+    active_scanner.inject_advertisement(active_device, active_adv)
+
+    assert manager._name_cache[address] == "Onvis XXX"
+    assert manager._all_history[address].name == "Onvis XXX"
+
+    # Passive scanner reports the same address without a name, with stronger
+    # RSSI so it wins the source-preference comparison.
+    passive_device = generate_ble_device(address, None, {}, rssi=-30)
+    passive_adv = generate_advertisement_data(
+        local_name=None,
+        # Distinct manufacturer data to force past the fast-path early-return
+        # so we actually exercise the patch path.
+        manufacturer_data={99: b"\x99"},
+        rssi=-30,
+    )
+    passive_scanner.inject_advertisement(passive_device, passive_adv)
+
+    # The patched view in _all_history must carry the active scanner's name.
+    patched = manager._all_history[address]
+    assert patched.name == "Onvis XXX"
+    assert patched.device.name == "Onvis XXX"
+    # And the AdvertisementData built on-demand for bleak callbacks must
+    # carry it too.
+    assert patched.advertisement.local_name == "Onvis XXX"
+
+    active_cancel()
+    active_unsetup()
+    passive_cancel()
+    passive_unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_active_scanner_extension_propagates_across_sources() -> None:
+    """
+    An active scanner's longer name upgrades the cache populated by a passive one.
+
+    Order: passive sees the short name first, then active sees the full
+    SCAN_RSP-derived name. The cache must upgrade and the dispatched view
+    must carry the longer name.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:51"
+
+    # Passive scanner sees the shortened name first.
+    passive_device = generate_ble_device(address, "Onv", {}, rssi=-80)
+    passive_adv = generate_advertisement_data(local_name="Onv", rssi=-80)
+    inject_advertisement_with_source(passive_device, passive_adv, "passive-source")
+    assert manager._name_cache[address] == "Onv"
+
+    # Active scanner sees the full SCAN_RSP-derived name.
+    active_device = generate_ble_device(address, "Onvis XXX", {}, rssi=-70)
+    active_adv = generate_advertisement_data(
+        local_name="Onvis XXX",
+        manufacturer_data={1: b"\x01"},
+        rssi=-70,
+    )
+    inject_advertisement_with_source(active_device, active_adv, "active-source")
+
+    assert manager._name_cache[address] == "Onvis XXX"
+    assert manager._all_history[address].name == "Onvis XXX"
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rename_replaces_across_sources() -> None:
+    """A genuine rename (not a prefix relationship) replaces the cached name."""
+    manager = get_manager()
+    address = "44:44:33:11:23:52"
+
+    device_a = generate_ble_device(address, "Onv", {}, rssi=-60)
+    adv_a = generate_advertisement_data(local_name="Onv", rssi=-60)
+    inject_advertisement_with_source(device_a, adv_a, "source-a")
+    assert manager._name_cache[address] == "Onv"
+
+    device_b = generate_ble_device(address, "Donkey", {}, rssi=-60)
+    adv_b = generate_advertisement_data(
+        local_name="Donkey",
+        manufacturer_data={1: b"\x01"},
+        rssi=-60,
+    )
+    inject_advertisement_with_source(device_b, adv_b, "source-b")
+    assert manager._name_cache[address] == "Donkey"
+    assert manager._all_history[address].name == "Donkey"
+
+
+# ---------------------------------------------------------------------------
+# Eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_async_clear_advertisement_history_evicts_cache() -> None:
+    """async_clear_advertisement_history removes the name cache entry."""
+    manager = get_manager()
+    address = "44:44:33:11:23:53"
+
+    device = generate_ble_device(address, "Onvis XXX", {}, rssi=-60)
+    adv = generate_advertisement_data(local_name="Onvis XXX", rssi=-60)
+    inject_advertisement_with_source(device, adv, "source")
+    assert address in manager._name_cache
+
+    manager.async_clear_advertisement_history(address)
+    assert address not in manager._name_cache
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_disappearance_evicts_cache() -> None:
+    """A device that disappears via _async_check_unavailable evicts its cache entry."""
+    from datetime import timedelta
+    from unittest.mock import patch
+
+    from freezegun import freeze_time
+
+    from . import utcnow
+
+    manager = get_manager()
+    address = "44:44:33:11:23:54"
+
+    device = generate_ble_device(address, "Onvis XXX", {}, rssi=-60)
+    adv = generate_advertisement_data(local_name="Onvis XXX", rssi=-60)
+    inject_advertisement_with_source(device, adv, "source")
+    assert address in manager._name_cache
+
+    future_time = utcnow() + timedelta(seconds=3600)
+    future_monotonic_time = time.monotonic() + 3600
+    with (
+        freeze_time(future_time),
+        patch(
+            "habluetooth.manager.monotonic_time_coarse",
+            return_value=future_monotonic_time,
+        ),
+    ):
+        manager._async_check_unavailable()
+
+    assert address not in manager._name_cache
+
+
+# ---------------------------------------------------------------------------
+# Seed on load from per-scanner persisted state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_restore_discovered_devices_seeds_cache() -> None:
+    """
+    Restoring a scanner's persisted history seeds the shared name cache.
+
+    Subsequent passive-scanner ads on the same address inherit the
+    previously-known name without waiting for an active scanner to
+    re-observe it.
+    """
+    manager = get_manager()
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+
+    src_scanner = _SeedFakeScanner("esp32-src", "esp32-src", connector, True)
+    src_unsetup = src_scanner.async_setup()
+    src_cancel = manager.async_register_scanner(src_scanner)
+
+    address = "44:44:33:11:23:55"
+    device = generate_ble_device(address, "Onvis XXX", {}, rssi=-60)
+    adv = generate_advertisement_data(local_name="Onvis XXX", rssi=-60)
+    src_scanner.inject_advertisement(device, adv)
+    history = src_scanner.serialize_discovered_devices()
+
+    # Fresh cache state; restore should re-populate it.
+    manager._name_cache.pop(address, None)
+    assert address not in manager._name_cache
+
+    dst_scanner = _SeedFakeScanner("esp32-dst", "esp32-dst", connector, True)
+    dst_unsetup = dst_scanner.async_setup()
+    dst_cancel = manager.async_register_scanner(dst_scanner)
+    dst_scanner.restore_discovered_devices(history)
+
+    assert manager._name_cache[address] == "Onvis XXX"
+
+    src_cancel()
+    src_unsetup()
+    dst_cancel()
+    dst_unsetup()

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -49,7 +49,7 @@ def test_name_cache_empty_to_name() -> None:
     """First non-empty name observed is stored."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:01"
-    manager._update_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "Onv")
     assert manager._name_cache[address] == "Onv"
 
 
@@ -57,8 +57,8 @@ def test_name_cache_extension_replaces_truncation() -> None:
     """A new name that extends the cached short name replaces it."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:02"
-    manager._update_name_cache(address, "Onv")
-    manager._update_name_cache(address, "Onvis XXX")
+    manager.seed_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "Onvis XXX")
     assert manager._name_cache[address] == "Onvis XXX"
 
 
@@ -66,8 +66,8 @@ def test_name_cache_truncation_keeps_cached() -> None:
     """A new name that is a truncation of the cached complete name is rejected."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:03"
-    manager._update_name_cache(address, "Onvis XXX")
-    manager._update_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "Onvis XXX")
+    manager.seed_name_cache(address, "Onv")
     assert manager._name_cache[address] == "Onvis XXX"
 
 
@@ -75,8 +75,8 @@ def test_name_cache_rename_replaces() -> None:
     """A completely different name (not prefix-related) replaces the cached name."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:04"
-    manager._update_name_cache(address, "Onv")
-    manager._update_name_cache(address, "Donkey")
+    manager.seed_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "Donkey")
     assert manager._name_cache[address] == "Donkey"
 
 
@@ -84,9 +84,9 @@ def test_name_cache_same_name_noop() -> None:
     """Re-broadcasting the same name does not allocate a new cache entry."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:05"
-    manager._update_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "Onv")
     cached_first = manager._name_cache[address]
-    manager._update_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "Onv")
     # Same string compares equal; identity may or may not match depending on
     # interning but the value must be unchanged.
     assert manager._name_cache[address] == cached_first
@@ -96,8 +96,8 @@ def test_name_cache_empty_name_noop() -> None:
     """An empty name never overwrites the cached value."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:06"
-    manager._update_name_cache(address, "Onv")
-    manager._update_name_cache(address, "")
+    manager.seed_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "")
     assert manager._name_cache[address] == "Onv"
 
 
@@ -109,7 +109,7 @@ def test_name_cache_address_fallback_not_stored() -> None:
     """
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:07"
-    manager._update_name_cache(address, address)
+    manager.seed_name_cache(address, address)
     assert address not in manager._name_cache
 
 
@@ -117,8 +117,8 @@ def test_name_cache_address_fallback_does_not_overwrite() -> None:
     """The address-fallback no-op must not replace an existing cached name."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:08"
-    manager._update_name_cache(address, "Onv")
-    manager._update_name_cache(address, address)
+    manager.seed_name_cache(address, "Onv")
+    manager.seed_name_cache(address, address)
     assert manager._name_cache[address] == "Onv"
 
 
@@ -126,8 +126,8 @@ def test_name_cache_case_folded_extension() -> None:
     """The extension rule is case-folded: 'onv' is a prefix of 'ONVIS XXX'."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:09"
-    manager._update_name_cache(address, "onv")
-    manager._update_name_cache(address, "ONVIS XXX")
+    manager.seed_name_cache(address, "onv")
+    manager.seed_name_cache(address, "ONVIS XXX")
     assert manager._name_cache[address] == "ONVIS XXX"
 
 
@@ -135,8 +135,8 @@ def test_name_cache_case_folded_truncation_keeps_cached() -> None:
     """Case-folded truncation: 'ONV' is a truncation of 'Onvis XXX'."""
     manager = get_manager()
     address = "AA:BB:CC:DD:EE:0A"
-    manager._update_name_cache(address, "Onvis XXX")
-    manager._update_name_cache(address, "ONV")
+    manager.seed_name_cache(address, "Onvis XXX")
+    manager.seed_name_cache(address, "ONV")
     assert manager._name_cache[address] == "Onvis XXX"
 
 

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -140,6 +140,28 @@ def test_name_cache_case_folded_truncation_keeps_cached() -> None:
     assert manager._name_cache[address] == "Onvis XXX"
 
 
+def test_name_cache_equal_value_different_objects_noop() -> None:
+    """Two str objects with identical value hit the cached == name no-op path."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:0B"
+    first = b"Onvis XXX".decode()
+    second = b"Onvis XXX".decode()
+    assert first is not second
+    manager.seed_name_cache(address, first)
+    manager.seed_name_cache(address, second)
+    # Value unchanged; the original object is still cached (no rewrite).
+    assert manager._name_cache[address] is first
+
+
+def test_name_cache_equal_length_case_only_diff_keeps_cached() -> None:
+    """Equal-length casefolded names differing only in case keep the cached value."""
+    manager = get_manager()
+    address = "AA:BB:CC:DD:EE:0C"
+    manager.seed_name_cache(address, "Onv")
+    manager.seed_name_cache(address, "ONV")
+    assert manager._name_cache[address] == "Onv"
+
+
 # ---------------------------------------------------------------------------
 # Cross-scanner integration: passive scanner gains name from active scanner
 # ---------------------------------------------------------------------------
@@ -235,6 +257,98 @@ async def test_active_scanner_extension_propagates_across_sources() -> None:
 
     assert manager._name_cache[address] == "Onvis XXX"
     assert manager._all_history[address].name == "Onvis XXX"
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_second_scanner_same_name_different_object_noop() -> None:
+    """
+    Second scanner reporting the same name (different str object) is a no-op.
+
+    Exercises the cached_name == service_info.name early-return inside
+    _handle_name_cache_miss: identity mismatch but value match.
+    """
+    manager = get_manager()
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+
+    scanner_a = _SeedFakeScanner("esp32-a", "esp32-a", connector, True)
+    scanner_b = _SeedFakeScanner("esp32-b", "esp32-b", connector, True)
+    cancels = [
+        scanner_a.async_setup(),
+        manager.async_register_scanner(scanner_a),
+        scanner_b.async_setup(),
+        manager.async_register_scanner(scanner_b),
+    ]
+
+    address = "44:44:33:11:23:56"
+    # Use bytes.decode() so each scanner gets a distinct str object.
+    device_a = generate_ble_device(address, b"Onvis XXX".decode(), {}, rssi=-60)
+    adv_a = generate_advertisement_data(local_name=b"Onvis XXX".decode(), rssi=-60)
+    scanner_a.inject_advertisement(device_a, adv_a)
+    cached_first = manager._name_cache[address]
+
+    device_b = generate_ble_device(address, b"Onvis XXX".decode(), {}, rssi=-50)
+    adv_b = generate_advertisement_data(
+        local_name=b"Onvis XXX".decode(),
+        manufacturer_data={1: b"\x01"},
+        rssi=-50,
+    )
+    scanner_b.inject_advertisement(device_b, adv_b)
+
+    # Cache value unchanged; original object is preserved (no rewrite).
+    assert manager._name_cache[address] is cached_first
+
+    for c in cancels:
+        c()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_truncation_from_second_scanner_patched_back() -> None:
+    """
+    Scanner reporting a truncated name has its service_info patched back.
+
+    Exercises the post-update patch branch in _handle_name_cache_miss:
+    _update_name_cache decides to keep the longer cached value, then the
+    incoming service_info is patched back to that cached value so the
+    dispatch carries the canonical name.
+    """
+    manager = get_manager()
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+
+    active = _SeedFakeScanner("esp32-full", "esp32-full", connector, True)
+    secondary = _SeedFakeScanner("esp32-trunc", "esp32-trunc", connector, True)
+    cancels = [
+        active.async_setup(),
+        manager.async_register_scanner(active),
+        secondary.async_setup(),
+        manager.async_register_scanner(secondary),
+    ]
+
+    address = "44:44:33:11:23:57"
+    active_device = generate_ble_device(address, "Onvis XXX", {}, rssi=-60)
+    active_adv = generate_advertisement_data(local_name="Onvis XXX", rssi=-60)
+    active.inject_advertisement(active_device, active_adv)
+    assert manager._name_cache[address] == "Onvis XXX"
+
+    # Secondary scanner sees only the truncated name (e.g. no SCAN_RSP yet).
+    trunc_device = generate_ble_device(address, "Onv", {}, rssi=-50)
+    trunc_adv = generate_advertisement_data(
+        local_name="Onv", manufacturer_data={1: b"\x01"}, rssi=-50
+    )
+    secondary.inject_advertisement(trunc_device, trunc_adv)
+
+    # Cache keeps the longer name and the dispatched view is patched back.
+    assert manager._name_cache[address] == "Onvis XXX"
+    assert manager._all_history[address].name == "Onvis XXX"
+    assert manager._all_history[address].device.name == "Onvis XXX"
+
+    for c in cancels:
+        c()
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -306,6 +306,47 @@ async def test_second_scanner_same_name_different_object_noop() -> None:
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_local_passive_scanner_advertisement_rebuilt_with_cached_name() -> None:
+    """
+    Local passive scanner's AdvertisementData is rebuilt with the cached name.
+
+    HaScanner.on_advertisement (scanner.py) pre-sets service_info._advertisement
+    to bleak's AdvertisementData, so without invalidation the patched
+    service_info.name would not propagate to advertisement.local_name for
+    bleak callbacks. Mimics that producer shape via inject_advertisement_with_source
+    (which also pre-sets _advertisement) and verifies the dispatch path
+    rebuilds the AdvertisementData with the patched name.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:58"
+
+    # Seed the cache from an active scanner.
+    active_device = generate_ble_device(address, "Onvis XXX", {}, rssi=-60)
+    active_adv = generate_advertisement_data(local_name="Onvis XXX", rssi=-60)
+    inject_advertisement_with_source(active_device, active_adv, "active-source")
+    assert manager._name_cache[address] == "Onvis XXX"
+
+    # Local passive scanner sees the same device without a name; its
+    # AdvertisementData has local_name = None and is pre-built on
+    # service_info._advertisement (matches HaScanner.on_advertisement).
+    passive_device = generate_ble_device(address, None, {}, rssi=-30)
+    passive_adv = generate_advertisement_data(
+        local_name=None,
+        manufacturer_data={123: b"\xde\xad"},
+        rssi=-30,
+    )
+    inject_advertisement_with_source(passive_device, passive_adv, "passive-source")
+
+    patched = manager._all_history[address]
+    assert patched.name == "Onvis XXX"
+    assert patched.device.name == "Onvis XXX"
+    # _advertisement was invalidated on patch, so the lazy rebuild picks
+    # up the canonical name; bleak callbacks now see it.
+    assert patched.advertisement.local_name == "Onvis XXX"
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_truncation_from_second_scanner_patched_back() -> None:
     """
     Scanner reporting a truncated name has its service_info patched back.


### PR DESCRIPTION
Passive scanners almost never see device names since the local name lives in SCAN_RSP, so whenever a passive scanner wins the per-ad dispatch the manager forwarded a nameless advertisement even though an active scanner had already learned the name.

The manager now keeps a small address to name dict that every scanner contributes to, and patches `service_info.name` / `device.name` from it before dispatch so bleak callbacks always see the canonical name. New names replace cached ones using a case folded prefix rule: `Onv` upgrades to `Onvis XXX` (SCAN_RSP extension), `Onvis XXX` then `Onv` is kept as the longer complete name, and a clearly different name like `Donkey` replaces the cached value as a rename.

The cache is seeded from each scanner's persisted history on restore so passive only setups inherit known names across restarts, and it is evicted alongside `_all_history` on `async_clear_advertisement_history` and the unavailable tracker.

Hot path is cpdef with length dispatched casefold so we do at most one `startswith` per call; identity short circuit on the cached name keeps the steady state at around 14 ns per call on my machine (new dedicated codspeed benchmarks added).