### PR TITLE
ci: enable ruff PYI (flake8-pyi)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ select = [
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
     "PTH",  # flake8-use-pathlib
+    "PYI",  # flake8-pyi
     "Q",    # flake8-quotes
     "RET",  # return
     "RSE",  # flake8-raise

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Final, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Self
 
 from bleak import BaseBleakClient
 from bleak.backends.device import BLEDevice
@@ -15,13 +15,7 @@ from bleak_retry_connector import NO_RSSI_VALUE
 if TYPE_CHECKING:
     from .base_scanner import BaseHaScanner
 
-_BluetoothServiceInfoSelfT = TypeVar(
-    "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
-)
 
-_BluetoothServiceInfoBleakSelfT = TypeVar(
-    "_BluetoothServiceInfoBleakSelfT", bound="BluetoothServiceInfoBleak"
-)
 SOURCE_LOCAL: Final = "local"
 TUPLE_NEW: Final = tuple.__new__
 
@@ -139,11 +133,11 @@ class BluetoothServiceInfo:
 
     @classmethod
     def from_advertisement(
-        cls: type[_BluetoothServiceInfoSelfT],
+        cls,
         device: BLEDevice,
         advertisement_data: AdvertisementData,
         source: str,
-    ) -> _BluetoothServiceInfoSelfT:
+    ) -> Self:
         """Create a BluetoothServiceInfo from an advertisement."""
         return cls(
             advertisement_data.local_name or device.name or device.address,
@@ -286,13 +280,13 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
 
     @classmethod
     def from_scan(
-        cls: type[_BluetoothServiceInfoBleakSelfT],
+        cls,
         source: str,
         device: BLEDevice,
         advertisement_data: AdvertisementData,
         monotonic_time: _float,
         connectable: bool,
-    ) -> _BluetoothServiceInfoBleakSelfT:
+    ) -> Self:
         """Create a BluetoothServiceInfoBleak from a scanner."""
         return cls(
             advertisement_data.local_name or device.name or device.address,
@@ -311,13 +305,13 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
 
     @classmethod
     def from_device_and_advertisement_data(
-        cls: type[_BluetoothServiceInfoBleakSelfT],
+        cls,
         device: BLEDevice,
         advertisement_data: AdvertisementData,
         source: str,
         time: _float,
         connectable: bool,
-    ) -> _BluetoothServiceInfoBleakSelfT:
+    ) -> Self:
         """Create a BluetoothServiceInfoBleak from a device and advertisement."""
         return cls(
             advertisement_data.local_name or device.name or device.address,

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Final, Literal, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, Self, overload
 
 from bleak import BleakClient, BleakError, normalize_uuid_str
 from bleak.backends import BleakBackend
@@ -154,12 +154,12 @@ class HaBleakScannerWrapper:
     async def start(self, *args: Any, **kwargs: Any) -> None:
         """Start scanning for devices."""
 
-    async def __aenter__(self) -> HaBleakScannerWrapper:
+    async def __aenter__(self) -> Self:
         """Enter the context manager."""
         await self.start()
         return self
 
-    async def __aexit__(self, *args: Any) -> None:
+    async def __aexit__(self, *args: object) -> None:
         """Exit the context manager."""
         await self.stop()
 


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config.

PYI019: `BluetoothServiceInfo.from_advertisement` and the two `BluetoothServiceInfoBleak.from_scan` and `from_device_and_advertisement_data` classmethods used hand rolled `_BluetoothServiceInfo*SelfT` TypeVars to type `cls` and the return value; replaced with `typing.Self`. The TypeVar declarations and import are removed.

PYI034: `HaBleakScannerWrapper.__aenter__` returned the concrete class; switched to `Self` so subclasses propagate.

PYI036: `HaBleakScannerWrapper.__aexit__` star args are now `object` instead of `Any`.

All auto fix; no behavior change.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (389 pass, 1 skip)