### PR TITLE
ci: enable ruff ISC (flake8-implicit-str-concat)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ select = [
     "I",    # isort
     "ICN",  # flake8-import-conventions
     "INP",  # flake8-no-pep420
+    "ISC",  # flake8-implicit-str-concat
     "NPY",  # numpy-specific rules
     "PERF", # Perflint
     "PGH",  # pygrep-hooks

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -1238,8 +1238,8 @@ async def test_command_response_context_manager() -> None:
         # Simulate receiving a response
         response_data = (
             b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
-            + b"\x00\x00"  # controller index
-            + b"\x03\x00"  # param_len (3 bytes: opcode=2 + status=1)
+            b"\x00\x00"  # controller index
+            b"\x03\x00"  # param_len (3 bytes: opcode=2 + status=1)
             + opcode.to_bytes(2, "little")  # opcode
             + b"\x00"  # status (success)
         )
@@ -1299,8 +1299,8 @@ async def test_get_connections_response_handling() -> None:
         # Test with permission denied status (0x14)
         response_data = (
             b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
-            + b"\x00\x00"  # controller index
-            + b"\x03\x00"  # param_len
+            b"\x00\x00"  # controller index
+            b"\x03\x00"  # param_len
             + opcode.to_bytes(2, "little")  # opcode
             + b"\x14"  # status (permission denied)
         )
@@ -1334,7 +1334,7 @@ async def test_get_connections_response_with_data() -> None:
         extra_data = b"\x01\x02\x03\x04"
         response_data = (
             b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
-            + b"\x00\x00"  # controller index
+            b"\x00\x00"  # controller index
             + (3 + len(extra_data)).to_bytes(
                 2, "little"
             )  # param_len (opcode=2 + status=1 + extra_data)

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -998,7 +998,7 @@ async def test_inject_100_bluez_raw_end_to_end_changed(
         ad_data = (
             b"\x02\x01\x06"  # Flags
             b"\x08\x09TestDev"  # Complete Local Name = "TestDev"
-            + b"\x04\xff\x01\x00"  # Manufacturer data header: company 0x0001
+            b"\x04\xff\x01\x00"  # Manufacturer data header: company 0x0001
             + bytes((i,))  # Varying data byte
         )
         param_len = 6 + 1 + 1 + 4 + 2 + len(ad_data)


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. ISC003 flags explicit `b"x" + b"y"` between adjacent literals where Python already implicitly concatenates `b"x" b"y"`; auto fix collapses the literal to literal joins in the bluez channel and benchmark tests while leaving the literal to expression `+` operators (opcode.to_bytes, len() based length prefixes) alone.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)