### PR TITLE
test: add pytest-timeout with 5s default timeout

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -772,7 +772,7 @@ version = "3.15"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["docs"]
 files = [
     {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
     {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
@@ -1242,6 +1242,21 @@ pytest = ">=7"
 
 [package.extras]
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
 
 [[package]]
 name = "python-dateutil"
@@ -2210,4 +2225,4 @@ all = ["winrt-Windows.Foundation.Collections[all] (>=3.2.1.0,<3.3.0.0)", "winrt-
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "848ad4d5e1b3cb71a118e244870dd89ec4445ebb1fbaf727634b4f51d27fa549"
+content-hash = "18f740b211e115c7c37bdcb910c755282a5e38bb34ae3677c59dd01b5ad2b838"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pytest = ">=9.0.3,<10"
 pytest-cov = ">=3,<8"
 pytest-asyncio = ">=0.23.6,<1.4.0"
 pytest-codspeed = ">=5.0.2,<6.0.0"
+pytest-timeout = ">=2.3.1"
 freezegun = "^1.5.5"
 dbus-fast = ">=4.3.0"
 
@@ -90,6 +91,7 @@ addopts = "-v -Wdefault --cov=habluetooth --cov-report=term-missing:skip-covered
 pythonpath = ["src"]
 log_cli="true"
 log_level="NOTSET"
+timeout = 5
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Adds pytest-timeout as a dev dependency and sets a 5 second default timeout on the test suite; this catches hung tests early instead of waiting for CI to time out.