### PR TITLE
ci: enable ruff PT (flake8-pytest-style)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ select = [
     "PERF", # Perflint
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
+    "PT",   # flake8-pytest-style
     "PTH",  # flake8-use-pathlib
     "PYI",  # flake8-pyi
     "Q",    # flake8-quotes

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -1268,12 +1268,15 @@ async def test_command_response_cleanup_on_exception() -> None:
     )
 
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
+
     # Test cleanup on exception
-    with pytest.raises(ValueError):
+    async def _raise_inside_command_response() -> None:
         async with protocol.command_response(opcode) as response_future:
-            # Verify we got a future
             assert response_future is not None
             raise ValueError("Test exception")
+
+    with pytest.raises(ValueError, match="Test exception"):
+        await _raise_inside_command_response()
 
     # The future should still exist after exception
     # (cleanup just removes it from internal tracking)

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -1342,7 +1342,8 @@ async def test_run_exits_when_scheduler_not_running() -> None:
         sched._running = False
         new_task = loop.create_task(worker._run())
         await asyncio.wait_for(new_task, timeout=1.0)
-        assert new_task.done() and not new_task.cancelled()
+        assert new_task.done()
+        assert not new_task.cancelled()
     finally:
         sched._running = True
         register_cancel()
@@ -1362,7 +1363,8 @@ async def test_run_exits_when_loop_detached() -> None:
         sched._loop = None
         new_task = asyncio.get_running_loop().create_task(worker._run())
         await asyncio.wait_for(new_task, timeout=1.0)
-        assert new_task.done() and not new_task.cancelled()
+        assert new_task.done()
+        assert not new_task.cancelled()
         sched._loop = original_loop
     finally:
         register_cancel()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -222,16 +222,15 @@ async def test_dbus_socket_missing_in_container(
         patch(
             "habluetooth.scanner.OriginalBleakScanner.stop",
         ) as mock_stop,
-        pytest.raises(
-            ScannerStartError,
-            match="DBus service not found; docker config may be missing",
-        ),
     ):
         scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
         scanner.async_setup()
-        await scanner.async_start()
+        with pytest.raises(
+            ScannerStartError,
+            match="DBus service not found; docker config may be missing",
+        ):
+            await scanner.async_start()
         assert mock_stop.called
-        await scanner.async_stop()
 
 
 @pytest.mark.asyncio
@@ -247,16 +246,15 @@ async def test_dbus_socket_missing(caplog: pytest.LogCaptureFixture) -> None:
         patch(
             "habluetooth.scanner.OriginalBleakScanner.stop",
         ) as mock_stop,
-        pytest.raises(
-            ScannerStartError,
-            match="DBus service not found; make sure the DBus socket is available",
-        ),
     ):
         scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
         scanner.async_setup()
-        await scanner.async_start()
+        with pytest.raises(
+            ScannerStartError,
+            match="DBus service not found; make sure the DBus socket is available",
+        ):
+            await scanner.async_start()
         assert mock_stop.called
-        await scanner.async_stop()
 
 
 @pytest.mark.asyncio
@@ -321,13 +319,12 @@ async def test_dbus_broken_pipe_in_container(caplog: pytest.LogCaptureFixture) -
         patch(
             "habluetooth.scanner.OriginalBleakScanner.stop",
         ) as mock_stop,
-        pytest.raises(ScannerStartError, match="DBus connection broken"),
     ):
         scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
         scanner.async_setup()
-        await scanner.async_start()
+        with pytest.raises(ScannerStartError, match="DBus connection broken"):
+            await scanner.async_start()
         assert mock_stop.called
-        await scanner.async_stop()
 
 
 @pytest.mark.asyncio
@@ -343,30 +340,26 @@ async def test_dbus_broken_pipe(caplog: pytest.LogCaptureFixture) -> None:
         patch(
             "habluetooth.scanner.OriginalBleakScanner.stop",
         ) as mock_stop,
-        pytest.raises(ScannerStartError, match="DBus connection broken:"),
     ):
         scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
         scanner.async_setup()
-        await scanner.async_start()
+        with pytest.raises(ScannerStartError, match="DBus connection broken:"):
+            await scanner.async_start()
         assert mock_stop.called
-        await scanner.async_stop()
 
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(NOT_POSIX)
 async def test_invalid_dbus_message(caplog: pytest.LogCaptureFixture) -> None:
     """Test we handle invalid dbus message."""
-    with (
-        patch(
-            "habluetooth.scanner.OriginalBleakScanner.start",
-            side_effect=InvalidMessageError,
-        ),
-        pytest.raises(ScannerStartError, match="Invalid DBus message received"),
+    with patch(
+        "habluetooth.scanner.OriginalBleakScanner.start",
+        side_effect=InvalidMessageError,
     ):
         scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
         scanner.async_setup()
-        await scanner.async_start()
-        await scanner.async_stop()
+        with pytest.raises(ScannerStartError, match="Invalid DBus message received"):
+            await scanner.async_start()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Nine fixes across three rules.

PT012 (6): the BlueZ recovery and dbus error tests in test_scanner and the cleanup test in test_bluez had patches and pytest.raises in one with group with extra assertions inside the raises body. Split so the patches stay in the outer with, pytest.raises wraps just the raising call, and the post raise asserts move out of the unreachable region.

PT011 (1): the ValueError raises in test_bluez now carries a match parameter ("Test exception").

PT018 (2): the `new_task.done() and not new_task.cancelled()` conjunctions in two test_auto_scheduler cases split into two asserts.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)