### PR TITLE
ci: retry setup-uv on manifest fetch failures

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,11 +1,13 @@
 name: Set up uv and managed Python
 description: >-
-  Pins uv (avoids the raw.githubusercontent.com manifest fetch on cache miss)
-  and proactively installs the requested Python so cached venvs resolve their
-  interpreter symlinks in jobs that only restore the venv. setup-uv alone
-  only sets UV_PYTHON, it does not actually fetch the interpreter until uv
-  first uses it, so jobs that just activate a cached venv blow up with
-  broken symlinks on cache hit.
+  Pins uv and proactively installs the requested Python so cached venvs
+  resolve their interpreter symlinks in jobs that only restore the venv.
+  setup-uv alone only sets UV_PYTHON, it does not actually fetch the
+  interpreter until uv first uses it, so jobs that just activate a cached
+  venv blow up with broken symlinks on cache hit. setup-uv v8.1.0 also
+  fetches its version manifest from raw.githubusercontent.com on every run
+  even when version is pinned, so the setup step is retried a couple of
+  times to ride out raw.githubusercontent.com flakes.
 
 inputs:
   python-version:
@@ -18,13 +20,14 @@ inputs:
 outputs:
   python-version:
     description: The Python version uv reports as installed.
-    value: ${{ steps.uv.outputs.python-version }}
+    value: ${{ steps.uv3.outputs.python-version || steps.uv2.outputs.python-version || steps.uv1.outputs.python-version }}
 
 runs:
   using: composite
   steps:
-    - name: Set up uv
-      id: uv
+    - name: Set up uv (attempt 1)
+      id: uv1
+      continue-on-error: true
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: ${{ inputs.uv-version }}
@@ -34,6 +37,25 @@ runs:
         cache-python: true
         # Jobs that only configure the toolchain (no deps to cache) would
         # otherwise abort with "Nothing to cache" on the post step.
+        ignore-nothing-to-cache: true
+    - name: Set up uv (attempt 2)
+      id: uv2
+      if: steps.uv1.outcome == 'failure'
+      continue-on-error: true
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        version: ${{ inputs.uv-version }}
+        python-version: ${{ inputs.python-version }}
+        cache-python: true
+        ignore-nothing-to-cache: true
+    - name: Set up uv (attempt 3)
+      id: uv3
+      if: steps.uv1.outcome == 'failure' && steps.uv2.outcome == 'failure'
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        version: ${{ inputs.uv-version }}
+        python-version: ${{ inputs.python-version }}
+        cache-python: true
         ignore-nothing-to-cache: true
     - name: Install Python interpreter
       shell: bash


### PR DESCRIPTION
## Summary
setup-uv@v8.1.0 always fetches its version manifest from raw.githubusercontent.com, even when the uv version is pinned, so transient outages there intermittently fail CI; this wraps the setup step in two retries before letting it fail for real.

Triggering run: https://github.com/Bluetooth-Devices/habluetooth/actions/runs/26308718698/job/77451904859

## Test plan
- [ ] CI green