### PR TITLE
ci: enable ruff RSE (flake8-raise)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ select = [
     "PTH",  # flake8-use-pathlib
     "Q",    # flake8-quotes
     "RET",  # return
+    "RSE",  # flake8-raise
     "RUF",  # ruff specific
     "S",    # flake8-bandit
     "SIM",  # simplify

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -1129,7 +1129,7 @@ async def test_reconnect_task() -> None:
             raise BluetoothSocketError("Test error")
         else:
             # Stop the test
-            raise asyncio.CancelledError()
+            raise asyncio.CancelledError
 
     with patch.object(
         ctl, "_establish_connection", side_effect=mock_establish_connection


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. The RSE family flags constructs like raise Foo() where raise Foo is identical and idiomatic; one existing site (raise asyncio.CancelledError() in tests/channels/test_bluez.py) was updated.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)