### PR TITLE
refactor(manager): extract _should_keep_previous_adv from hot path

### DIFF
--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -84,6 +84,13 @@ cdef class BluetoothManager:
         BluetoothServiceInfoBleak new
     )
 
+    @cython.locals(scanner=BaseHaScanner)
+    cdef bint _should_keep_previous_adv(
+        self,
+        BluetoothServiceInfoBleak old_info,
+        BluetoothServiceInfoBleak new_info
+    )
+
     @cython.locals(
         cached=str,
         cached_cf=str,
@@ -106,8 +113,6 @@ cdef class BluetoothManager:
         old_connectable_service_info=BluetoothServiceInfoBleak,
         source=str,
         connectable=bint,
-        scanner=BaseHaScanner,
-        connectable_scanner=BaseHaScanner,
         apple_cstr="const unsigned char *",
         bleak_callback=BleakCallback,
         cached_name=str,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -524,6 +524,26 @@ class BluetoothManager:
         This method is intended to be overridden by subclasses.
         """
 
+    def _should_keep_previous_adv(
+        self,
+        old_info: BluetoothServiceInfoBleak,
+        new_info: BluetoothServiceInfoBleak,
+    ) -> bool:
+        """
+        Return True when ``old_info`` should win over ``new_info``.
+
+        Only relevant when ``old_info`` came from a different still-scanning
+        source. The ``is not / !=`` ordering is a PyObject_RichCompare
+        short-circuit that dominates this hot path; keep it intact.
+        """
+        return (
+            new_info.source is not old_info.source
+            and new_info.source != old_info.source
+            and (scanner := self._sources.get(old_info.source)) is not None
+            and scanner.scanning
+            and self._prefer_previous_adv_from_different_source(old_info, new_info)
+        )
+
     def _prefer_previous_adv_from_different_source(
         self,
         old: BluetoothServiceInfoBleak,
@@ -771,42 +791,22 @@ class BluetoothManager:
         #                       connectable scanner
         #
         if (
-            (old_service_info := self._all_history.get(service_info.address))
-            is not None
-            and service_info.source is not old_service_info.source
-            and service_info.source != old_service_info.source
-            and (scanner := self._sources.get(old_service_info.source)) is not None
-            and scanner.scanning
-            and self._prefer_previous_adv_from_different_source(
-                old_service_info, service_info
-            )
+            old_service_info := self._all_history.get(service_info.address)
+        ) is not None and self._should_keep_previous_adv(
+            old_service_info, service_info
         ):
             # If we are rejecting the new advertisement and the device is connectable
             # but not in the connectable history or the connectable source is the same
             # as the new source, we need to add it to the connectable history
             if service_info.connectable:
                 if old_connectable_service_info is not None and (
-                    # If its the same as the preferred source, we are done
-                    # as we know we prefer the old advertisement
-                    # from the check above
-                    (old_connectable_service_info is old_service_info)
-                    # If the old connectable source is different from the preferred
-                    # source, we need to check it as well to see if we prefer
-                    # the old connectable advertisement
-                    or (
-                        old_connectable_service_info.source is not service_info.source
-                        and old_connectable_service_info.source != service_info.source
-                        and (
-                            connectable_scanner := self._sources.get(
-                                old_connectable_service_info.source
-                            )
-                        )
-                        is not None
-                        and connectable_scanner.scanning
-                        and self._prefer_previous_adv_from_different_source(
-                            old_connectable_service_info,
-                            service_info,
-                        )
+                    # If it's the same as the preferred source, we're done; we know
+                    # we prefer the old advertisement from the check above.
+                    old_connectable_service_info is old_service_info
+                    # Otherwise the old connectable came from a different source;
+                    # re-run the predicate against the connectable history entry.
+                    or self._should_keep_previous_adv(
+                        old_connectable_service_info, service_info
                     )
                 ):
                     return


### PR DESCRIPTION
## Summary

Flattens the triple-nested preference block in `_scanner_adv_received` by extracting `_should_keep_previous_adv(old_info, new_info)`. The outer check and the inner connectable sub-branch were running the same source-differs + scanner-still-scanning + `_prefer_previous_adv_from_different_source` predicate; now both call the named helper, so a fix in one applies to both. The `is not / !=` PyObject_RichCompare short-circuit pattern is preserved verbatim inside the helper. Helper is declared `cdef bint` with a typed `scanner` local, and the now-unused `scanner` / `connectable_scanner` cython.locals are dropped from `_scanner_adv_received`. Cython's annotation HTML confirms both call sites stay a direct vtable dispatch with score-0/1; no Python interaction added on the hot path. Closes #441.

## Test plan

- [x] `poetry run pytest tests/` green (389 pass, 1 skip); existing `test_switching_adapters_*` cases already cover the four (connectable times old-connectable-present) combinations
- [x] `pre-commit run -a` green
- [x] `cythonize -i -a` clean; manager.html shows direct C vtable dispatch at both call sites