### PR TITLE
ci: enable ruff PIE (flake8-pie)

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -48,7 +48,6 @@ class BuildExt(build_ext):
             # platform mismatch, etc.) should fall back to the pure-Python
             # install rather than break the build.
             _LOGGER.debug("Failed to build extensions: %s", ex, exc_info=True)
-            pass
 
 
 def build(setup_kwargs: Any) -> None:
@@ -74,4 +73,3 @@ def build(setup_kwargs: Any) -> None:
     except Exception:
         if os.environ.get("REQUIRE_CYTHON"):
             raise
-        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ select = [
     "NPY",  # numpy-specific rules
     "PERF", # Perflint
     "PGH",  # pygrep-hooks
+    "PIE",  # flake8-pie
     "PTH",  # flake8-use-pathlib
     "Q",    # flake8-quotes
     "RET",  # return

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -899,8 +899,6 @@ def test_remote_scanner_type() -> None:
     class TestRemoteScanner(BaseHaRemoteScanner):
         """Test remote scanner implementation."""
 
-        pass
-
     scanner = TestRemoteScanner("test_source", "test_adapter")
     assert scanner.details.scanner_type is HaScannerType.REMOTE
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,8 +23,6 @@ def test_create_scanner():
     connector = HaBluetoothConnector(MockBleakClient, "any", lambda: True)
 
     class MockScanner(BaseHaScanner):
-        pass
-
         @property
         def discovered_devices_and_advertisement_data(self):
             return []

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1303,7 +1303,6 @@ async def test_mgmt_permission_error_fallback() -> None:
             self, service_info: BluetoothServiceInfoBleak
         ) -> None:
             """Track discovered service info."""
-            pass
 
     adapters = FakeBluetoothAdapters()
     slot_manager = BleakSlotManager()


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Five unnecessary `pass` statements removed across build_ext, test_base_scanner, test_init, and test_scanner; all auto fix.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)