### PR TITLE
ci: enable ruff FURB (refurb)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ select = [
     "FA",   # flake8-future-annotations
     "FIX",  # flake8-fixme
     "FLY",  # flynt
+    "FURB", # refurb
     "G",    # flake8-logging-format
     "I",    # isort
     "ICN",  # flake8-import-conventions

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -604,7 +604,7 @@ class BaseHaScanner:
                 info.name = prev_name
             else:
                 info.device.name = local_name
-                info.name = local_name if local_name else address
+                info.name = local_name or address
 
             has_service_uuids = bool(service_uuids)
             if (


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. One existing site (``local_name if local_name else address`` in BaseHaScanner) collapses to ``local_name or address`` (FURB110); auto fix applied.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)