### PR TITLE
ci: enable ruff ERA (eradicate)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ select = [
     "D",    # flake8-docstrings
     "DTZ",  # flake8-datetimez
     "E",    # pycodestyle
+    "ERA",  # eradicate
     "EXE",  # flake8-executable
     "F",    # pyflake
     "FA",   # flake8-future-annotations

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -481,22 +481,22 @@ class MGMTBluetoothCtl:
             _LOGGER.error("Invalid MAC address: %s", address)
             return False
 
-        # Build command structure
+        # Build command structure (C definitions from BlueZ mgmt-api.txt):
         # struct mgmt_cp_load_conn_param {
         #     uint16_t param_count;
         #     struct mgmt_conn_param params[0];
-        # }
+        # };
         # struct mgmt_conn_param {
         #     struct mgmt_addr_info addr;
         #     uint16_t min_interval;
         #     uint16_t max_interval;
         #     uint16_t latency;
         #     uint16_t timeout;
-        # }
+        # };
         # struct mgmt_addr_info {
         #     bdaddr_t bdaddr;
         #     uint8_t type;
-        # }
+        # };
 
         # Get the appropriate connection parameters based on the enum
         if params is ConnectParams.FAST:

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -144,10 +144,10 @@ def test_data_received_device_found(
         future, scanners, on_connection_lost, is_shutting_down, mock_sock
     )
 
-    # Create a DEVICE_FOUND event (event_code 0x0012)
-    # Header: event_code (2), controller_idx (2), param_len (2)
-    # Params: address (6), address_type (1), rssi (1), flags (4),
-    # ad_data_len (2), ad_data
+    # Create a DEVICE_FOUND event (event_code 0x0012). Header layout is
+    # event_code (2), controller_idx (2), param_len (2); params layout
+    # is address (6), address_type (1), rssi (1), flags (4),
+    # ad_data_len (2), then ad_data.
     ad_data = b"\x02\x01\x06"  # Simple advertisement data
     param_len = 6 + 1 + 1 + 4 + 2 + len(ad_data)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1225,8 +1225,8 @@ async def test_set_fallback_interval_big() -> None:
         is None
     )
 
-    # Force the interval to be really big and check it doesn't expire using the default
-    # timeout (900)
+    # Force the interval to be really big and check it doesn't expire using
+    # the default timeout of 900 seconds.
 
     get_manager().async_set_fallback_availability_interval(
         "44:44:33:11:23:12", 604800.0

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1831,15 +1831,15 @@ async def test_connection_path_scoring_with_slots_and_logging(
                 assert "(slots=1/3 free)" in line
                 assert "(score=-63.8)" in line
 
-                # Scanner 2 has RSSI -65 with 2 slots free, no penalty:
-                # score = -65
+                # Scanner 2 has RSSI -65 with 2 slots free, no penalty, so
+                # the score is just -65.
                 assert "Scanner 2" in line
                 assert "(slots=2/3 free)" in line
                 # Check for both -65 and -65.0
                 assert ("(score=-65)" in line) or ("(score=-65.0)" in line)
 
-                # Scanner 3 has RSSI -70 with all slots free, no penalty:
-                # score = -70
+                # Scanner 3 has RSSI -70 with all slots free, no penalty, so
+                # the score is just -70.
                 assert "Scanner 3" in line
                 assert "(slots=3/3 free)" in line
                 # Check for both -70 and -70.0


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. All seven hits were false positives: BlueZ C struct definitions in bluez.py, the DEVICE_FOUND wire format crib in test_bluez, a stray timeout note in test_manager, and two score arithmetic comments in test_wrappers. Each comment is rephrased so ruff no longer reads the line as commented out code (struct definitions get a trailing semicolon, multi line notes are conjugated into a sentence) and the documentation stays in place.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)