### PR TITLE
ci: enable ruff TC (flake8-type-checking)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ select = [
     "SLOT", # flake8-slots
     "T10",  # flake8-debugger
     "T20",  # flake8-print
+    "TC",   # flake8-type-checking
     "TD",   # flake8-todos
     "UP",   # pyupgrade
     "W",    # pycodestyle

--- a/src/habluetooth/advertisement_tracker.py
+++ b/src/habluetooth/advertisement_tracker.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from .models import BluetoothServiceInfoBleak
+if TYPE_CHECKING:
+    from .models import BluetoothServiceInfoBleak
 
 ADVERTISING_TIMES_NEEDED = 16
 _ADVERTISING_TIMES_NEEDED = ADVERTISING_TIMES_NEEDED

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import warnings
-from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Final, final
 
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
 from bleak_retry_connector import NO_RSSI_VALUE, Allocations
 from bluetooth_adapters import adapter_human_name
 from bluetooth_data_tools import monotonic_time_coarse, parse_advertisement_data_bytes
@@ -29,8 +27,14 @@ from .models import (
     HaScannerDetails,
     HaScannerType,
 )
-from .scanner_device import BluetoothScannerDevice
 from .storage import DiscoveredDeviceAdvertisementData
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from bleak.backends.scanner import AdvertisementData
+
+    from .scanner_device import BluetoothScannerDevice
 
 SCANNER_WATCHDOG_INTERVAL_SECONDS: Final = SCANNER_WATCHDOG_INTERVAL.total_seconds()
 _LOGGER = logging.getLogger(__name__)

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import socket
 from asyncio import timeout as asyncio_timeout
-from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from struct import Struct
 from typing import TYPE_CHECKING, cast
@@ -23,7 +21,12 @@ from ..const import (
     MEDIUM_MIN_CONN_INTERVAL,
     ConnectParams,
 )
-from ..scanner import HaScanner
+
+if TYPE_CHECKING:
+    import socket
+    from collections.abc import AsyncIterator, Callable
+
+    from ..scanner import HaScanner
 
 _LOGGER = logging.getLogger(__name__)
 _int = int
@@ -89,7 +92,7 @@ class BluetoothMGMTProtocol:
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """Handle connection made."""
         _set_future_if_not_done(self.connection_made_future)
-        self.transport = cast(asyncio.Transport, transport)
+        self.transport = cast("asyncio.Transport", transport)
 
     def _write_to_socket(self, data: bytes) -> None:
         """
@@ -357,7 +360,7 @@ class MGMTBluetoothCtl:
             btmgmt_socket.close(self.sock)
             raise
         _LOGGER.debug("Bluetooth management socket connection established")
-        self.protocol = cast(BluetoothMGMTProtocol, protocol)
+        self.protocol = cast("BluetoothMGMTProtocol", protocol)
         self._on_connection_lost_future = loop.create_future()
 
     def _has_mgmt_capabilities_from_status(self, status: int) -> bool:

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -7,12 +7,10 @@ import itertools
 import logging
 import math
 import platform
-from collections.abc import Callable, Iterable
 from dataclasses import asdict
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final
 
-from bleak.backends.scanner import AdvertisementDataCallback
 from bleak_retry_connector import (
     NO_RSSI_VALUE,
     AllocationChangeEvent,
@@ -57,8 +55,10 @@ from .usage import install_multiple_bleak_catcher, uninstall_multiple_bleak_catc
 from .util import async_reset_adapter
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from bleak.backends.device import BLEDevice
-    from bleak.backends.scanner import AdvertisementData
+    from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
 
     from .base_scanner import BaseHaScanner
     from .scanner import HaScanner

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Self
 
-from bleak import BaseBleakClient
-from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak_retry_connector import NO_RSSI_VALUE
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bleak import BaseBleakClient
+    from bleak.backends.device import BLEDevice
+
     from .base_scanner import BaseHaScanner
 
 

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -7,7 +7,6 @@ import contextlib
 import logging
 import math
 import platform
-from collections.abc import Coroutine, Iterable
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, no_type_check
 
@@ -15,8 +14,6 @@ import async_interrupt
 import bleak
 from bleak import BleakError
 from bleak.assigned_numbers import AdvertisementDataType
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
 from bleak_retry_connector import Allocations, restore_discoveries
 from bleak_retry_connector.bluez import stop_discovery
 from bluetooth_adapters import DEFAULT_ADDRESS
@@ -33,6 +30,12 @@ from .const import (
 )
 from .models import BluetoothScanningMode, BluetoothServiceInfoBleak
 from .util import async_reset_adapter, is_docker_env
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine, Iterable
+
+    from bleak.backends.device import BLEDevice
+    from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
 
 int_ = int
 

--- a/src/habluetooth/scanner_device.py
+++ b/src/habluetooth/scanner_device.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-
 if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
+    from bleak.backends.scanner import AdvertisementData
+
     from .base_scanner import BaseHaScanner
 
 

--- a/src/habluetooth/usage.py
+++ b/src/habluetooth/usage.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import bleak
 import bleak_retry_connector
-from bleak.backends.service import BleakGATTServiceCollection
 
 from .wrappers import HaBleakClientWrapper, HaBleakScannerWrapper
+
+if TYPE_CHECKING:
+    from bleak.backends.service import BleakGATTServiceCollection
 
 ORIGINAL_BLEAK_SCANNER = bleak.BleakScanner
 ORIGINAL_BLEAK_CLIENT = bleak.BleakClient

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -7,20 +7,13 @@ import contextlib
 import inspect
 import logging
 import warnings
-from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final, Literal, Self, overload
 
 from bleak import BleakClient, BleakError, normalize_uuid_str
-from bleak.backends import BleakBackend
 from bleak.backends.client import BaseBleakClient, get_platform_client_backend_type
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import (
-    AdvertisementData,
-    AdvertisementDataCallback,
-    AdvertisementDataFilter,
-)
 from bleak_retry_connector import (
     ble_device_description,
     clear_cache,
@@ -51,6 +44,15 @@ def _get_device_address_type(device: BLEDevice) -> int:
 
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable
+
+    from bleak.backends import BleakBackend
+    from bleak.backends.scanner import (
+        AdvertisementData,
+        AdvertisementDataCallback,
+        AdvertisementDataFilter,
+    )
+
     from .base_scanner import BaseHaScanner
     from .manager import BluetoothManager
 

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import pytest
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
 
 from habluetooth import (
     BaseHaScanner,
@@ -26,6 +24,12 @@ from habluetooth.const import (
 )
 
 from . import generate_advertisement_data, generate_ble_device
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from bleak.backends.device import BLEDevice
+    from bleak.backends.scanner import AdvertisementData
 
 
 class _RecordingAutoScanner(BaseHaScanner):

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from bleak.backends.scanner import AdvertisementData
 from bluetooth_data_tools import monotonic_time_coarse
-from pytest_codspeed import BenchmarkFixture
 
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector, get_manager
 from habluetooth.channels.bluez import BluetoothMGMTProtocol
@@ -20,6 +19,10 @@ from . import (
     generate_advertisement_data,
     generate_ble_device,
 )
+
+if TYPE_CHECKING:
+    from bleak.backends.scanner import AdvertisementData
+    from pytest_codspeed import BenchmarkFixture
 
 pytestmark = pytest.mark.timeout(60)
 

--- a/tests/test_central_manager.py
+++ b/tests/test_central_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -11,6 +11,9 @@ from habluetooth.central_manager import (
     get_manager,
     set_manager,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @pytest.fixture

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from habluetooth.util import async_reset_adapter, is_docker_env
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @pytest.fixture

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -4,21 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager, suppress
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import bleak
 import pytest
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakError
 from bleak_retry_connector import Allocations
 
 from habluetooth import HaBluetoothConnector
 from habluetooth import get_manager as _get_manager
-from habluetooth.manager import BluetoothManager
 from habluetooth.usage import (
     install_multiple_bleak_catcher,
     uninstall_multiple_bleak_catcher,
@@ -33,6 +30,13 @@ from . import (
     inject_advertisement,
     patch_discovered_devices,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Generator
+
+    from bleak.backends.scanner import AdvertisementData
+
+    from habluetooth.manager import BluetoothManager
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. 42 fixes across the package and the test suite, all auto applied: typing only imports move under `if TYPE_CHECKING:` (TC001, TC002, TC003), and two `cast()` call sites quote the type expression (TC006).

Safe for the cython build because every module that has a paired .pxd does its real type wiring through `cimport`; the Python level imports were already only used for type annotations, and `from __future__ import annotations` was already in effect, so runtime never resolved the names. Both the cython and pure python test runs pass (390 pass, 1 skip).

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green on cython build (390 pass, 1 skip)
- [x] `SKIP_CYTHON=1 poetry run pytest tests/` green on pure python (390 pass, 1 skip)