### PR TITLE
feat(auto-scheduler): expose diagnostics for sweeps, windows, and watched devices

### DIFF
--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -142,7 +142,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bleak_retry_connector import NO_RSSI_VALUE
 
@@ -834,3 +834,51 @@ class AutoScanScheduler:
         if requested > _AUTO_WINDOW_MAX_DURATION:
             return _AUTO_WINDOW_MAX_DURATION
         return requested
+
+    def async_diagnostics(self) -> dict[str, Any]:
+        """
+        Return a snapshot of scheduler state for diagnostics.
+
+        Per-worker timing fields and ``monotonic_time`` are raw
+        ``loop.time()`` values so callers can compute deltas; before
+        ``start()`` (or after ``stop()``) ``_loop`` is None and these
+        are reported as 0.0.
+        """
+        loop = self._loop
+        now = loop.time() if loop is not None else 0.0
+        workers: dict[str, dict[str, Any]] = {}
+        for source, worker in self._workers.items():
+            workers[source] = {
+                "name": worker._scanner.name,
+                "window_end": worker._window_end,
+                "sweep_last_completed": worker._sweep_last_completed,
+                "next_sweep_at": (
+                    worker._sweep_last_completed + _AUTO_REDISCOVERY_INTERVAL
+                ),
+                "next_event_at": (
+                    worker._next_event_at(now) if loop is not None else 0.0
+                ),
+                "failed_window": worker._failed_window,
+                "warned_no_fallback": worker._warned_no_fallback,
+            }
+        last_service_info = self._manager.async_last_service_info
+        requests: dict[str, list[dict[str, Any]]] = {}
+        for address, bucket in self._requests_by_address.items():
+            entries = self._needs.get(address, {})
+            history = last_service_info(address, False)
+            owner_source = history.source if history is not None else None
+            requests[address] = [
+                {
+                    "scan_interval": request.scan_interval,
+                    "scan_duration": request.scan_duration,
+                    "next_due": entries.get(request),
+                    "owner_source": owner_source,
+                }
+                for request in bucket
+            ]
+        return {
+            "running": self._running,
+            "monotonic_time": now,
+            "workers": workers,
+            "requests": requests,
+        }

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -281,6 +281,7 @@ class BluetoothManager:
                 service_info.as_dict() for service_info in self._all_history.values()
             ],
             "advertisement_tracker": self._advertisement_tracker.async_diagnostics(),
+            "auto_scheduler": self._auto_scheduler.async_diagnostics(),
         }
 
     def _find_adapter_by_address(self, address: str) -> str | None:

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4294,3 +4294,55 @@ async def test_worker_tick_dispatch_samples_time_per_fallback() -> None:
         c_owner()
         c_s()
         c_l()
+
+
+@pytest.mark.asyncio
+async def test_async_diagnostics() -> None:
+    """Diagnostics expose per-worker sweep timing and per-address requests."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel1 = manager.async_register_active_scan(
+        address, scan_interval=120.0, scan_duration=5.0
+    )
+    cancel2 = manager.async_register_active_scan(
+        address, scan_interval=240.0, scan_duration=10.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        diagnostics = sched.async_diagnostics()
+        assert diagnostics["running"] is True
+        assert diagnostics["monotonic_time"] == pytest.approx(loop.time(), abs=0.5)
+        workers = diagnostics["workers"]
+        assert set(workers) == {scanner.source}
+        worker_diag = workers[scanner.source]
+        assert worker_diag["name"] == scanner.name
+        assert worker_diag["window_end"] == 0.0
+        assert worker_diag["failed_window"] is False
+        assert worker_diag["warned_no_fallback"] is False
+        assert worker_diag["next_sweep_at"] == pytest.approx(
+            worker_diag["sweep_last_completed"] + AUTO_REDISCOVERY_INTERVAL
+        )
+        assert worker_diag["next_event_at"] > 0.0
+        requests = diagnostics["requests"]
+        assert set(requests) == {address}
+        entries = requests[address]
+        assert len(entries) == 2
+        pairs = sorted(
+            (entry["scan_interval"], entry["scan_duration"]) for entry in entries
+        )
+        assert pairs == [(120.0, 5.0), (240.0, 10.0)]
+        for entry in entries:
+            assert entry["owner_source"] == scanner.source
+            assert entry["next_due"] is not None
+            assert entry["next_due"] > loop.time()
+    finally:
+        cancel1()
+        cancel2()
+        register_cancel()
+    # After cancellation the address falls out of both indexes.
+    post = sched.async_diagnostics()
+    assert post["requests"] == {}

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -543,6 +543,7 @@ async def test_diagnostics(register_hci0_scanner: None) -> None:
                 "source": "AA:BB:CC:DD:EE:00",
             }
         },
+        "auto_scheduler": ANY,
         "connectable_history": ANY,
         "scanners": [
             {


### PR DESCRIPTION
Surfaces the auto-mode scheduler's internal state in `BluetoothManager.async_diagnostics()` so HA's diagnostics download captures it; the new `auto_scheduler` key reports each worker's `window_end`, `sweep_last_completed`, `next_sweep_at`, and `next_event_at` plus per-address active-scan requests with `scan_interval`, `scan_duration`, `next_due`, and `owner_source`. Read-only; no behavior change.