### PR TITLE
test(benchmark): bump pytest-timeout to 60s for benchmark suite

### DIFF
--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -21,6 +21,8 @@ from . import (
     generate_ble_device,
 )
 
+pytestmark = pytest.mark.timeout(60)
+
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The 5s default `pytest-timeout` added in #450 trips the benchmark suite, since codspeed runs each function many times.
- Override per-module via `pytestmark = pytest.mark.timeout(60)` in `tests/test_benchmark_base_scanner.py`.

Refs failing run on #448: https://github.com/Bluetooth-Devices/habluetooth/actions/runs/26304981402/job/77439334542

## Test plan
- [ ] CI green on `tests/test_benchmark_base_scanner.py`
- [ ] Other tests still subject to 5s default timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)