### PR TITLE
ci: install astral managed Python so prerelease setup is cached

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -39,4 +39,10 @@ runs:
       shell: bash
       env:
         PYTHON_VERSION: ${{ inputs.python-version }}
-      run: uv python install "${PYTHON_VERSION}"
+      # 'uv python install' on Windows blows up with a reparse-point tag
+      # mismatch (os error 4394) when cache-python: true already restored
+      # the install dir, so only install when find says we have nothing yet.
+      run: |
+        if ! uv python find "${PYTHON_VERSION}" >/dev/null 2>&1; then
+          uv python install "${PYTHON_VERSION}"
+        fi

--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,0 +1,42 @@
+name: Set up uv and managed Python
+description: >-
+  Pins uv (avoids the raw.githubusercontent.com manifest fetch on cache miss)
+  and proactively installs the requested Python so cached venvs resolve their
+  interpreter symlinks in jobs that only restore the venv. setup-uv alone
+  only sets UV_PYTHON, it does not actually fetch the interpreter until uv
+  first uses it, so jobs that just activate a cached venv blow up with
+  broken symlinks on cache hit.
+
+inputs:
+  python-version:
+    description: The Python version uv should install and use.
+    required: true
+  uv-version:
+    description: The uv version setup-uv should install.
+    required: true
+
+outputs:
+  python-version:
+    description: The Python version uv reports as installed.
+    value: ${{ steps.uv.outputs.python-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      id: uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        version: ${{ inputs.uv-version }}
+        python-version: ${{ inputs.python-version }}
+        # Persist astral's managed Python across jobs so 'uv venv' / poetry
+        # env use below is fast on the second job onwards.
+        cache-python: true
+        # Jobs that only configure the toolchain (no deps to cache) would
+        # otherwise abort with "Nothing to cache" on the post step.
+        ignore-nothing-to-cache: true
+    - name: Install Python interpreter
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+      run: uv python install "${PYTHON_VERSION}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   POETRY_VIRTUALENVS_IN_PROJECT: "true"
   UV_PYTHON_PREFERENCE: only-managed
+  UV_VERSION: "0.11.16"
 
 jobs:
   lint:
@@ -55,19 +56,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Set up uv and Python ${{ matrix.python-version }}
+        id: python
+        uses: ./.github/actions/setup-uv-python
         with:
-          enable-cache: true
+          uv-version: ${{ env.UV_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: uv tool install poetry
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-          allow-prereleases: true
+        shell: bash
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -75,10 +72,13 @@ jobs:
           path: |
             .venv
             src/habluetooth/**/*.so
-          key: venv-v2-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
+          key: venv-v3-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
+          poetry env use "$(uv python find "${PYTHON_VERSION}")"
           if [ "${{ matrix.extension }}" = "skip_cython" ]; then
             SKIP_CYTHON=1 poetry install --only=main,dev
           else
@@ -97,19 +97,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Set up uv and Python 3.14
+        id: python
+        uses: ./.github/actions/setup-uv-python
         with:
-          enable-cache: true
+          uv-version: ${{ env.UV_VERSION }}
+          python-version: "3.14"
       - name: Install poetry
         run: uv tool install poetry
-      - name: Setup Python 3.14
-        id: setup-python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
-        with:
-          python-version: "3.14"
-          cache: "poetry"
-          allow-prereleases: true
+        shell: bash
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -117,10 +113,11 @@ jobs:
           path: |
             .venv
             src/habluetooth/**/*.so
-          key: venv-v2-${{ runner.os }}-benchmark-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
+          key: venv-v3-${{ runner.os }}-benchmark-py${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
+          poetry env use "$(uv python find 3.14)"
           REQUIRE_CYTHON=1 poetry install --only=main,dev
         shell: bash
       - name: Run benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,18 +94,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   benchmark:
+    # Keep actions/setup-python here so codspeed history stays comparable;
+    # astral's managed Python ships PGO/LTO/BOLT/mimalloc which would shift
+    # the baseline.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - name: Set up uv and Python 3.14
-        id: python
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          uv-version: ${{ env.UV_VERSION }}
-          python-version: "3.14"
+          enable-cache: true
       - name: Install poetry
         run: uv tool install poetry
-        shell: bash
+      - name: Setup Python 3.14
+        id: setup-python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.14"
+          cache: "poetry"
+          allow-prereleases: true
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -113,11 +120,10 @@ jobs:
           path: |
             .venv
             src/habluetooth/**/*.so
-          key: venv-v3-${{ runner.os }}-benchmark-py${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
+          key: venv-v2-${{ runner.os }}-benchmark-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
-          poetry env use "$(uv python find 3.14)"
           REQUIRE_CYTHON=1 poetry install --only=main,dev
         shell: bash
       - name: Run benchmarks


### PR DESCRIPTION
The big chunk of time in the test matrix is actions/setup-python downloading and installing Python from manifest. On Windows + 3.14t (free threaded) that step alone takes around 50 seconds because the prerelease is not pre-baked into the hosted-tools cache.

Move the test and benchmark jobs to astral managed Python through a small composite action mirroring the home-assistant/core#171760 approach: pin uv (no manifest fetch on cache miss), request the interpreter via setup-uv with cache-python: true, then eagerly uv python install so cached venvs that point at the managed python resolve their symlinks on restore. Poetry is pointed at the managed interpreter with poetry env use $(uv python find $version) on cache miss.

Venv cache key bumped from v2 to v3 to discard older entries that pointed at the actions/setup-python interpreter.

Lint and build_wheels left alone; lint is already fast and cibuildwheel manages its own pythons.