### PR TITLE
ci: enable ruff SLOT (flake8-slots)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ select = [
     "RUF",  # ruff specific
     "S",    # flake8-bandit
     "SIM",  # simplify
+    "SLOT", # flake8-slots
     "T10",  # flake8-debugger
     "T20",  # flake8-print
     "TD",   # flake8-todos

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -183,10 +183,10 @@ def test_from_device_and_advertisement_data():
 
 def test_pyobjc_compat():
     class pyobjc_str(str):
-        pass
+        __slots__ = ()
 
     class pyobjc_int(int):
-        pass
+        __slots__ = ()
 
     name = pyobjc_str("wohand")
     address = pyobjc_str("44:44:33:11:23:45")

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2502,6 +2502,8 @@ async def test_detection_callback_coerces_non_str_name_and_non_int_tx_power() ->
     class _StrSubclass(str):
         """str subclass — `type() is not str` so coercion fires."""
 
+        __slots__ = ()
+
     class _IntLike:
         """Non-int that ``int()`` accepts (e.g. numpy.int64 stand-in)."""
 


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Three str/int subclasses in the test suite (the pyobjc compat fakes in test_models, the coercion stand in in test_scanner) now declare `__slots__ = ()` so they inherit the slotted layout of their base.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)