### PR TITLE
ci: enable ruff N (pep8-naming)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ select = [
     "INP",  # flake8-no-pep420
     "ISC",  # flake8-implicit-str-concat
     "LOG",  # flake8-logging
+    "N",    # pep8-naming
     "NPY",  # numpy-specific rules
     "PERF", # Perflint
     "PGH",  # pygrep-hooks

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -62,14 +62,17 @@ if IS_LINUX:
     class HaAdvertisementMonitor(AdvertisementMonitor):
         """Implementation of the org.bluez.AdvertisementMonitor1 D-Bus interface."""
 
+        # Method names are dictated by the BlueZ AdvertisementMonitor1
+        # D-Bus interface; ``dbus_fast`` matches the Python attribute
+        # name against the interface, so the CamelCase form is required.
         @method()
         @no_type_check
-        def DeviceFound(self, device: o):  # noqa: F821
+        def DeviceFound(self, device: o):  # noqa: F821, N802
             """Device found."""
 
         @method()
         @no_type_check
-        def DeviceLost(self, device: o):  # noqa: F821
+        def DeviceLost(self, device: o):  # noqa: F821, N802
             """Device lost."""
 
     AdvertisementMonitor.DeviceFound = HaAdvertisementMonitor.DeviceFound

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -182,10 +182,13 @@ def test_from_device_and_advertisement_data():
 
 
 def test_pyobjc_compat():
-    class pyobjc_str(str):
+    # pyobjc-style snake_case names intentionally mirror the runtime
+    # types we receive from CoreBluetooth so the coercion paths are
+    # exercised with realistic class identities.
+    class pyobjc_str(str):  # noqa: N801
         __slots__ = ()
 
-    class pyobjc_int(int):
+    class pyobjc_int(int):  # noqa: N801
         __slots__ = ()
 
     name = pyobjc_str("wohand")

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -15,7 +15,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakError
 from bleak_retry_connector import Allocations
-from bluetooth_data_tools import monotonic_time_coarse as MONOTONIC_TIME
+from bluetooth_data_tools import monotonic_time_coarse
 
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 from habluetooth import get_manager as _get_manager
@@ -74,7 +74,7 @@ class FakeScanner(BaseHaRemoteScanner):
             advertisement_data.manufacturer_data,
             advertisement_data.tx_power,
             device.details | {"scanner_specific_data": "test"},
-            MONOTONIC_TIME(),
+            monotonic_time_coarse(),
         )
 
 


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. The HaAdvertisementMonitor DeviceFound and DeviceLost handlers keep a noqa with a why comment; the names are the BlueZ AdvertisementMonitor1 D-Bus interface contract and dbus_fast matches on the Python attribute name. The pyobjc_str and pyobjc_int test fakes mirror the runtime class identities CoreBluetooth hands us; they also keep a noqa with a why comment. The MONOTONIC_TIME alias in test_wrappers is renamed back to the underlying monotonic_time_coarse since it is only used twice and the alias was just adding noise.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)