### PR TITLE
ci: enable ruff rule families that pass against main with zero violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,18 +120,35 @@ ignore = [
     "D401", # First line of docstring should be in imperative mood
 ]
 select = [
-    "B",   # flake8-bugbear
-    "D",   # flake8-docstrings
-    "C4",  # flake8-comprehensions
-    "S",   # flake8-bandit
-    "F",   # pyflake
-    "E",   # pycodestyle
-    "W",   # pycodestyle
-    "UP",  # pyupgrade
-    "I",   # isort
-    "RUF", # ruff specific
-    "RET", # return
-    "SIM", # simplify
+    "A",    # flake8-builtins
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "D",    # flake8-docstrings
+    "DTZ",  # flake8-datetimez
+    "E",    # pycodestyle
+    "EXE",  # flake8-executable
+    "F",    # pyflake
+    "FA",   # flake8-future-annotations
+    "FIX",  # flake8-fixme
+    "FLY",  # flynt
+    "G",    # flake8-logging-format
+    "I",    # isort
+    "ICN",  # flake8-import-conventions
+    "INP",  # flake8-no-pep420
+    "NPY",  # numpy-specific rules
+    "PERF", # Perflint
+    "PTH",  # flake8-use-pathlib
+    "Q",    # flake8-quotes
+    "RET",  # return
+    "RUF",  # ruff specific
+    "S",    # flake8-bandit
+    "SIM",  # simplify
+    "T10",  # flake8-debugger
+    "T20",  # flake8-print
+    "TD",   # flake8-todos
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
+    "YTT",  # flake8-2020
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -145,7 +162,10 @@ select = [
 ]
 "setup.py" = ["D100"]
 "conftest.py" = ["D100"]
-"docs/conf.py" = ["D100"]
+# Sphinx config: ``copyright`` is the Sphinx convention, file is not a package
+"docs/conf.py" = ["D100", "A001", "INP001"]
+# Example scripts intentionally use print and aren't a package
+"examples/*" = ["INP001", "T201"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["habluetooth", "tests"]


### PR DESCRIPTION
## Summary

Refs #454 (align with the aioesphomeapi ruff config). Brings over every rule family that already passes against the current tree, so we lock in the floor and keep regressions out without doing any code refactors. The families added are A, DTZ, EXE, FA, FIX, FLY, G, ICN, INP, NPY, PERF, PTH, Q, T10, T20, TD, YTT. Two narrow per-file ignores were needed: docs/conf.py (Sphinx config; copyright is a Sphinx convention, file is not a package) and examples/* (deliberately print-based standalone scripts). Remaining families from aioesphomeapi have actual violations to fix and will land one per follow up PR.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)