### PR TITLE
fix(storage): narrow deserialize exception so shape mismatches don't hide bugs

### DIFF
--- a/src/habluetooth/storage.py
+++ b/src/habluetooth/storage.py
@@ -143,11 +143,15 @@ def discovered_device_advertisement_data_from_dict(
             ),
             _deserialize_discovered_device_raw(data.get(DISCOVERED_DEVICE_RAW, {})),
         )
-    except Exception as err:  # pylint: disable=broad-except
+    except (KeyError, ValueError, TypeError):
+        _LOGGER.warning(
+            "Discovery cache shape mismatch, discarding cache; "
+            "adapter startup will be slow"
+        )
+    except Exception:  # pylint: disable=broad-except
         _LOGGER.exception(
-            "Error deserializing discovered_device_advertisement_data"
-            ", adapter startup will be slow: %s",
-            err,
+            "Unexpected error deserializing discovered_device_advertisement_data, "
+            "adapter startup will be slow"
         )
     return None
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -338,7 +338,7 @@ def test_expire_future_discovered_device_advertisement_data(
 
 
 def test_discovered_device_advertisement_data_from_dict_corrupt(caplog):
-    """Test discovered_device_advertisement_data_from_dict with corrupt data."""
+    """Shape mismatches log a WARNING and discard the cache without a traceback."""
     now = time.time()
     result = discovered_device_advertisement_data_from_dict(
         {
@@ -364,7 +364,45 @@ def test_discovered_device_advertisement_data_from_dict_corrupt(caplog):
         }
     )
     assert result is None
-    assert "Error deserializing discovered_device_advertisement_data" in caplog.text
+    assert "Discovery cache shape mismatch" in caplog.text
+    # The shape-mismatch path is logged at WARNING without a traceback so
+    # operators can distinguish it from genuinely unexpected failures.
+    records = [
+        r for r in caplog.records if "Discovery cache shape mismatch" in r.getMessage()
+    ]
+    assert len(records) == 1
+    assert records[0].levelname == "WARNING"
+    assert records[0].exc_info is None
+
+
+def test_discovered_device_advertisement_data_from_dict_unexpected_error(
+    caplog, monkeypatch
+):
+    """Unexpected errors keep the full traceback and are logged at ERROR."""
+
+    def boom(_data):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "habluetooth.storage._deserialize_discovered_device_advertisement_datas",
+        boom,
+    )
+    result = discovered_device_advertisement_data_from_dict(
+        {
+            "connectable": True,
+            "discovered_device_advertisement_datas": {},
+            "discovered_device_timestamps": {},
+            "expire_seconds": 100,
+            "discovered_device_raw": {},
+        }
+    )
+    assert result is None
+    records = [
+        r for r in caplog.records if "Unexpected error deserializing" in r.getMessage()
+    ]
+    assert len(records) == 1
+    assert records[0].levelname == "ERROR"
+    assert records[0].exc_info is not None
 
 
 def test_backward_compatibility_rssi_in_device_dict():


### PR DESCRIPTION
## Summary

The single `except Exception` around `discovered_device_advertisement_data_from_dict` was logging *any* failure (including the expected `KeyError` / `ValueError` / `TypeError` from a post-upgrade cache shape change) with `_LOGGER.exception(...)`, so operators couldn't tell a normal post-upgrade reload from genuine corruption or upstream API drift. Splits the handler in two; shape-mismatch errors log at WARNING with a clear "Discovery cache shape mismatch, discarding cache" message and no traceback, everything else still goes through `_LOGGER.exception` with the full stack. Also drops the redundant trailing `: %s, err` interpolation since `exception()` already emits the trace. Closes #440.

## Test plan

- [x] `poetry run pytest tests/` green (390 pass, 1 skip)
- [x] `pre-commit run -a` green
- [x] Updated `test_discovered_device_advertisement_data_from_dict_corrupt` to assert the new WARNING level and the absence of a traceback
- [x] Added `test_discovered_device_advertisement_data_from_dict_unexpected_error` covering the fallback `except Exception` branch still emits ERROR with traceback