### PR TITLE
ci: enable ruff ASYNC (flake8-async)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,16 +111,18 @@ line-length = 88
 
 [tool.ruff.lint]
 ignore = [
-    "E721", # type checks for cython
-    "D203", # 1 blank line required before class docstring
-    "D212", # Multi-line docstring summary should start at the first line
-    "D100", # Missing docstring in public module
-    "D104", # Missing docstring in public package
-    "D107", # Missing docstring in `__init__`
-    "D401", # First line of docstring should be in imperative mood
+    "E721",    # type checks for cython
+    "D203",    # 1 blank line required before class docstring
+    "D212",    # Multi-line docstring summary should start at the first line
+    "D100",    # Missing docstring in public module
+    "D104",    # Missing docstring in public package
+    "D107",    # Missing docstring in `__init__`
+    "D401",    # First line of docstring should be in imperative mood
+    "ASYNC109", # ``timeout`` is part of our bleak-compatible public API
 ]
 select = [
     "A",    # flake8-builtins
+    "ASYNC", # flake8-async
     "B",    # flake8-bugbear
     "BLE",  # flake8-blind-except
     "C4",   # flake8-comprehensions


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. ASYNC109 is ignored: the HaBleakScannerWrapper.find_device_by_* and discover methods expose a `timeout` kwarg because they implement the bleak.BleakScanner public API contract; the kwarg cannot be renamed or dropped. aioesphomeapi ignores ASYNC109 for the same reason.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)