### PR TITLE
test: extract InjectableRemoteScanner base shared across test files

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,8 +13,9 @@ from bleak.backends.scanner import (
     AdvertisementDataCallback,
     BLEDevice,
 )
+from bluetooth_data_tools import monotonic_time_coarse
 
-from habluetooth import get_manager
+from habluetooth import BaseHaRemoteScanner, get_manager
 from habluetooth.models import BluetoothServiceInfoBleak
 
 utcnow = partial(datetime.now, UTC)
@@ -150,6 +151,54 @@ class MockBleakScanner:
 
     def register_detection_callback(self, callback: AdvertisementDataCallback) -> None:
         """No-op detection-callback registration."""
+
+
+class InjectableRemoteScanner(BaseHaRemoteScanner):
+    """
+    Remote scanner that exposes test-only ``inject_advertisement`` helpers.
+
+    Replaces the near-identical ``FakeScanner`` / ``_SeedFakeScanner``
+    classes that used to live in test_base_scanner / test_name_cache /
+    test_wrappers. ``device.details`` (when present) is merged into the
+    advertisement ``details`` dict so callers that route via DBus paths
+    (e.g. test_wrappers) keep the path key, while callers that pass a
+    ``details``-less device (the default) see only the test marker.
+    """
+
+    def inject_advertisement(
+        self,
+        device: BLEDevice,
+        advertisement_data: AdvertisementData,
+        now: float | None = None,
+    ) -> None:
+        """Inject an advertisement through the scanner's normal entry point."""
+        self._async_on_advertisement(
+            device.address,
+            advertisement_data.rssi,
+            device.name,
+            advertisement_data.service_uuids,
+            advertisement_data.service_data,
+            advertisement_data.manufacturer_data,
+            advertisement_data.tx_power,
+            (device.details or {}) | {"scanner_specific_data": "test"},
+            now if now is not None else monotonic_time_coarse(),
+        )
+
+    def inject_raw_advertisement(
+        self,
+        address: str,
+        rssi: int,
+        adv: bytes,
+        now: float | None = None,
+    ) -> None:
+        """Inject a raw advertisement through the scanner's normal entry point."""
+        self._async_on_raw_advertisement(
+            address,
+            rssi,
+            adv,
+            {"scanner_specific_data": "test"},
+            now if now is not None else monotonic_time_coarse(),
+        )
 
 
 def patch_bleak_scanner_factory(factory: Any) -> Any:

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -46,46 +46,10 @@ from . import (
     patch_bluetooth_time,
     utcnow,
 )
+from . import (
+    InjectableRemoteScanner as FakeScanner,
+)
 from .conftest import FakeBluetoothAdapters, MockBluetoothManagerWithCallbacks
-
-
-class FakeScanner(BaseHaRemoteScanner):
-    """Fake scanner."""
-
-    def inject_advertisement(
-        self,
-        device: BLEDevice,
-        advertisement_data: AdvertisementData,
-        now: float | None = None,
-    ) -> None:
-        """Inject an advertisement."""
-        self._async_on_advertisement(
-            device.address,
-            advertisement_data.rssi,
-            device.name,
-            advertisement_data.service_uuids,
-            advertisement_data.service_data,
-            advertisement_data.manufacturer_data,
-            advertisement_data.tx_power,
-            {"scanner_specific_data": "test"},
-            now or monotonic_time_coarse(),
-        )
-
-    def inject_raw_advertisement(
-        self,
-        address: str,
-        rssi: int,
-        adv: bytes,
-        now: float | None = None,
-    ) -> None:
-        """Inject a raw advertisement."""
-        self._async_on_raw_advertisement(
-            address,
-            rssi,
-            adv,
-            {"scanner_specific_data": "test"},
-            now or monotonic_time_coarse(),
-        )
 
 
 @pytest.mark.parametrize("name_2", [None, "w"])

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -3,42 +3,18 @@
 import time
 
 import pytest
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-from bluetooth_data_tools import monotonic_time_coarse
 
-from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector, get_manager
+from habluetooth import HaBluetoothConnector, get_manager
 
+from . import (
+    InjectableRemoteScanner as _SeedFakeScanner,
+)
 from . import (
     MockBleakClient,
     generate_advertisement_data,
     generate_ble_device,
     inject_advertisement_with_source,
 )
-
-
-class _SeedFakeScanner(BaseHaRemoteScanner):
-    """Minimal remote scanner that exposes inject_advertisement for tests."""
-
-    def inject_advertisement(
-        self,
-        device: BLEDevice,
-        advertisement_data: AdvertisementData,
-        now: float | None = None,
-    ) -> None:
-        """Inject an advertisement through the scanner's normal entry point."""
-        self._async_on_advertisement(
-            device.address,
-            advertisement_data.rssi,
-            device.name,
-            advertisement_data.service_uuids,
-            advertisement_data.service_data,
-            advertisement_data.manufacturer_data,
-            advertisement_data.tx_power,
-            {"scanner_specific_data": "test"},
-            now or monotonic_time_coarse(),
-        )
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for the prefix-extension policy

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -15,9 +15,8 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakError
 from bleak_retry_connector import Allocations
-from bluetooth_data_tools import monotonic_time_coarse
 
-from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
+from habluetooth import HaBluetoothConnector
 from habluetooth import get_manager as _get_manager
 from habluetooth.manager import BluetoothManager
 from habluetooth.usage import (
@@ -28,6 +27,7 @@ from habluetooth.wrappers import HaBleakScannerWrapper
 
 from . import (
     HCI0_SOURCE_ADDRESS,
+    InjectableRemoteScanner,
     generate_advertisement_data,
     generate_ble_device,
     inject_advertisement,
@@ -43,8 +43,8 @@ def mock_shutdown(manager: BluetoothManager) -> Generator[None, None, None]:
     manager.shutdown = False
 
 
-class FakeScanner(BaseHaRemoteScanner):
-    """Fake scanner."""
+class FakeScanner(InjectableRemoteScanner):
+    """Wrappers-test scanner that empties _details for routing tests."""
 
     def __init__(
         self,
@@ -60,22 +60,6 @@ class FakeScanner(BaseHaRemoteScanner):
     def __repr__(self) -> str:
         """Return the representation."""
         return f"FakeScanner({self.name})"
-
-    def inject_advertisement(
-        self, device: BLEDevice, advertisement_data: AdvertisementData
-    ) -> None:
-        """Inject an advertisement."""
-        self._async_on_advertisement(
-            device.address,
-            advertisement_data.rssi,
-            device.name,
-            advertisement_data.service_uuids,
-            advertisement_data.service_data,
-            advertisement_data.manufacturer_data,
-            advertisement_data.tx_power,
-            device.details | {"scanner_specific_data": "test"},
-            monotonic_time_coarse(),
-        )
 
 
 class BaseFakeBleakClient:


### PR DESCRIPTION
## Summary

Three test files (test_base_scanner.py, test_name_cache.py, test_wrappers.py) each defined a tiny ``BaseHaRemoteScanner`` subclass with an ~12-line ``inject_advertisement`` body that was effectively identical apart from one of them merging ``device.details`` into the advertisement details. Consolidates them into ``InjectableRemoteScanner`` in tests/__init__.py (sibling to the existing ``MockBleakScanner`` base from #456). The unified helper falls back to ``(device.details or {})`` so callers that pass a ``details``-less device (test_base_scanner, test_name_cache) keep their existing behavior and the wrappers tests still get the DBus path key merged in. test_base_scanner and test_name_cache import it under the old name via ``InjectableRemoteScanner as FakeScanner`` / ``as _SeedFakeScanner`` so call sites are unchanged; test_wrappers narrows its local ``FakeScanner`` to the bits that actually differ (empty ``_details`` for routing tests plus ``__repr__``).

## Test plan

- [x] ``poetry run pytest tests/`` green (390 pass, 1 skip)
- [x] ``pre-commit run -a`` green