### PR TITLE
ci: enable ruff LOG (flake8-logging)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ select = [
     "ICN",  # flake8-import-conventions
     "INP",  # flake8-no-pep420
     "ISC",  # flake8-implicit-str-concat
+    "LOG",  # flake8-logging
     "NPY",  # numpy-specific rules
     "PERF", # Perflint
     "PGH",  # pygrep-hooks

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -553,7 +553,7 @@ class HaScanner(BaseHaScanner):
             attempt,
             START_ATTEMPTS,
             ex,
-            exc_info=True,
+            exc_info=ex,
         )
 
     def _log_start_attempt(self, attempt: int) -> None:
@@ -569,7 +569,7 @@ class HaScanner(BaseHaScanner):
             "%s: Starting bluetooth scanner aborted: %s",
             self.name,
             ex,
-            exc_info=True,
+            exc_info=ex,
         )
         msg = f"{self.name}: Starting bluetooth scanner aborted"
         raise ScannerStartError(msg) from ex
@@ -579,7 +579,7 @@ class HaScanner(BaseHaScanner):
             "%s: FileNotFoundError while starting bluetooth: %s",
             self.name,
             ex,
-            exc_info=True,
+            exc_info=ex,
         )
         if is_docker_env():
             raise ScannerStartError(
@@ -593,7 +593,7 @@ class HaScanner(BaseHaScanner):
 
     def _raise_for_broken_pipe_error(self, ex: BrokenPipeError) -> None:
         """Raise a ScannerStartError for a BrokenPipeError."""
-        _LOGGER.debug("%s: DBus connection broken: %s", self.name, ex, exc_info=True)
+        _LOGGER.debug("%s: DBus connection broken: %s", self.name, ex, exc_info=ex)
         if is_docker_env():
             msg = (
                 f"{self.name}: DBus connection broken: {ex}; try restarting "
@@ -612,7 +612,7 @@ class HaScanner(BaseHaScanner):
             "%s: Invalid DBus message received: %s",
             self.name,
             ex,
-            exc_info=True,
+            exc_info=ex,
         )
         msg = f"{self.name}: Invalid DBus message received: {ex}; try restarting `dbus`"
         raise ScannerStartError(msg) from ex


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. LOG014 flags `exc_info=True` outside a lexical except block, since the underlying `sys.exc_info()` lookup is fragile when the logging call lives in a helper called from the handler. The five sites all sit in the `_log_start_failed` / `_raise_for_*` helpers, which already receive the exception as an argument; switching to `exc_info=ex` makes the traceback source explicit and satisfies the rule without changing the captured information.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)