### PR TITLE
ci: enable ruff PLW (pylint warnings)

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -52,7 +52,7 @@ class BuildExt(build_ext):
 
 def build(setup_kwargs: Any) -> None:
     """Build optional cython modules."""
-    if os.environ.get("SKIP_CYTHON", False):
+    if os.environ.get("SKIP_CYTHON"):
         return
     try:
         from Cython.Build import cythonize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ select = [
     "PERF", # Perflint
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
+    "PLW",  # pylint warnings
     "PT",   # flake8-pytest-style
     "PTH",  # flake8-use-pathlib
     "PYI",  # flake8-pyi


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. One violation: build_ext.py passed `False` as the second argument to `os.environ.get` where getenv style APIs require `str | None`. Drop the default so the natural `None` is used; the truthy check is unchanged. First of three PRs splitting the PL family (PLW, PLR, PLC) so each landing is bounded.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)