### PR TITLE
ci: enable ruff C90 (mccabe complexity)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ select = [
     "B",    # flake8-bugbear
     "BLE",  # flake8-blind-except
     "C4",   # flake8-comprehensions
+    "C90",  # mccabe complexity
     "D",    # flake8-docstrings
     "DTZ",  # flake8-datetimez
     "E",    # pycodestyle

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -552,7 +552,7 @@ class BaseHaScanner:
             None,
         )
 
-    def _async_on_advertisement_internal(
+    def _async_on_advertisement_internal(  # noqa: C901
         self,
         address: _str,
         rssi: _int,

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -180,7 +180,7 @@ class BluetoothMGMTProtocol:
         # since Cython will stop at any '\0' character if we don't
         self._buffer = cstr[end_of_frame_pos : self._buffer_len + end_of_frame_pos]
 
-    def data_received(self, data: _bytes) -> None:
+    def data_received(self, data: _bytes) -> None:  # noqa: C901
         """Handle data received."""
         self._add_to_buffer(data)
         while self._buffer_len >= 6:

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -454,7 +454,7 @@ class BluetoothManager:
             loop.time() + UNAVAILABLE_TRACK_SECONDS, self._async_check_unavailable
         )
 
-    def _async_check_unavailable(self) -> None:
+    def _async_check_unavailable(self) -> None:  # noqa: C901
         """Watch for unavailable devices and cleanup state history."""
         monotonic_now = monotonic_time_coarse()
         connectable_history = self._connectable_history
@@ -733,7 +733,9 @@ class BluetoothManager:
         """
         self._scanner_adv_received(service_info)
 
-    def _scanner_adv_received(self, service_info: BluetoothServiceInfoBleak) -> None:
+    def _scanner_adv_received(  # noqa: C901
+        self, service_info: BluetoothServiceInfoBleak
+    ) -> None:
         """
         Handle a new advertisement from any scanner (internal cdef path).
 

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -400,7 +400,7 @@ class HaScanner(BaseHaScanner):
         """
         return self._scan_mode_override or self.requested_mode
 
-    async def _async_start_attempt(self, attempt: int) -> bool:
+    async def _async_start_attempt(self, attempt: int) -> bool:  # noqa: C901
         """Start the scanner and handle errors."""
         assert (  # noqa: S101
             self._loop is not None

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -407,7 +407,7 @@ class HaBleakClientWrapper(BleakClient):
         """
         return None if callback is None else partial(callback, self)
 
-    async def connect(self, **kwargs: Any) -> None:
+    async def connect(self, **kwargs: Any) -> None:  # noqa: C901
         """Connect to the specified GATT server."""
         if self.is_connected:
             return

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1972,7 +1972,7 @@ async def test_connection_path_scoring_no_slots_available(
 
 
 @pytest.mark.asyncio
-async def test_thundering_herd_connection_slots() -> None:
+async def test_thundering_herd_connection_slots() -> None:  # noqa: C901
     """
     Test thundering herd scenario with limited connection slots.
 


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Seven intentional complexity functions get per function `# noqa: C901` since the branching is structure, not accidental: `_async_on_advertisement_internal` and `_scanner_adv_received` (advertisement dispatch hot path), `data_received` (BlueZ wire protocol framing), `_async_check_unavailable` (periodic device cleanup), `_async_start_attempt` (4 attempt BlueZ recovery state machine), `HaBleakClientWrapper.connect` (proxy slot allocation and scanner selection), and the thundering herd connection slots test.

Future refactors can drop individual noqa as the structure simplifies; for now the rule guards against new accidental complexity from landing.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)