### PR TITLE
ci: enable ruff PLR (pylint refactor)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,11 @@ ignore = [
     "D401",    # First line of docstring should be in imperative mood
     "ASYNC109", # ``timeout`` is part of our bleak-compatible public API
     "TRY003",  # too many to fix; long messages outside the exception class
+    "PLR0911", # too many return statements (matches aioesphomeapi)
+    "PLR0912", # too many branches (matches aioesphomeapi)
+    "PLR0913", # too many arguments (matches aioesphomeapi)
+    "PLR0915", # too many statements (matches aioesphomeapi)
+    "PLR2004", # magic value in comparison (matches aioesphomeapi)
 ]
 select = [
     "A",    # flake8-builtins
@@ -150,6 +155,7 @@ select = [
     "PERF", # Perflint
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
+    "PLR",  # pylint refactor
     "PLW",  # pylint warnings
     "PT",   # flake8-pytest-style
     "PTH",  # flake8-use-pathlib

--- a/src/habluetooth/advertisement_tracker.py
+++ b/src/habluetooth/advertisement_tracker.py
@@ -59,8 +59,9 @@ class AdvertisementTracker:
         max_time_between_advertisements = timings[1] - timings[0]
         for i in range(2, len(timings)):
             time_between_advertisements = timings[i] - timings[i - 1]
-            if time_between_advertisements > max_time_between_advertisements:
-                max_time_between_advertisements = time_between_advertisements
+            max_time_between_advertisements = max(
+                max_time_between_advertisements, time_between_advertisements
+            )
 
         # We now know the maximum time between advertisements
         self.intervals[service_info.address] = max_time_between_advertisements

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -232,8 +232,7 @@ class _ScannerWorker:
             if history is None or history.source != source:
                 continue
             earliest = min(entries.values())
-            if earliest < next_at:
-                next_at = earliest
+            next_at = min(next_at, earliest)
         return next_at
 
     async def _run(self) -> None:

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -241,7 +241,12 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
             self._advertisement = TUPLE_NEW(
                 AdvertisementData,
                 (
-                    None if self.name == "" or self.name == self.address else self.name,
+                    # The ``in`` form (PLR1714) makes cython emit an extra
+                    # INCREF/DECREF on self.name in this hot path; the
+                    # explicit ``or`` short-circuits without aliasing.
+                    None
+                    if self.name == "" or self.name == self.address  # noqa: PLR1714
+                    else self.name,
                     self.manufacturer_data,
                     self.service_data,
                     self.service_uuids,


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Three sites fixed after applying the same ignore list aioesphomeapi uses for the noisy `too-many-*` and `magic-value` checks (PLR0911, 0912, 0913, 0915, 2004).

PLR1730 (2): the if-compare-assign idiom collapses to `max(...)` in `AdvertisementTracker` and `min(...)` in `_ScannerWorker._next_event_at`; both auto fixes.

PLR1714 (1): the `self.name == "" or self.name == self.address` check in `BluetoothServiceInfoBleak._advertisement_internal` stays as is with a noqa comment. The mechanical `in ("", self.address)` rewrite makes cython emit an extra INCREF/DECREF pair on `self.name` (aliased into a temp for the membership check); this is the per advertisement hot path so the explicit short circuit pair of `==` is preferred.

Second of three PRs splitting the PL family.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)