### PR TITLE
ci: enable ruff BLE (flake8-blind-except)

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -43,7 +43,10 @@ class BuildExt(build_ext):
             self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
-        except Exception as ex:  # nosec
+        except Exception as ex:  # nosec  # noqa: BLE001
+            # Cython is optional; any compile failure (missing C compiler,
+            # platform mismatch, etc.) should fall back to the pure-Python
+            # install rather than break the build.
             _LOGGER.debug("Failed to build extensions: %s", ex, exc_info=True)
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ ignore = [
 select = [
     "A",    # flake8-builtins
     "B",    # flake8-bugbear
+    "BLE",  # flake8-blind-except
     "C4",   # flake8-comprehensions
     "D",    # flake8-docstrings
     "DTZ",  # flake8-datetimez

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -952,5 +952,8 @@ class HaScanner(BaseHaScanner):
                 await stop_discovery(self.adapter)
         except TimeoutError as ex:
             _LOGGER.error("%s: Timeout force stopping scanner: %s", self.name, ex)
-        except Exception as ex:
+        except Exception as ex:  # noqa: BLE001
+            # Best-effort BlueZ cleanup; dbus_fast can raise a wide
+            # variety of errors and we don't want any of them to
+            # propagate out of the recovery path.
             _LOGGER.error("%s: Failed to force stop scanner: %s", self.name, ex)


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Two existing broad except Exception sites are intentional best effort recovery points: HaScanner._async_force_stop_discovery swallows whatever dbus_fast throws on a BlueZ cleanup so the recovery path always completes, and BuildExt.build_extensions swallows Cython compile failures so the pure Python install still works. Both kept with a noqa plus a why comment.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)