### PR TITLE
ci: enable ruff PLC (pylint convention)

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -55,7 +55,9 @@ def build(setup_kwargs: Any) -> None:
     if os.environ.get("SKIP_CYTHON"):
         return
     try:
-        from Cython.Build import cythonize
+        # Cython is optional; defer the import so the SKIP_CYTHON
+        # branch above never has to find it on sys.path.
+        from Cython.Build import cythonize  # noqa: PLC0415
 
         setup_kwargs.update(
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ select = [
     "PERF", # Perflint
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
+    "PLC",  # pylint convention
     "PLW",  # pylint warnings
     "PT",   # flake8-pytest-style
     "PTH",  # flake8-use-pathlib

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -363,7 +363,11 @@ class BluetoothManager:
 
     async def async_setup(self) -> None:
         """Set up the bluetooth manager."""
-        from .central_manager import CentralBluetoothManager
+        # Deferred to avoid the circular import that a top-level
+        # ``from .central_manager import CentralBluetoothManager``
+        # would create (central_manager itself imports BluetoothManager
+        # under TYPE_CHECKING but only this method writes through it).
+        from .central_manager import CentralBluetoothManager  # noqa: PLC0415
 
         if CentralBluetoothManager.manager is None:
             CentralBluetoothManager.manager = self

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -154,9 +154,10 @@ class BluetoothServiceInfo:
     @property
     def manufacturer(self) -> str | None:
         """Convert manufacturer data to a string."""
-        from bleak.backends._manufacturers import (
-            MANUFACTURERS,  # pylint: disable=import-outside-toplevel
-        )
+        # MANUFACTURERS is a multi-kilobyte dict; lazy-load so the
+        # cost is only paid by the rare caller that asks for the
+        # manufacturer name (most don't).
+        from bleak.backends._manufacturers import MANUFACTURERS  # noqa: PLC0415
 
         for manufacturer in self.manufacturer_data:
             if manufacturer in MANUFACTURERS:

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
+import math
 from typing import TYPE_CHECKING
 
 import pytest
@@ -21,6 +23,8 @@ from habluetooth.const import (
     AUTO_REDISCOVERY_SWEEP_DURATION,
     AUTO_WINDOW_MAX_DURATION,
     AUTO_WINDOW_MIN_DURATION,
+    DEFAULT_ACTIVE_SCAN_DURATION,
+    DEFAULT_ACTIVE_SCAN_INTERVAL,
 )
 
 from . import generate_advertisement_data, generate_ble_device
@@ -711,9 +715,7 @@ async def test_register_active_scan_validates_inputs() -> None:
     # Non-finite values must be rejected: NaN compared to anything
     # returns False, so without the explicit isfinite() check a NaN
     # would slip past the lower-bound validators.
-    import math as _math
-
-    for bad in (_math.nan, _math.inf, -_math.inf):
+    for bad in (math.nan, math.inf, -math.inf):
         with pytest.raises(ValueError, match="scan_interval must be a finite number"):
             manager.async_register_active_scan("AA:BB:CC:DD:EE:00", scan_interval=bad)
         with pytest.raises(ValueError, match="scan_duration must be a finite number"):
@@ -725,11 +727,6 @@ async def test_register_active_scan_validates_inputs() -> None:
 @pytest.mark.asyncio
 async def test_register_active_scan_applies_defaults() -> None:
     """Omitting scan_interval/scan_duration uses the configured defaults."""
-    from habluetooth.const import (
-        DEFAULT_ACTIVE_SCAN_DURATION,
-        DEFAULT_ACTIVE_SCAN_INTERVAL,
-    )
-
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "AA:BB:CC:DD:EE:42"
@@ -857,8 +854,6 @@ async def test_repeated_window_failures_log_only_first_traceback(
     still logs the full stack so the root cause is captured; subsequent
     failures collapse to a one-line warning to avoid flooding the log.
     """
-    import logging
-
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()
@@ -899,8 +894,6 @@ async def test_tick_sync_phase_exception_is_logged_and_worker_survives(
     Stubs async_last_service_info to raise so _collect_due_buckets
     blows up; the outer except in _tick catches it and logs.
     """
-    import logging
-
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:55:91"

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -1,8 +1,11 @@
 """Tests for the cross-scanner name cache on BluetoothManager."""
 
 import time
+from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
+from freezegun import freeze_time
 
 from habluetooth import HaBluetoothConnector, get_manager
 
@@ -14,6 +17,7 @@ from . import (
     generate_advertisement_data,
     generate_ble_device,
     inject_advertisement_with_source,
+    utcnow,
 )
 
 # ---------------------------------------------------------------------------
@@ -416,13 +420,6 @@ async def test_async_clear_advertisement_history_evicts_cache() -> None:
 @pytest.mark.asyncio
 async def test_disappearance_evicts_cache() -> None:
     """A device that disappears via _async_check_unavailable evicts its cache entry."""
-    from datetime import timedelta
-    from unittest.mock import patch
-
-    from freezegun import freeze_time
-
-    from . import utcnow
-
     manager = get_manager()
     address = "44:44:33:11:23:54"
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -4,19 +4,21 @@ import asyncio
 import logging
 import platform
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from datetime import timedelta
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from bleak import BleakError
-from bleak.backends.scanner import AdvertisementDataCallback
-from bleak_retry_connector import BleakSlotManager
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
+from bleak_retry_connector import Allocations, BleakSlotManager
 
 from habluetooth import (
     SCANNER_WATCHDOG_INTERVAL,
     SCANNER_WATCHDOG_TIMEOUT,
+    BaseHaScanner,
     BluetoothManager,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
@@ -1576,8 +1578,6 @@ def test_ha_scanner_get_allocations_no_slot_manager() -> None:
 
 def test_ha_scanner_get_allocations_with_slot_manager() -> None:
     """Test HaScanner.get_allocations returns allocation info from BleakSlotManager."""
-    from bleak_retry_connector import Allocations
-
     scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
     manager = get_manager()
 
@@ -1603,8 +1603,6 @@ def test_ha_scanner_get_allocations_with_slot_manager() -> None:
 
 def test_ha_scanner_get_allocations_updates_dynamically() -> None:
     """Test that HaScanner.get_allocations returns current values as they change."""
-    from bleak_retry_connector import Allocations
-
     scanner = HaScanner(BluetoothScanningMode.ACTIVE, "hci0", "AA:BB:CC:DD:EE:FF")
     manager = get_manager()
 
@@ -2223,12 +2221,6 @@ async def test_base_scanner_default_active_window_is_noop(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """BaseHaScanner.async_request_active_window default returns False."""
-    from collections.abc import Iterable
-
-    from bleak.backends.device import BLEDevice
-    from bleak.backends.scanner import AdvertisementData
-
-    from habluetooth import BaseHaScanner
 
     class _PlainScanner(BaseHaScanner):
         @property

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -16,11 +16,12 @@ from bleak_retry_connector import Allocations
 
 from habluetooth import HaBluetoothConnector
 from habluetooth import get_manager as _get_manager
+from habluetooth.const import BDADDR_LE_PUBLIC, BDADDR_LE_RANDOM
 from habluetooth.usage import (
     install_multiple_bleak_catcher,
     uninstall_multiple_bleak_catcher,
 )
-from habluetooth.wrappers import HaBleakScannerWrapper
+from habluetooth.wrappers import HaBleakScannerWrapper, _get_device_address_type
 
 from . import (
     HCI0_SOURCE_ADDRESS,
@@ -1555,9 +1556,6 @@ async def test_get_device_address_type_random(
         },
     )
 
-    from habluetooth.const import BDADDR_LE_RANDOM
-    from habluetooth.wrappers import _get_device_address_type
-
     assert _get_device_address_type(device) == BDADDR_LE_RANDOM
 
     cancel_hci0()
@@ -1575,9 +1573,6 @@ async def test_get_device_address_type_public(
 
     # Create a device with public address type (default)
     device = hci0_device_advs["00:00:00:00:00:01"][0]
-
-    from habluetooth.const import BDADDR_LE_PUBLIC
-    from habluetooth.wrappers import _get_device_address_type
 
     assert _get_device_address_type(device) == BDADDR_LE_PUBLIC
 
@@ -1707,8 +1702,6 @@ async def test_connection_path_scoring_with_slots_and_logging(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test connection path scoring and logging reflects slot availability."""
-    from bleak_retry_connector import Allocations
-
     manager = _get_manager()
 
     class FakeBleakClientNoConnect(BaseFakeBleakClient):
@@ -1967,8 +1960,6 @@ async def test_thundering_herd_connection_slots() -> None:  # noqa: C901
     - First 6 devices should connect to proxy1 and proxy2 (3 each)
     - 7th device should connect to proxy3 (bad signal) when others are full
     """
-    from bleak_retry_connector import Allocations
-
     manager = _get_manager()
 
     # Track which backend each device connected to


### PR DESCRIPTION
## Summary

Refs #454; aligns with the aioesphomeapi ruff config. Twenty three PLC0415 violations split across the test suite (mundane stdlib and internal imports that just hadn't moved to the top) and three production sites with real reasons to stay inline.

Tests: every inline `import math`, `import logging`, `from freezegun`, `from bleak_retry_connector import Allocations`, etc. moves to the module's top import block. tests/test_scanner also picks up `BaseHaScanner` (and `BLEDevice` / `AdvertisementData` / `Iterable` for annotations) at module scope so the in body declarations vanish.

Source files keep their inline imports with a per line `# noqa: PLC0415` and a one line why:

* build_ext.py: `from Cython.Build import cythonize` lives in the try block because Cython is optional; the SKIP_CYTHON path must not require it on sys.path.
* manager.py: `from .central_manager import CentralBluetoothManager` is the only writer through the singleton and the module pair already pins the avoid circular import contract.
* models.py: `from bleak.backends._manufacturers import MANUFACTURERS` is a multi kilobyte dict and only the `manufacturer` property reads it.

Third (and final) of the PL family splits; PLR was skipped because the cython output it produced was worse on the hot path.

## Test plan

- [x] `pre-commit run -a` green
- [x] `poetry run pytest tests/` green (390 pass, 1 skip)