### PR TITLE
ci: enable ruff PGH (pygrep-hooks)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ select = [
     "INP",  # flake8-no-pep420
     "NPY",  # numpy-specific rules
     "PERF", # Perflint
+    "PGH",  # pygrep-hooks
     "PTH",  # flake8-use-pathlib
     "Q",    # flake8-quotes
     "RET",  # return

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -475,7 +475,7 @@ async def test_recovery_from_dbus_restart() -> None:
         with patch_bluetooth_time(
             start_time_monotonic,
         ):
-            _callback(  # type: ignore
+            _callback(  # type: ignore[misc]
                 generate_ble_device("44:44:33:11:23:42", "any_name"),
                 generate_advertisement_data(local_name="any_name"),
             )

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -275,7 +275,7 @@ async def test_test_switch_adapters_when_out_of_slots(
 
     with (
         patch.object(manager.slot_manager, "release_slot") as release_slot_mock,
-        patch.object(  # type: ignore
+        patch.object(  # type: ignore[assignment]
             manager.slot_manager, "allocate_slot", _allocate_slot_mock
         ) as allocate_slot_mock,
     ):


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. PGH003 flags bare `# type: ignore` comments without a specific code; two test sites get the real mypy code (`[misc]` for the None callable spot in test_scanner, `[assignment]` for the patch.object mock in test_wrappers).

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)