### PR TITLE
ci: enable ruff TRY (tryceratops)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ ignore = [
     "D107",    # Missing docstring in `__init__`
     "D401",    # First line of docstring should be in imperative mood
     "ASYNC109", # ``timeout`` is part of our bleak-compatible public API
+    "TRY003",  # too many to fix; long messages outside the exception class
 ]
 select = [
     "A",    # flake8-builtins
@@ -163,6 +164,7 @@ select = [
     "T20",  # flake8-print
     "TC",   # flake8-type-checking
     "TD",   # flake8-todos
+    "TRY",  # tryceratops
     "UP",   # pyupgrade
     "W",    # pycodestyle
     "YTT",  # flake8-2020

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -116,8 +116,8 @@ class BluetoothMGMTProtocol:
                     "Bluetooth mgmt socket returned 0 for %d bytes (kernel bug fix)",
                     len(data),
                 )
-        except Exception as exc:
-            _LOGGER.error("Failed to write to mgmt socket: %s", exc)
+        except Exception:
+            _LOGGER.exception("Failed to write to mgmt socket")
             raise
 
     @asynccontextmanager
@@ -539,10 +539,11 @@ class MGMTBluetoothCtl:
                 latency,
                 timeout,
             )
-            return True
         except Exception:
             _LOGGER.exception("Failed to load conn params")
             return False
+        else:
+            return True
 
     def load_conn_params_explicit(
         self,
@@ -608,7 +609,8 @@ class MGMTBluetoothCtl:
                 latency,
                 timeout,
             )
-            return True
         except Exception:
             _LOGGER.exception("Failed to load conn params")
             return False
+        else:
+            return True

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -377,12 +377,11 @@ class BluetoothManager:
         self._mgmt_ctl = MGMTBluetoothCtl(10.0, self._side_channel_scanners)
         try:
             await self._mgmt_ctl.setup()
-        except PermissionError as ex:
-            _LOGGER.error(
-                "Missing required permissions for Bluetooth management: %s. "
+        except PermissionError:
+            _LOGGER.exception(
+                "Missing required permissions for Bluetooth management. "
                 "Automatic adapter recovery is unavailable. "
-                "Add NET_ADMIN and NET_RAW capabilities to the container to enable it",
-                ex,
+                "Add NET_ADMIN and NET_RAW capabilities to the container to enable it"
             )
             self._mgmt_ctl = None
         except CONNECTION_ERRORS as ex:

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -664,11 +664,10 @@ class HaScanner(BaseHaScanner):
                 await self._async_reset_adapter(True)
             try:
                 await self._async_start()
-            except ScannerStartError as ex:
+            except ScannerStartError:
                 _LOGGER.exception(
-                    "%s: Failed to restart Bluetooth scanner: %s",
+                    "%s: Failed to restart Bluetooth scanner",
                     self.name,
-                    ex,
                 )
 
     async def _async_reset_adapter(self, gone_silent: bool) -> None:
@@ -948,11 +947,11 @@ class HaScanner(BaseHaScanner):
         try:
             async with asyncio.timeout(STOP_TIMEOUT):
                 await self.scanner.stop()
-        except (TimeoutError, BleakError) as ex:
+        except (TimeoutError, BleakError):
             # This is not fatal, and they may want to reload
             # the config entry to restart the scanner if they
             # change the bluetooth dongle.
-            _LOGGER.error("%s: Error stopping scanner: %s", self.name, ex)
+            _LOGGER.exception("%s: Error stopping scanner", self.name)
         self.scanner = None
 
     async def _async_force_stop_discovery(self) -> None:
@@ -961,10 +960,10 @@ class HaScanner(BaseHaScanner):
         try:
             async with asyncio.timeout(STOP_TIMEOUT):
                 await stop_discovery(self.adapter)
-        except TimeoutError as ex:
-            _LOGGER.error("%s: Timeout force stopping scanner: %s", self.name, ex)
-        except Exception as ex:  # noqa: BLE001
+        except TimeoutError:
+            _LOGGER.exception("%s: Timeout force stopping scanner", self.name)
+        except Exception:
             # Best-effort BlueZ cleanup; dbus_fast can raise a wide
             # variety of errors and we don't want any of them to
             # propagate out of the recovery path.
-            _LOGGER.error("%s: Failed to force stop scanner: %s", self.name, ex)
+            _LOGGER.exception("%s: Failed to force stop scanner", self.name)

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -1037,8 +1037,9 @@ def test_kernel_bug_workaround_send_raises_exception(
     with pytest.raises(OSError, match="Socket error"):
         protocol._write_to_socket(test_data)
 
-    # Verify the error was logged
-    assert "Failed to write to mgmt socket: Socket error" in caplog.text
+    # Verify the error was logged; the traceback carries the OSError text.
+    assert "Failed to write to mgmt socket" in caplog.text
+    assert "Socket error" in caplog.text
     mock_socket.send.assert_called_once_with(test_data)
 
 
@@ -1190,7 +1191,7 @@ async def test_reconnect_task_shutdown() -> None:
         establish_called = True
         # Should not be called since we're shutting down
         msg = "Should not be called"
-        raise Exception(msg)
+        raise AssertionError(msg)
 
     with patch.object(
         ctl, "_establish_connection", side_effect=mock_establish_connection


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. After the EM PR, most TRY003 noise is gone. The remaining 9 sites split across:

TRY400 (5): `_LOGGER.error(...)` inside `except` switches to `_LOGGER.exception(...)` so the traceback is included.

TRY401 (1 original + 5 that became visible after the TRY400 fixes): drops the redundant `ex` argument from the format string in the same six call sites; the exception already comes through the traceback attached by `logger.exception`.

TRY300 (2): hoists the `return True` after a successful `_write_to_socket` into an `else` clause in `MGMTBluetoothCtl.load_conn_params*`.

TRY002 (1): swaps a generic `raise Exception` in a test stub for `raise AssertionError`; the intent is "should never run", which AssertionError encodes more precisely.

TRY003 (long messages outside the exception class) is ignored, matching aioesphomeapi; addressing it would require either a custom exception per site or wrapping every dynamic message into a helper, neither of which adds value.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)