### PR TITLE
ci: enable ruff TID (flake8-tidy-imports)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ select = [
     "T10",  # flake8-debugger
     "T20",  # flake8-print
     "TD",   # flake8-todos
+    "TID",  # flake8-tidy-imports
     "UP",   # pyupgrade
     "W",    # pycodestyle
     "YTT",  # flake8-2020

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, cast
 from btsocket import btmgmt_socket
 from btsocket.btmgmt_socket import BluetoothSocketError
 
-from ..const import (
+from habluetooth.const import (
     FAST_CONN_LATENCY,
     FAST_CONN_TIMEOUT,
     FAST_MAX_CONN_INTERVAL,
@@ -23,7 +23,7 @@ from ..const import (
     MEDIUM_MIN_CONN_INTERVAL,
     ConnectParams,
 )
-from ..scanner import HaScanner
+from habluetooth.scanner import HaScanner
 
 _LOGGER = logging.getLogger(__name__)
 _int = int


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Two relative imports in channels/bluez.py (`from ..const` and `from ..scanner`) become absolute (`from habluetooth.const` and `from habluetooth.scanner`).

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)