### PR TITLE
ci: replace per-commit conventional commits check with pr title check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,26 @@ jobs:
           python-version: 3.13
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
-  # Make sure commit messages follow the conventional commits convention:
+  # Make sure the PR title follows the conventional commits convention:
   # https://www.conventionalcommits.org
-  commitlint:
-    name: Lint Commit Messages
+  # PRs are squash-merged, so the PR title becomes the commit on main and
+  # drives python-semantic-release's version bump.
+  pr-title:
+    name: Lint PR Title
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with a lowercase character.
 
   test:
     strategy:
@@ -137,7 +147,6 @@ jobs:
     needs:
       - test
       - lint
-      - commitlint
 
     runs-on: ubuntu-latest
     # Only enter the protected 'release' environment when actually releasing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ ci:
   autoupdate_commit_msg: "chore(pre-commit.ci): pre-commit autoupdate"
 
 repos:
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.2
-    hooks:
-      - id: commitizen
-        stages: [commit-msg]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ poetry run pytest -k allocation            # by keyword
 ```
 
 Lint / format (pre-commit covers ruff, black, mypy, codespell, prettier,
-poetry-check, commitizen):
+poetry-check):
 
 ```bash
 pre-commit run -a
@@ -157,9 +157,15 @@ Tests use `pytest-asyncio` (no auto-mode — mark coroutines explicitly) and
 
 ## Commit / PR conventions
 
-- **Conventional Commits** are enforced via `commitlint` on CI and
-  `commitizen` in pre-commit (`commit-msg` stage). Typical scopes:
-  `feat`, `fix`, `chore`, `ci`, `docs`, `refactor`, `test`, `perf`.
+- **Conventional Commits PR title, lowercase subject.** PRs are
+  squash-merged, so the **PR title** becomes the commit on `main` and is the
+  only string that has to parse as a Conventional Commit. The repo enforces
+  this via the `pr-title` CI job in `ci.yml` using
+  `amannn/action-semantic-pull-request`. Accepted types: `feat`, `fix`,
+  `chore`, `ci`, `docs`, `refactor`, `test`, `perf`, `build`, etc. The
+  subject (text after `type(scope):`) must start lowercase (enforced by
+  `subjectPattern: ^(?![A-Z]).+$`). Per-commit messages on the PR branch are
+  **not** linted; they get collapsed at squash-merge.
 - Releases are fully automated by `python-semantic-release` from the commit
   log. Anything that should land in the changelog must use `feat:` or `fix:`
   (or a breaking-change footer). `chore*` and `ci*` are excluded.

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,8 +1,0 @@
-export default {
-  extends: ["@commitlint/config-conventional"],
-  rules: {
-    "header-max-length": [0, "always", Infinity],
-    "body-max-line-length": [0, "always", Infinity],
-    "footer-max-line-length": [0, "always", Infinity],
-  },
-};


### PR DESCRIPTION
## Summary

PRs are squash-merged so the per-commit commitlint job and the commitizen pre-commit hook are noise; only the PR title lands on main. Replaces the commitlint job with a `pr-title` job using `amannn/action-semantic-pull-request`, configures `subjectPattern` to keep the lowercase-first-character rule, drops the commitizen hook and `commitlint.config.mjs`, and updates `CLAUDE.md`.

Ports https://github.com/python-zeroconf/python-zeroconf/pull/1740

## Test plan

- [x] `yaml.safe_load` on `ci.yml` and `.pre-commit-config.yaml` parses cleanly
- [ ] `pr-title` CI job runs against this PR
