### PR TITLE
ci: enable ruff EM (flake8-errmsg)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ select = [
     "D",    # flake8-docstrings
     "DTZ",  # flake8-datetimez
     "E",    # pycodestyle
+    "EM",   # flake8-errmsg
     "ERA",  # eradicate
     "EXE",  # flake8-executable
     "F",    # pyflake

--- a/src/habluetooth/central_manager.py
+++ b/src/habluetooth/central_manager.py
@@ -17,7 +17,8 @@ class CentralBluetoothManager:
 def get_manager() -> BluetoothManager:
     """Get the BluetoothManager."""
     if CentralBluetoothManager.manager is None:
-        raise RuntimeError("BluetoothManager has not been set")
+        msg = "BluetoothManager has not been set"
+        raise RuntimeError(msg)
     return CentralBluetoothManager.manager
 
 

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -447,9 +447,8 @@ class MGMTBluetoothCtl:
             if self.protocol and self.protocol.transport:
                 self.protocol.transport.close()
             btmgmt_socket.close(self.sock)
-            raise PermissionError(
-                "Missing NET_ADMIN/NET_RAW capabilities for Bluetooth management"
-            )
+            msg = "Missing NET_ADMIN/NET_RAW capabilities for Bluetooth management"
+            raise PermissionError(msg)
 
         self._reconnect_task = asyncio.create_task(self.reconnect_task())
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1096,7 +1096,8 @@ class BluetoothManager:
         ignore the request. Returns a cancel callable.
         """
         if not address:
-            raise ValueError("address must be a non-empty string")
+            msg = "address must be a non-empty string"
+            raise ValueError(msg)
         if scan_interval is None:
             scan_interval = DEFAULT_ACTIVE_SCAN_INTERVAL
         if scan_duration is None:
@@ -1106,15 +1107,17 @@ class BluetoothManager:
         # checks below and end up in _needs and call_later as a NaN
         # due-time / duration, busy-looping the worker.
         if not math.isfinite(scan_interval) or scan_interval < MIN_ACTIVE_SCAN_INTERVAL:
-            raise ValueError(
+            msg = (
                 f"scan_interval must be a finite number >= "
                 f"{MIN_ACTIVE_SCAN_INTERVAL:.0f}s"
             )
+            raise ValueError(msg)
         if not math.isfinite(scan_duration) or scan_duration < MIN_ACTIVE_SCAN_DURATION:
-            raise ValueError(
+            msg = (
                 f"scan_duration must be a finite number >= "
                 f"{MIN_ACTIVE_SCAN_DURATION:.0f}s"
             )
+            raise ValueError(msg)
         # MAC addresses (colon-form) get upper-cased to match BlueZ /
         # ESPHome conventions; UUIDs (macOS CoreBluetooth) pass
         # through as-is.

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -182,7 +182,8 @@ def create_bleak_scanner(
     try:
         return OriginalBleakScanner(**scanner_kwargs)
     except (FileNotFoundError, BleakError) as ex:
-        raise RuntimeError(f"Failed to initialize Bluetooth: {ex}") from ex
+        msg = f"Failed to initialize Bluetooth: {ex}"
+        raise RuntimeError(msg) from ex
 
 
 def _error_indicates_reset_needed(error_str: str) -> bool:
@@ -475,11 +476,12 @@ class HaScanner(BaseHaScanner):
             if attempt < START_ATTEMPTS:
                 self._log_start_timeout(attempt)
                 return False
-            raise ScannerStartError(
+            msg = (
                 f"{self.name}: Timed out starting Bluetooth after"
                 f" {START_TIMEOUT} seconds; "
                 "Try power cycling the Bluetooth hardware."
-            ) from ex
+            )
+            raise ScannerStartError(msg) from ex
         except BleakError as ex:
             await self._async_stop_scanner()
             error_str = str(ex)
@@ -499,10 +501,11 @@ class HaScanner(BaseHaScanner):
             if attempt < START_ATTEMPTS:
                 self._log_start_failed(ex, attempt)
                 return False
-            raise ScannerStartError(
+            msg = (
                 f"{self.name}: Failed to start Bluetooth: {ex}; "
                 "Try power cycling the Bluetooth hardware."
-            ) from ex
+            )
+            raise ScannerStartError(msg) from ex
         except BaseException:
             await self._async_stop_scanner()
             raise
@@ -588,14 +591,16 @@ class HaScanner(BaseHaScanner):
             exc_info=ex,
         )
         if is_docker_env():
-            raise ScannerStartError(
+            msg = (
                 f"{self.name}: DBus service not found; docker config may "
                 "be missing `-v /run/dbus:/run/dbus:ro`: {ex}"
-            ) from ex
-        raise ScannerStartError(
+            )
+            raise ScannerStartError(msg) from ex
+        msg = (
             f"{self.name}: DBus service not found; make sure the DBus socket "
             f"is available: {ex}"
-        ) from ex
+        )
+        raise ScannerStartError(msg) from ex
 
     def _raise_for_broken_pipe_error(self, ex: BrokenPipeError) -> None:
         """Raise a ScannerStartError for a BrokenPipeError."""

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -426,7 +426,8 @@ class HaBleakClientWrapper(BleakClient):
 
         manager = self.__manager
         if manager.shutdown:
-            raise BleakError("Bluetooth is already shutdown")
+            msg = "Bluetooth is already shutdown"
+            raise BleakError(msg)
         if debug_logging := _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug("%s: Looking for backend to connect", self.__address)
         wrapped_backend = self._async_get_best_available_backend_and_device(manager)
@@ -639,17 +640,19 @@ class HaBleakClientWrapper(BleakClient):
 
             if not has_active_capable_scanner:
                 scanner_names = [scanner.name for scanner in scanners]
-                raise BleakError(
+                msg = (
                     f"{address}: No connectable Bluetooth adapters. "
                     f"Shelly devices are passive-only and cannot connect. "
                     f"Need local Bluetooth adapter or ESPHome proxy. "
                     f"Available: {', '.join(scanner_names)}"
                 )
+                raise BleakError(msg)
 
-        raise BleakError(
+        msg = (
             "No backend with an available connection slot that can reach address"
             f" {address} was found"
         )
+        raise BleakError(msg)
 
     async def disconnect(self) -> None:
         """Disconnect from the device."""

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -1126,7 +1126,8 @@ async def test_reconnect_task() -> None:
             ctl._on_connection_lost_future = asyncio.get_running_loop().create_future()
         elif establish_count == 2:
             # Second call fails
-            raise BluetoothSocketError("Test error")
+            msg = "Test error"
+            raise BluetoothSocketError(msg)
         else:
             # Stop the test
             raise asyncio.CancelledError
@@ -1157,7 +1158,8 @@ async def test_reconnect_task_timeout() -> None:
     """Test reconnect_task with connection timeout."""
 
     async def mock_establish_connection() -> None:
-        raise TimeoutError("Connection timeout")
+        msg = "Connection timeout"
+        raise TimeoutError(msg)
 
     ctl = MGMTBluetoothCtl(5.0, {})
     ctl._on_connection_lost_future = None
@@ -1187,7 +1189,8 @@ async def test_reconnect_task_shutdown() -> None:
         nonlocal establish_called
         establish_called = True
         # Should not be called since we're shutting down
-        raise Exception("Should not be called")
+        msg = "Should not be called"
+        raise Exception(msg)
 
     with patch.object(
         ctl, "_establish_connection", side_effect=mock_establish_connection
@@ -1273,7 +1276,8 @@ async def test_command_response_cleanup_on_exception() -> None:
     async def _raise_inside_command_response() -> None:
         async with protocol.command_response(opcode) as response_future:
             assert response_future is not None
-            raise ValueError("Test exception")
+            msg = "Test exception"
+            raise ValueError(msg)
 
     with pytest.raises(ValueError, match="Test exception"):
         await _raise_inside_command_response()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -830,7 +830,8 @@ async def test_run_window_swallows_scanner_exception() -> None:
 
     class _FailingScanner(_RecordingAutoScanner):
         async def async_request_active_window(self, duration: float) -> bool:
-            raise RuntimeError("boom")
+            msg = "boom"
+            raise RuntimeError(msg)
 
     scanner = _FailingScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
@@ -864,7 +865,8 @@ async def test_repeated_window_failures_log_only_first_traceback(
 
     class _FailingScanner(_RecordingAutoScanner):
         async def async_request_active_window(self, duration: float) -> bool:
-            raise RuntimeError("boom")
+            msg = "boom"
+            raise RuntimeError(msg)
 
     scanner = _FailingScanner("AA:BB:CC:DD:EE:11", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
@@ -913,7 +915,8 @@ async def test_tick_sync_phase_exception_is_logged_and_worker_survives(
         original = manager.async_last_service_info
 
         def _boom(_addr: str, _conn: bool) -> None:
-            raise RuntimeError("boom in last_service_info")
+            msg = "boom in last_service_info"
+            raise RuntimeError(msg)
 
         manager.async_last_service_info = _boom  # type: ignore[assignment,method-assign]
         try:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -187,7 +187,8 @@ async def test_async_register_disappeared_callback(
     def _failing_callback(_address: str) -> None:
         """Failing callback."""
         failed_disappeared.append(_address)
-        raise ValueError("This is a test")
+        msg = "This is a test"
+        raise ValueError(msg)
 
     ok_disappeared: list[str] = []
 
@@ -258,7 +259,8 @@ async def test_async_register_allocation_callback(
     def _failing_callback(allocations: HaBluetoothSlotAllocations) -> None:
         """Failing callback."""
         failed_allocations.append(allocations)
-        raise ValueError("This is a test")
+        msg = "This is a test"
+        raise ValueError(msg)
 
     ok_allocations: list[HaBluetoothSlotAllocations] = []
 
@@ -380,7 +382,8 @@ async def test_async_register_scanner_registration_callback(
     def _failing_callback(scanner_registration: HaScannerRegistration) -> None:
         """Failing callback."""
         failed_scanner_callbacks.append(scanner_registration)
-        raise ValueError("This is a test")
+        msg = "This is a test"
+        raise ValueError(msg)
 
     ok_scanner_callbacks: list[HaScannerRegistration] = []
 
@@ -435,7 +438,8 @@ async def test_async_register_scanner_mode_change_callback(
     def _failing_callback(mode_change: HaScannerModeChange) -> None:
         """Failing callback."""
         failed_mode_callbacks.append(mode_change)
-        raise ValueError("This is a test")
+        msg = "This is a test"
+        raise ValueError(msg)
 
     ok_mode_callbacks: list[HaScannerModeChange] = []
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -607,7 +607,8 @@ async def test_adapter_scanner_fails_to_start_first_time() -> None:
             if called_start == 1:
                 return
             if called_start < 4:
-                raise BleakError("Failed to start")
+                msg = "Failed to start"
+                raise BleakError(msg)
 
         async def stop(self, *args: object, **kwargs: object) -> None:
             nonlocal called_stop
@@ -716,11 +717,14 @@ async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
             nonlocal called_start
             called_start += 1
             if called_start == 1:
-                raise BleakError("org.freedesktop.DBus.Error.UnknownObject")
+                msg = "org.freedesktop.DBus.Error.UnknownObject"
+                raise BleakError(msg)
             if called_start == 2:
-                raise BleakError("org.bluez.Error.InProgress")
+                msg = "org.bluez.Error.InProgress"
+                raise BleakError(msg)
             if called_start == 3:
-                raise BleakError("org.bluez.Error.InProgress")
+                msg = "org.bluez.Error.InProgress"
+                raise BleakError(msg)
 
         async def stop(self, *args: object, **kwargs: object) -> None:
             nonlocal called_stop
@@ -869,11 +873,14 @@ async def test_adapter_init_fails_fallback_to_passive(
             nonlocal called_start
             called_start += 1
             if called_start == 1:
-                raise BleakError("org.freedesktop.DBus.Error.UnknownObject")
+                msg = "org.freedesktop.DBus.Error.UnknownObject"
+                raise BleakError(msg)
             if called_start == 2:
-                raise BleakError("org.bluez.Error.InProgress")
+                msg = "org.bluez.Error.InProgress"
+                raise BleakError(msg)
             if called_start == 3:
-                raise BleakError("org.bluez.Error.InProgress")
+                msg = "org.bluez.Error.InProgress"
+                raise BleakError(msg)
 
         async def stop(self, *args: object, **kwargs: object) -> None:
             nonlocal called_stop
@@ -1794,7 +1801,8 @@ async def test_async_toggle_active_window_mode_returns_false_on_stop_error() -> 
 
     class StopErrorMockBleakScanner(MockBleakScanner):
         async def stop(self) -> None:
-            raise BleakError("simulated stop failure")
+            msg = "simulated stop failure"
+            raise BleakError(msg)
 
     with patch_bleak_scanner_factory(StopErrorMockBleakScanner):
         scanner_obj = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:FF")
@@ -1829,7 +1837,8 @@ async def test_async_toggle_active_window_mode_marks_not_scanning_on_start_error
             # First start (initial async_start) succeeds; the
             # post-flip start (second call) raises.
             if starts > 1:
-                raise BleakError("simulated start failure")
+                msg = "simulated start failure"
+                raise BleakError(msg)
 
     with patch_bleak_scanner_factory(StartErrorMockBleakScanner):
         scanner_obj = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:FF")
@@ -1860,11 +1869,13 @@ async def test_async_toggle_active_window_mode_attribute_error_marks_not_scannin
     class MockBackend:
         @property
         def _scanning_mode(self) -> str:
-            raise AttributeError("simulated bleak refactor — attribute removed")
+            msg = "simulated bleak refactor — attribute removed"
+            raise AttributeError(msg)
 
         @_scanning_mode.setter
         def _scanning_mode(self, value: str) -> None:
-            raise AttributeError("simulated bleak refactor — attribute removed")
+            msg = "simulated bleak refactor — attribute removed"
+            raise AttributeError(msg)
 
     class AttrErrorMockBleakScanner(MockBleakScanner):
         def __init__(self) -> None:
@@ -2148,7 +2159,8 @@ async def test_async_request_active_window_recovers_on_start_failure() -> None:
             nonlocal call_count
             call_count += 1
             if call_count <= fail_until:
-                raise BleakError("simulated start failure")
+                msg = "simulated start failure"
+                raise BleakError(msg)
 
     with patch_bleak_scanner_factory(_CountingFailScanner):
         scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:FF")
@@ -2191,7 +2203,8 @@ async def test_async_request_active_window_clears_override_on_unexpected_error()
             # raises a non-ScannerStartError so we exercise the
             # broad-except cleanup path.
             if start_count > 1:
-                raise RuntimeError("simulated unexpected error")
+                msg = "simulated unexpected error"
+                raise RuntimeError(msg)
 
     with patch_bleak_scanner_factory(_UnexpectedErrorAfterFirstScanner):
         scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:FF")
@@ -2304,7 +2317,8 @@ async def test_async_request_active_window_passive_fallback_on_linux() -> None:
             # Fail the first three attempts so the 4th-attempt PASSIVE
             # fallback inside _async_start_attempt kicks in.
             if 2 <= starts <= 4:
-                raise BleakError("simulated active failure")
+                msg = "simulated active failure"
+                raise BleakError(msg)
 
     with (
         patch("habluetooth.scanner.IS_LINUX", True),
@@ -2337,7 +2351,8 @@ async def test_async_end_active_window_handles_start_error(
             nonlocal starts
             starts += 1
             if starts <= fail_until:
-                raise BleakError("simulated end-window failure")
+                msg = "simulated end-window failure"
+                raise BleakError(msg)
 
     with patch_bleak_scanner_factory(_FailUntilThresholdScanner):
         scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:FF")
@@ -2538,7 +2553,8 @@ async def test_start_attempt_timeout_resets_then_raises_on_exhaustion(
 
     class TimeoutMockBleakScanner(MockBleakScanner):
         async def start(self) -> None:
-            raise TimeoutError("simulated start timeout")
+            msg = "simulated start timeout"
+            raise TimeoutError(msg)
 
     with patch_bleak_scanner_factory(TimeoutMockBleakScanner):
         ha_scanner = _RecordingResetScanner(
@@ -2570,7 +2586,8 @@ async def test_async_restart_scanner_logs_when_start_raises(
 
     class _RaisingRestartScanner(HaScanner):
         async def _async_start(self) -> None:
-            raise ScannerStartError("simulated restart failure")
+            msg = "simulated restart failure"
+            raise ScannerStartError(msg)
 
         async def _async_stop_scanner(self) -> None:
             pass
@@ -2636,7 +2653,8 @@ async def test_async_request_active_window_restart_path_scanner_start_error() ->
             # restart attempt exhaust, raising ScannerStartError,
             # which the abort path then suppresses.
             if starts > 1:
-                raise BleakError("simulated start failure")
+                msg = "simulated start failure"
+                raise BleakError(msg)
 
     class _NoResetScanner(HaScanner):
         async def _async_reset_adapter(self, gone_silent: bool) -> None:
@@ -2673,7 +2691,8 @@ async def test_async_request_active_window_restart_path_unexpected_error() -> No
     class _MaybeRaiseRestartScanner(HaScanner):
         async def _async_stop_then_start_under_lock(self) -> None:
             if raise_on_restart:
-                raise RuntimeError("simulated unexpected error")
+                msg = "simulated unexpected error"
+                raise RuntimeError(msg)
 
     with patch_bleak_scanner_factory(MockBleakScanner):
         ha_scanner = _MaybeRaiseRestartScanner(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -381,7 +381,8 @@ def test_discovered_device_advertisement_data_from_dict_unexpected_error(
     """Unexpected errors keep the full traceback and are logged at ERROR."""
 
     def boom(_data):
-        raise RuntimeError("boom")
+        msg = "boom"
+        raise RuntimeError(msg)
 
     monkeypatch.setattr(
         "habluetooth.storage._deserialize_discovered_device_advertisement_datas",

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -113,7 +113,8 @@ class FakeBleakClientRaisesOnConnect(BaseFakeBleakClient):
 
     async def connect(self, *args, **kwargs):
         """Connect."""
-        raise ConnectionError("Test exception")
+        msg = "Test exception"
+        raise ConnectionError(msg)
 
 
 class FakeBleakClientCancelledOnConnect(BaseFakeBleakClient):
@@ -483,7 +484,8 @@ async def test_switch_adapters_on_failure(
             """Connect."""
             assert isinstance(self._device, BLEDevice)
             if "/hci0/" in self._device.details["path"]:
-                raise BleakError("Failed to connect on hci0")
+                msg = "Failed to connect on hci0"
+                raise BleakError(msg)
 
         @property
         def is_connected(self) -> bool:
@@ -496,7 +498,8 @@ async def test_switch_adapters_on_failure(
             """Connect."""
             assert isinstance(self._device, BLEDevice)
             if "/hci1/" in self._device.details["path"]:
-                raise BleakError("Failed to connect on hci1")
+                msg = "Failed to connect on hci1"
+                raise BleakError(msg)
 
         @property
         def is_connected(self) -> bool:
@@ -1713,7 +1716,8 @@ async def test_connection_path_scoring_with_slots_and_logging(
 
         async def connect(self, *args, **kwargs):
             """Don't actually connect."""
-            raise BleakError("Test - connection not needed")
+            msg = "Test - connection not needed"
+            raise BleakError(msg)
 
     # Create fake connectors
     fake_connector_1 = HaBluetoothConnector(
@@ -1854,7 +1858,8 @@ async def test_connection_path_scoring_no_slots_available(
 
         async def connect(self, *args, **kwargs):
             """Don't actually connect."""
-            raise BleakError("Test - connection not needed")
+            msg = "Test - connection not needed"
+            raise BleakError(msg)
 
     # Create fake connectors
     fake_connector_1 = HaBluetoothConnector(


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. 49 sites (40 EM101 string literal in raise, 9 EM102 f-string in raise) across the package and tests are auto fixed; each `raise Foo(...)` hoists its message into a local `msg = ...` variable so the traceback shows the message text on its own line rather than inside the constructor call.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)