### PR TITLE
ci: replace black with ruff-format in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.0
-    hooks:
-      - id: black
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ poetry run pytest tests/test_manager.py    # single file
 poetry run pytest -k allocation            # by keyword
 ```
 
-Lint / format (pre-commit covers ruff, black, mypy, codespell, prettier,
+Lint / format (pre-commit covers ruff, ruff-format, mypy, codespell, prettier,
 poetry-check):
 
 ```bash

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -253,7 +253,9 @@ class _ScannerWorker:
                 return
             await self._tick()
 
-    def _collect_due_buckets(self, now: float) -> tuple[
+    def _collect_due_buckets(
+        self, now: float
+    ) -> tuple[
         list[tuple[dict[ActiveScanRequest, float], list[ActiveScanRequest]]],
         list[ActiveScanRequest],
     ]:

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -412,8 +412,7 @@ class MGMTBluetoothCtl:
             return await self._do_mgmt_op_get_connections(header)
         except (TimeoutError, OSError) as ex:
             _LOGGER.debug(
-                "MGMT capability check failed: %s - "
-                "likely missing NET_ADMIN/NET_RAW",
+                "MGMT capability check failed: %s - likely missing NET_ADMIN/NET_RAW",
                 ex,
             )
             return False

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -614,10 +614,7 @@ class HaScanner(BaseHaScanner):
             ex,
             exc_info=True,
         )
-        msg = (
-            f"{self.name}: Invalid DBus message received: {ex}; "
-            "try restarting `dbus`"
-        )
+        msg = f"{self.name}: Invalid DBus message received: {ex}; try restarting `dbus`"
         raise ScannerStartError(msg) from ex
 
     def _async_scanner_watchdog(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ from habluetooth import scanner as bluetooth_scanner
 
 
 class FakeBluetoothAdapters(BluetoothAdapters):
-
     @property
     def adapters(self) -> dict[str, AdapterDetails]:
         return {}
@@ -242,9 +241,9 @@ class MockBluetoothManagerWithCallbacks(BluetoothManager):
 
 
 @pytest.fixture
-def mock_manager_with_scanner_callbacks() -> (
-    Generator[MockBluetoothManagerWithCallbacks, None, None]
-):
+def mock_manager_with_scanner_callbacks() -> Generator[
+    MockBluetoothManagerWithCallbacks, None, None
+]:
     """Provide a mock BluetoothManager that tracks scanner start callbacks."""
     mock_bluetooth_adapters = FakeBluetoothAdapters()
     manager = MockBluetoothManagerWithCallbacks(
@@ -266,9 +265,9 @@ def mock_manager_with_scanner_callbacks() -> (
 
 
 @pytest_asyncio.fixture
-async def async_mock_manager_with_scanner_callbacks() -> (
-    AsyncGenerator[MockBluetoothManagerWithCallbacks, None]
-):
+async def async_mock_manager_with_scanner_callbacks() -> AsyncGenerator[
+    MockBluetoothManagerWithCallbacks, None
+]:
     """Provide an async mock BluetoothManager that tracks scanner start callbacks."""
     mock_bluetooth_adapters = FakeBluetoothAdapters()
     manager = MockBluetoothManagerWithCallbacks(

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -148,7 +148,6 @@ async def test_inject_100_different_advertisements(benchmark: BenchmarkFixture) 
     )
     advs: list[AdvertisementData] = []
     for i in range(100):
-
         switchbot_device_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
@@ -208,7 +207,6 @@ async def test_inject_100_different_manufacturer_data(
     )
     advs: list[AdvertisementData] = []
     for i in range(100):
-
         switchbot_device_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
@@ -268,7 +266,6 @@ async def test_inject_100_different_service_data(
     )
     advs: list[AdvertisementData] = []
     for i in range(100):
-
         switchbot_device_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
@@ -612,7 +609,6 @@ async def test_inject_100_rotating_manufacturer_data(
 
     advs: list[AdvertisementData] = []
     for i in range(100):
-
         sensorpush_device_adv = generate_advertisement_data(
             local_name="",
             service_uuids=["ef090000-11d6-42ba-93b8-9dd7ec090ab0"],

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -978,7 +978,6 @@ async def test_scanner_with_bluez_mgmt_side_channel(mock_btmgmt_socket: Mock) ->
     """Test scanner receiving advertisements via BlueZ management side channel."""
     # Mock capability check for the entire test
     with patch.object(MGMTBluetoothCtl, "_check_capabilities", return_value=True):
-
         # Create a custom manager that tracks discovered devices
         class TestBluetoothManager(BluetoothManager):
             def __init__(self, *args, **kwargs):
@@ -1153,7 +1152,6 @@ async def test_bluez_mgmt_protocol_data_flow(mock_btmgmt_socket: Mock) -> None:
     """Test data flow from BlueZ protocol through manager to scanner."""
     # Mock capability check for the entire test
     with patch.object(MGMTBluetoothCtl, "_check_capabilities", return_value=True):
-
         # Create manager
         class TestBluetoothManager(BluetoothManager):
             def __init__(self, *args, **kwargs):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1910,7 +1910,10 @@ async def test_connection_path_scoring_no_slots_available(
             scanner2,
             "get_allocations",
             return_value=Allocations(
-                adapter="scanner2", slots=3, free=3, allocated=[]  # All slots free
+                adapter="scanner2",
+                slots=3,
+                free=3,
+                allocated=[],  # All slots free
             ),
         ),
     ):
@@ -2162,48 +2165,48 @@ async def test_thundering_herd_connection_slots() -> None:
 
         # Verify constraints
         # 1. No proxy should exceed its slot limit
-        assert (
-            len(proxy1_connections) <= 3
-        ), f"Proxy1 exceeded slot limit: {len(proxy1_connections)} > 3"
-        assert (
-            len(proxy2_connections) <= 3
-        ), f"Proxy2 exceeded slot limit: {len(proxy2_connections)} > 3"
-        assert (
-            len(proxy3_connections) <= 3
-        ), f"Proxy3 exceeded slot limit: {len(proxy3_connections)} > 3"
+        assert len(proxy1_connections) <= 3, (
+            f"Proxy1 exceeded slot limit: {len(proxy1_connections)} > 3"
+        )
+        assert len(proxy2_connections) <= 3, (
+            f"Proxy2 exceeded slot limit: {len(proxy2_connections)} > 3"
+        )
+        assert len(proxy3_connections) <= 3, (
+            f"Proxy3 exceeded slot limit: {len(proxy3_connections)} > 3"
+        )
 
         # 2. Good signal proxies should be preferred and fill up first
         good_proxy_total = len(proxy1_connections) + len(proxy2_connections)
-        assert (
-            good_proxy_total == 6
-        ), f"Expected exactly 6 connections on good proxies, got {good_proxy_total}"
+        assert good_proxy_total == 6, (
+            f"Expected exactly 6 connections on good proxies, got {good_proxy_total}"
+        )
 
         # 3. All 7 devices should connect (6 to good proxies, 1 to bad proxy)
         total_connected = (
             len(proxy1_connections) + len(proxy2_connections) + len(proxy3_connections)
         )
-        assert (
-            total_connected == 7
-        ), f"Expected all 7 devices to connect, but only {total_connected} did"
+        assert total_connected == 7, (
+            f"Expected all 7 devices to connect, but only {total_connected} did"
+        )
 
         # 4. The 7th device should go to proxy3 since good ones are full
-        assert (
-            len(proxy3_connections) == 1
-        ), f"Expected exactly 1 connection on proxy3, got {len(proxy3_connections)}"
+        assert len(proxy3_connections) == 1, (
+            f"Expected exactly 1 connection on proxy3, got {len(proxy3_connections)}"
+        )
 
         # 5. Verify good distribution across proxy1 and proxy2
         # Both should have roughly equal load (3 connections each)
-        assert (
-            len(proxy1_connections) == 3
-        ), f"Expected proxy1 to have 3 connections, got {len(proxy1_connections)}"
-        assert (
-            len(proxy2_connections) == 3
-        ), f"Expected proxy2 to have 3 connections, got {len(proxy2_connections)}"
+        assert len(proxy1_connections) == 3, (
+            f"Expected proxy1 to have 3 connections, got {len(proxy1_connections)}"
+        )
+        assert len(proxy2_connections) == 3, (
+            f"Expected proxy2 to have 3 connections, got {len(proxy2_connections)}"
+        )
 
         # 6. No connections should fail
-        assert (
-            len(failed_connections) == 0
-        ), f"Expected no failed connections, but {len(failed_connections)} failed"
+        assert len(failed_connections) == 0, (
+            f"Expected no failed connections, but {len(failed_connections)} failed"
+        )
 
         # Clean up
         cancel1()


### PR DESCRIPTION
## Summary

Black was still pinned in pre-commit even though we moved to ruff; swapped the black hook for ruff-format under the existing astral-sh/ruff-pre-commit entry. Ruff format produced a handful of small reflows vs black; those are folded in so pre-commit stays green.

## Test plan

- [x] `pre-commit run -a` green