### PR TITLE
feat(scanner): log MGMT side channel state when watchdog fires

### DIFF
--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -628,6 +628,27 @@ class HaScanner(BaseHaScanner):
         msg = f"{self.name}: Invalid DBus message received: {ex}; try restarting `dbus`"
         raise ScannerStartError(msg) from ex
 
+    def _describe_side_channel_state(self) -> str:
+        """Summarize where this scanner expects advertisements to come from."""
+        manager = self._manager
+        idx = self.adapter_idx
+        if idx is None:
+            return "no adapter_idx; bleak detection_callback path"
+        if not manager.has_advertising_side_channel:
+            return "MGMT side channel unavailable; bleak detection_callback path"
+        registered = manager._side_channel_scanners.get(idx)
+        if registered is None:
+            return f"MGMT side channel up but hci{idx} unregistered"
+        if registered is not self:
+            return f"MGMT side channel at hci{idx} bound to a different scanner"
+        mgmt_ctl = manager._mgmt_ctl
+        protocol = getattr(mgmt_ctl, "protocol", None) if mgmt_ctl else None
+        if protocol is None:
+            return f"MGMT side channel registered at hci{idx} but protocol down"
+        if protocol.transport is None:
+            return f"MGMT side channel registered at hci{idx} but transport closed"
+        return f"MGMT side channel feeding hci{idx}"
+
     def _async_scanner_watchdog(self) -> None:
         """Check if the scanner is running."""
         if not self._async_watchdog_triggered():
@@ -639,9 +660,10 @@ class HaScanner(BaseHaScanner):
             )
             return
         _LOGGER.debug(
-            "%s: Bluetooth scanner has gone quiet for %ss, restarting",
+            "%s: Bluetooth scanner has gone quiet for %ss (%s), restarting",
             self.name,
             self.time_since_last_detection(),
+            self._describe_side_channel_state(),
         )
         # Immediately mark the scanner as not scanning
         # since the restart task will have to wait for the lock

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2766,3 +2766,150 @@ async def test_async_request_active_window_restart_path_mode_mismatch() -> None:
         finally:
             noop_restart = False
             await ha_scanner.async_stop()
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_no_adapter_idx() -> None:
+    """Non-hci adapter names have no MGMT index so report the fallback path."""
+    ha_scanner = HaScanner(
+        BluetoothScanningMode.PASSIVE, "Core Bluetooth", "AA:BB:CC:DD:EE:01"
+    )
+    assert (
+        ha_scanner._describe_side_channel_state()
+        == "no adapter_idx; bleak detection_callback path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_no_side_channel() -> None:
+    """When the manager never brought MGMT up we fall back to bleak's callback."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = False
+    ha_scanner = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:02")
+    assert (
+        ha_scanner._describe_side_channel_state()
+        == "MGMT side channel unavailable; bleak detection_callback path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_unregistered() -> None:
+    """Side channel is alive but the scanner isn't in _side_channel_scanners."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = True
+    manager._side_channel_scanners.clear()
+    ha_scanner = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:03")
+    assert (
+        ha_scanner._describe_side_channel_state()
+        == "MGMT side channel up but hci0 unregistered"
+    )
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_bound_to_other_scanner() -> None:
+    """Another scanner owns the hciN slot in _side_channel_scanners."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = True
+    other = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:04")
+    manager._side_channel_scanners[0] = other
+    ha_scanner = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:05")
+    try:
+        assert (
+            ha_scanner._describe_side_channel_state()
+            == "MGMT side channel at hci0 bound to a different scanner"
+        )
+    finally:
+        manager._side_channel_scanners.clear()
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_protocol_down() -> None:
+    """Scanner is registered but the MGMT ctl is gone — socket died."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = True
+    ha_scanner = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:06")
+    manager._side_channel_scanners[0] = ha_scanner
+    manager._mgmt_ctl = None
+    try:
+        assert (
+            ha_scanner._describe_side_channel_state()
+            == "MGMT side channel registered at hci0 but protocol down"
+        )
+    finally:
+        manager._side_channel_scanners.clear()
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_transport_closed() -> None:
+    """Scanner is registered, protocol exists, but the transport is gone."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = True
+    ha_scanner = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:07")
+    manager._side_channel_scanners[0] = ha_scanner
+    mgmt_ctl = Mock()
+    mgmt_ctl.protocol = Mock(spec=BluetoothMGMTProtocol)
+    mgmt_ctl.protocol.transport = None
+    manager._mgmt_ctl = mgmt_ctl
+    try:
+        assert (
+            ha_scanner._describe_side_channel_state()
+            == "MGMT side channel registered at hci0 but transport closed"
+        )
+    finally:
+        manager._side_channel_scanners.clear()
+        manager._mgmt_ctl = None
+
+
+@pytest.mark.asyncio
+async def test_describe_side_channel_state_feeding() -> None:
+    """Happy path: scanner registered, protocol and transport both live."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = True
+    ha_scanner = HaScanner(BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:08")
+    manager._side_channel_scanners[0] = ha_scanner
+    mgmt_ctl = Mock()
+    mgmt_ctl.protocol = Mock(spec=BluetoothMGMTProtocol)
+    mgmt_ctl.protocol.transport = Mock()
+    manager._mgmt_ctl = mgmt_ctl
+    try:
+        assert (
+            ha_scanner._describe_side_channel_state()
+            == "MGMT side channel feeding hci0"
+        )
+    finally:
+        manager._side_channel_scanners.clear()
+        manager._mgmt_ctl = None
+
+
+@pytest.mark.asyncio
+async def test_scanner_watchdog_log_includes_side_channel_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The 'gone quiet' restart log line carries the side-channel diagnostic."""
+    manager = get_manager()
+    manager.has_advertising_side_channel = True
+
+    class _NoRestartScanner(HaScanner):
+        # Skip the actual restart so the test just exercises the log path.
+        def _create_background_task(self, coro):
+            coro.close()
+
+    with patch_bleak_scanner_factory(MockBleakScanner):
+        ha_scanner = _NoRestartScanner(
+            BluetoothScanningMode.PASSIVE, "hci0", "AA:BB:CC:DD:EE:09"
+        )
+        ha_scanner.async_setup()
+        await ha_scanner.async_start()
+        try:
+            # Force the watchdog over its timeout without producing any
+            # advertisements, and clear out the side-channel registration
+            # to make the diagnostic message distinctive.
+            manager._side_channel_scanners.clear()
+            ha_scanner._last_detection = (
+                ha_scanner._last_detection - SCANNER_WATCHDOG_TIMEOUT - 1.0
+            )
+            with caplog.at_level(logging.DEBUG, logger="habluetooth.scanner"):
+                ha_scanner._async_scanner_watchdog()
+            assert "MGMT side channel up but hci0 unregistered" in caplog.text
+        finally:
+            await ha_scanner.async_stop()


### PR DESCRIPTION
When the local scanner watchdog flags a quiet adapter, the log line now says whether the MGMT side channel is feeding it, is wired up but pointed at a different scanner, has no scanner registered for that hci index, or has lost its socket; this is for triaging cases where kernel adverts are clearly flowing but `_last_detection` never updates.

Tests cover the six states the helper can report plus an end to end check that the watchdog log carries the diagnostic.