### PR TITLE
feat(manager): expose async_request_active_scan for on-demand discovery

### DIFF
--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -80,6 +80,7 @@ cdef class AutoScanScheduler:
     cdef public object _loop
     cdef public bint _running
     cdef public object _on_demand_sweep_future
+    cdef public double _on_demand_sweep_end
 
     @cython.locals(
         existing=dict,

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -11,6 +11,9 @@ cdef double _AUTO_CONNECTING_DEFER
 cdef int NO_RSSI_VALUE
 
 
+cdef double _clamp_window_duration(double duration) noexcept
+
+
 cdef class ActiveScanRequest:
 
     cdef public str address
@@ -76,6 +79,7 @@ cdef class AutoScanScheduler:
     cdef public dict _workers
     cdef public object _loop
     cdef public bint _running
+    cdef public object _on_demand_sweep_future
 
     @cython.locals(
         existing=dict,

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -930,8 +930,7 @@ class AutoScanScheduler:
             await asyncio.sleep(duration)
         finally:
             self._on_demand_sweep_future = None
-            if not future.done():
-                future.set_result(None)
+            future.set_result(None)
 
     def async_diagnostics(self) -> dict[str, Any]:
         """

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -177,6 +177,15 @@ _AUTO_CONNECTING_DEFER = 30.0
 _LOGGER = logging.getLogger(__name__)
 
 
+def _clamp_window_duration(duration: float) -> float:
+    """Clamp a window duration into ``[MIN, MAX]``."""
+    if duration < _AUTO_WINDOW_MIN_DURATION:
+        return _AUTO_WINDOW_MIN_DURATION
+    if duration > _AUTO_WINDOW_MAX_DURATION:
+        return _AUTO_WINDOW_MAX_DURATION
+    return duration
+
+
 class ActiveScanRequest:
     """
     A registered need for on-demand active scans on one address.
@@ -588,6 +597,7 @@ class AutoScanScheduler:
         "_loop",
         "_manager",
         "_needs",
+        "_on_demand_sweep_future",
         "_requests_by_address",
         "_running",
         "_workers",
@@ -601,6 +611,7 @@ class AutoScanScheduler:
         self._workers: dict[str, _ScannerWorker] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
+        self._on_demand_sweep_future: asyncio.Future[None] | None = None
 
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         """
@@ -825,15 +836,70 @@ class AutoScanScheduler:
         float (``async_register_active_scan`` enforces this at the
         boundary).
         """
-        requested = max(
-            (e.scan_duration for e in entries),
-            default=_AUTO_WINDOW_MIN_DURATION,
+        return _clamp_window_duration(
+            max(
+                (e.scan_duration for e in entries),
+                default=_AUTO_WINDOW_MIN_DURATION,
+            )
         )
-        if requested < _AUTO_WINDOW_MIN_DURATION:
-            return _AUTO_WINDOW_MIN_DURATION
-        if requested > _AUTO_WINDOW_MAX_DURATION:
-            return _AUTO_WINDOW_MAX_DURATION
-        return requested
+
+    async def async_request_sweep(self, duration: float) -> None:
+        """
+        Flip every AUTO scanner to ACTIVE for ``duration`` seconds.
+
+        Used by the public ``BluetoothManager.async_request_sweep``
+        entry point for HA config-flow discovery. The manager
+        validates that ``duration`` is finite and positive; this
+        method clamps into ``[MIN, MAX]`` to keep parity with the
+        scheduled-window path.
+
+        Concurrent callers share an in-flight sweep via
+        ``_on_demand_sweep_future``: there is never more than one
+        on-demand window outstanding on the bus, so joining callers
+        wait on the same future and return when it resolves. The
+        check-and-set on the future is synchronous (no ``await``
+        before it) so it is atomic under cooperative scheduling.
+
+        Skips scanners whose radio is busy with a connect attempt;
+        adjacent scanners cover those devices. Advances each flipped
+        worker's ``_sweep_last_completed`` and ``_window_end`` via
+        ``note_window_dispatched`` so the next periodic sweep is
+        deferred and the worker's own ``_tick`` suppresses itself
+        during the on-demand window. Always awaits the full
+        ``duration`` so the caller can read advertisements collected
+        during the window before this returns.
+        """
+        if (in_flight := self._on_demand_sweep_future) is not None:
+            await in_flight
+            return
+        if self._loop is None:
+            return
+        duration = _clamp_window_duration(duration)
+        future = self._loop.create_future()
+        self._on_demand_sweep_future = future
+        try:
+            now = self._loop.time()
+            window_end = now + duration
+            targets: list[BaseHaScanner] = []
+            for worker in self._workers.values():
+                scanner = worker._scanner
+                if scanner._connections_in_progress() > 0:
+                    continue
+                worker.note_window_dispatched(window_end, now)
+                targets.append(scanner)
+            if targets:
+                await asyncio.gather(
+                    *(
+                        scanner.async_request_active_window(duration)
+                        for scanner in targets
+                    ),
+                    return_exceptions=True,
+                )
+            await asyncio.sleep(duration)
+        finally:
+            self._on_demand_sweep_future = None
+            if not future.done():
+                future.set_result(None)
 
     def async_diagnostics(self) -> dict[str, Any]:
         """

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -898,8 +898,7 @@ class AutoScanScheduler:
             await asyncio.sleep(duration)
         finally:
             self._on_demand_sweep_future = None
-            if not future.done():
-                future.set_result(None)
+            future.set_result(None)
 
     def async_diagnostics(self) -> dict[str, Any]:
         """

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -913,10 +913,14 @@ class AutoScanScheduler:
         future and take down the siblings or the leader's
         ``set_result``.
         """
-        if self._loop is None:
+        # Capture loop locally so a concurrent stop() (which nulls
+        # self._loop) during the sleep loop or the flip-await cannot
+        # turn a re-read into AttributeError.
+        loop = self._loop
+        if loop is None:
             return
         duration = _clamp_window_duration(duration)
-        now = self._loop.time()
+        now = loop.time()
         desired_end = now + duration
         in_flight = self._on_demand_sweep_future
         if in_flight is not None:
@@ -925,13 +929,13 @@ class AutoScanScheduler:
                 await self._flip_scanners_for_sweep(desired_end - now)
             await asyncio.shield(in_flight)
             return
-        future = self._loop.create_future()
+        future = loop.create_future()
         self._on_demand_sweep_future = future
         self._on_demand_sweep_end = desired_end
         try:
             await self._flip_scanners_for_sweep(duration)
             while True:
-                remaining = self._on_demand_sweep_end - self._loop.time()
+                remaining = self._on_demand_sweep_end - loop.time()
                 if remaining <= 0:
                     break
                 await asyncio.sleep(remaining)

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -597,6 +597,7 @@ class AutoScanScheduler:
         "_loop",
         "_manager",
         "_needs",
+        "_on_demand_sweep_end",
         "_on_demand_sweep_future",
         "_requests_by_address",
         "_running",
@@ -612,6 +613,7 @@ class AutoScanScheduler:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
+        self._on_demand_sweep_end: float = 0.0
 
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         """
@@ -843,6 +845,55 @@ class AutoScanScheduler:
             )
         )
 
+    async def _flip_scanners_for_sweep(self, duration: float) -> None:
+        """
+        Flip every non-busy AUTO scanner into a ``duration``-second window.
+
+        Iterates the workers, calls ``note_window_dispatched`` to
+        reset the per-worker sweep cadence, and gathers the radio
+        flips with ``return_exceptions=True`` so one stuck adapter
+        cannot abort the bus-wide sweep. Per-scanner flip failures
+        are logged one-line-per-scanner so a persistently broken
+        adapter is observable instead of silently swallowed.
+
+        Scanners with a connect in progress are skipped; the
+        on-demand sweep is best-effort and does not route around
+        them (the periodic ``_tick`` path handles fallback).
+        Called both on initial sweep start and on joiner-extension,
+        so a re-flip with a longer duration extends the radio's
+        open window in place (per
+        ``BaseHaScanner.async_request_active_window``).
+
+        Callers must guard on ``self._loop is not None`` before
+        invoking; the type-checking assert below documents that
+        invariant.
+        """
+        if TYPE_CHECKING:
+            assert self._loop is not None
+        now = self._loop.time()
+        window_end = now + duration
+        targets: list[BaseHaScanner] = []
+        for worker in self._workers.values():
+            scanner = worker._scanner
+            if scanner._connections_in_progress() > 0:
+                continue
+            worker.note_window_dispatched(window_end, now)
+            targets.append(scanner)
+        if not targets:
+            return
+        results = await asyncio.gather(
+            *(scanner.async_request_active_window(duration) for scanner in targets),
+            return_exceptions=True,
+        )
+        for scanner, result in zip(targets, results, strict=True):
+            if isinstance(result, BaseException):
+                _LOGGER.warning(
+                    "%s: error running on-demand active window of %.1fs: %s",
+                    scanner.name,
+                    duration,
+                    result,
+                )
+
     async def async_request_sweep(self, duration: float) -> None:
         """
         Flip every AUTO scanner to ACTIVE for ``duration`` seconds.
@@ -860,76 +911,72 @@ class AutoScanScheduler:
         check-and-set on the future is synchronous (no ``await``
         before it) so it is atomic under cooperative scheduling.
 
-        Per-scanner flip failures are gathered with
-        ``return_exceptions=True`` and logged one-line-per-scanner;
-        a stuck adapter never aborts the bus-wide sweep, but its
-        failure is observable rather than silently swallowed.
+        A joiner whose requested end-time exceeds the current
+        ``_on_demand_sweep_end`` extends the in-flight window: it
+        re-flips the scanners with the longer remaining duration
+        (``BaseHaScanner.async_request_active_window`` natively
+        extends an open window) and updates
+        ``_on_demand_sweep_end``. The leader's sleep loop re-reads
+        ``_on_demand_sweep_end`` after each wake, so an extension
+        causes the leader to sleep again. For four callers
+        requesting (10, 15, 5, 20) — whichever order they arrive —
+        the radio runs until the latest desired end (T0+20s), every
+        caller awaits until that end, and the 20s caller gets a
+        full 20s of fresh advertisements rather than being clipped
+        to whoever-won-the-race's duration.
 
-        Skips scanners whose radio is busy with a connect attempt;
-        adjacent scanners cover those devices. Unlike the periodic
-        ``_tick`` path this does not route a busy scanner's
-        coverage to a fallback; the on-demand sweep is best-effort
-        and the next ``_tick`` will pick the device up at its
-        normal cadence.
+        Per-scanner flip failures are logged via
+        ``_flip_scanners_for_sweep``; see that method for
+        busy-scanner and failure semantics.
 
         Advances each flipped worker's ``_sweep_last_completed`` and
         ``_window_end`` via ``note_window_dispatched`` so the next
         periodic sweep is deferred and the worker's own ``_tick``
-        suppresses itself during the on-demand window. Always awaits
-        the full ``duration`` for the leader so the caller can read
-        advertisements collected during the window before this
-        returns.
+        suppresses itself during the on-demand window.
 
-        Caveats:
-
-        * A late joiner that arrives near the end of an in-flight
-          window returns as soon as the leader finishes — its own
-          ``duration`` is not honored. For the typical
-          single-caller config-flow case this never trips; if
-          multiple flows race, joiners share the leader's window.
-        * If the leader is cancelled mid-sleep the future still
-          resolves to ``None`` (joiners do not see a propagated
-          ``CancelledError``); joiners benefit from whatever radio
-          activity already happened. The leader's own cancellation
-          propagates as usual.
+        If the leader is cancelled mid-sleep the future still
+        resolves to ``None`` (joiners do not see a propagated
+        ``CancelledError``); joiners benefit from whatever radio
+        activity already happened. The leader's own cancellation
+        propagates as usual.
         """
-        if (in_flight := self._on_demand_sweep_future) is not None:
-            await in_flight
-            return
         if self._loop is None:
             return
         duration = _clamp_window_duration(duration)
+        now = self._loop.time()
+        desired_end = now + duration
+        in_flight = self._on_demand_sweep_future
+        if in_flight is not None:
+            # Use a 1s slop on the extension threshold so concurrent
+            # same-duration callers (whose desired_end differs only
+            # by task-start jitter, microseconds) don't trigger
+            # bogus extensions. The 1s floor matches the resolution
+            # at which callers actually request durations.
+            if desired_end - self._on_demand_sweep_end > 1.0:
+                self._on_demand_sweep_end = desired_end
+                # Re-flip every non-busy scanner so the radio stays
+                # active until the new end; async_request_active_window
+                # extends an open window in place when called with a
+                # longer remaining duration.
+                await self._flip_scanners_for_sweep(desired_end - now)
+            await in_flight
+            return
         future = self._loop.create_future()
         self._on_demand_sweep_future = future
+        self._on_demand_sweep_end = desired_end
         try:
-            now = self._loop.time()
-            window_end = now + duration
-            targets: list[BaseHaScanner] = []
-            for worker in self._workers.values():
-                scanner = worker._scanner
-                if scanner._connections_in_progress() > 0:
-                    continue
-                worker.note_window_dispatched(window_end, now)
-                targets.append(scanner)
-            if targets:
-                results = await asyncio.gather(
-                    *(
-                        scanner.async_request_active_window(duration)
-                        for scanner in targets
-                    ),
-                    return_exceptions=True,
-                )
-                for scanner, result in zip(targets, results, strict=True):
-                    if isinstance(result, BaseException):
-                        _LOGGER.warning(
-                            "%s: error running on-demand active window of %.1fs: %s",
-                            scanner.name,
-                            duration,
-                            result,
-                        )
-            await asyncio.sleep(duration)
+            await self._flip_scanners_for_sweep(duration)
+            # Sleep until the window end, re-checking each wake so a
+            # joiner extension simply pushes the end out and we sleep
+            # again.
+            while True:
+                remaining = self._on_demand_sweep_end - self._loop.time()
+                if remaining <= 0:
+                    break
+                await asyncio.sleep(remaining)
         finally:
             self._on_demand_sweep_future = None
+            self._on_demand_sweep_end = 0.0
             future.set_result(None)
 
     def async_diagnostics(self) -> dict[str, Any]:

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -860,14 +860,38 @@ class AutoScanScheduler:
         check-and-set on the future is synchronous (no ``await``
         before it) so it is atomic under cooperative scheduling.
 
+        Per-scanner flip failures are gathered with
+        ``return_exceptions=True`` and logged one-line-per-scanner;
+        a stuck adapter never aborts the bus-wide sweep, but its
+        failure is observable rather than silently swallowed.
+
         Skips scanners whose radio is busy with a connect attempt;
-        adjacent scanners cover those devices. Advances each flipped
-        worker's ``_sweep_last_completed`` and ``_window_end`` via
-        ``note_window_dispatched`` so the next periodic sweep is
-        deferred and the worker's own ``_tick`` suppresses itself
-        during the on-demand window. Always awaits the full
-        ``duration`` so the caller can read advertisements collected
-        during the window before this returns.
+        adjacent scanners cover those devices. Unlike the periodic
+        ``_tick`` path this does not route a busy scanner's
+        coverage to a fallback; the on-demand sweep is best-effort
+        and the next ``_tick`` will pick the device up at its
+        normal cadence.
+
+        Advances each flipped worker's ``_sweep_last_completed`` and
+        ``_window_end`` via ``note_window_dispatched`` so the next
+        periodic sweep is deferred and the worker's own ``_tick``
+        suppresses itself during the on-demand window. Always awaits
+        the full ``duration`` for the leader so the caller can read
+        advertisements collected during the window before this
+        returns.
+
+        Caveats:
+
+        * A late joiner that arrives near the end of an in-flight
+          window returns as soon as the leader finishes — its own
+          ``duration`` is not honored. For the typical
+          single-caller config-flow case this never trips; if
+          multiple flows race, joiners share the leader's window.
+        * If the leader is cancelled mid-sleep the future still
+          resolves to ``None`` (joiners do not see a propagated
+          ``CancelledError``); joiners benefit from whatever radio
+          activity already happened. The leader's own cancellation
+          propagates as usual.
         """
         if (in_flight := self._on_demand_sweep_future) is not None:
             await in_flight
@@ -888,17 +912,26 @@ class AutoScanScheduler:
                 worker.note_window_dispatched(window_end, now)
                 targets.append(scanner)
             if targets:
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *(
                         scanner.async_request_active_window(duration)
                         for scanner in targets
                     ),
                     return_exceptions=True,
                 )
+                for scanner, result in zip(targets, results, strict=True):
+                    if isinstance(result, BaseException):
+                        _LOGGER.warning(
+                            "%s: error running on-demand active window of %.1fs: %s",
+                            scanner.name,
+                            duration,
+                            result,
+                        )
             await asyncio.sleep(duration)
         finally:
             self._on_demand_sweep_future = None
-            future.set_result(None)
+            if not future.done():
+                future.set_result(None)
 
     def async_diagnostics(self) -> dict[str, Any]:
         """

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -849,24 +849,15 @@ class AutoScanScheduler:
         """
         Flip every non-busy AUTO scanner into a ``duration``-second window.
 
-        Iterates the workers, calls ``note_window_dispatched`` to
-        reset the per-worker sweep cadence, and gathers the radio
-        flips with ``return_exceptions=True`` so one stuck adapter
-        cannot abort the bus-wide sweep. Per-scanner flip failures
-        are logged one-line-per-scanner so a persistently broken
-        adapter is observable instead of silently swallowed.
-
-        Scanners with a connect in progress are skipped; the
-        on-demand sweep is best-effort and does not route around
-        them (the periodic ``_tick`` path handles fallback).
-        Called both on initial sweep start and on joiner-extension,
-        so a re-flip with a longer duration extends the radio's
-        open window in place (per
-        ``BaseHaScanner.async_request_active_window``).
-
-        Callers must guard on ``self._loop is not None`` before
-        invoking; the type-checking assert below documents that
-        invariant.
+        ``return_exceptions=True`` plus the per-scanner log keeps one
+        stuck adapter from aborting the bus-wide sweep while still
+        surfacing its failure. Mid-connect scanners are skipped —
+        unlike the periodic ``_tick`` path this does not route to a
+        fallback; on-demand is best-effort. Re-flipping with a
+        longer duration extends the radio's open window in place
+        (``BaseHaScanner.async_request_active_window`` contract),
+        so the same helper serves both leader and joiner-extension.
+        Caller must guard ``self._loop is not None``.
         """
         if TYPE_CHECKING:
             assert self._loop is not None
@@ -886,11 +877,8 @@ class AutoScanScheduler:
             return_exceptions=True,
         )
         for scanner, result in zip(targets, results, strict=True):
-            # Narrowed to Exception so a cancellation surfaced as a
-            # gather result (CancelledError / KeyboardInterrupt /
-            # SystemExit) is not mis-classified as a flip failure;
-            # matches the except-Exception convention elsewhere in
-            # this module.
+            # Exception not BaseException so a CancelledError surfaced
+            # as a result propagates instead of being mis-logged.
             if isinstance(result, Exception):
                 _LOGGER.warning(
                     "%s: error running on-demand active window of %.1fs: %s",
@@ -903,47 +891,27 @@ class AutoScanScheduler:
         """
         Flip every AUTO scanner to ACTIVE for ``duration`` seconds.
 
-        Used by the public ``BluetoothManager.async_request_sweep``
-        entry point for HA config-flow discovery. The manager
-        validates that ``duration`` is finite and positive; this
-        method clamps into ``[MIN, MAX]`` to keep parity with the
-        scheduled-window path.
+        Public entry is ``BluetoothManager.async_request_sweep``
+        (validates finite/positive); this method clamps to
+        ``[MIN, MAX]``.
 
-        Concurrent callers share an in-flight sweep via
-        ``_on_demand_sweep_future``: there is never more than one
-        on-demand window outstanding on the bus, so joining callers
-        wait on the same future and return when it resolves. The
-        check-and-set on the future is synchronous (no ``await``
-        before it) so it is atomic under cooperative scheduling.
+        Concurrent callers dedupe on ``_on_demand_sweep_future``
+        (synchronous check-and-set, atomic under cooperative
+        scheduling — exactly one window per bus). A joiner whose
+        ``desired_end`` exceeds the current end extends the
+        in-flight window: re-flip the scanners and push
+        ``_on_demand_sweep_end`` out; the leader's sleep loop
+        re-reads it on each wake, so an extension just makes the
+        leader sleep again. The 1s slop on the extension threshold
+        absorbs task-start jitter so same-duration concurrent
+        callers do not trigger bogus extensions.
 
-        A joiner whose requested end-time exceeds the current
-        ``_on_demand_sweep_end`` extends the in-flight window: it
-        re-flips the scanners with the longer remaining duration
-        (``BaseHaScanner.async_request_active_window`` natively
-        extends an open window) and updates
-        ``_on_demand_sweep_end``. The leader's sleep loop re-reads
-        ``_on_demand_sweep_end`` after each wake, so an extension
-        causes the leader to sleep again. For four callers
-        requesting (10, 15, 5, 20) — whichever order they arrive —
-        the radio runs until the latest desired end (T0+20s), every
-        caller awaits until that end, and the 20s caller gets a
-        full 20s of fresh advertisements rather than being clipped
-        to whoever-won-the-race's duration.
-
-        Per-scanner flip failures are logged via
-        ``_flip_scanners_for_sweep``; see that method for
-        busy-scanner and failure semantics.
-
-        Advances each flipped worker's ``_sweep_last_completed`` and
-        ``_window_end`` via ``note_window_dispatched`` so the next
-        periodic sweep is deferred and the worker's own ``_tick``
-        suppresses itself during the on-demand window.
-
-        If the leader is cancelled mid-sleep the future still
-        resolves to ``None`` (joiners do not see a propagated
-        ``CancelledError``); joiners benefit from whatever radio
-        activity already happened. The leader's own cancellation
-        propagates as usual.
+        Cancellation: leader's cancel propagates to its caller and
+        joiners wake to ``None`` (best-effort — they get whatever
+        radio activity happened). Joiners ``await asyncio.shield``
+        the future so a cancelled joiner cannot cancel the shared
+        future and take down the siblings or the leader's
+        ``set_result``.
         """
         if self._loop is None:
             return
@@ -952,23 +920,9 @@ class AutoScanScheduler:
         desired_end = now + duration
         in_flight = self._on_demand_sweep_future
         if in_flight is not None:
-            # Use a 1s slop on the extension threshold so concurrent
-            # same-duration callers (whose desired_end differs only
-            # by task-start jitter, microseconds) don't trigger
-            # bogus extensions. The 1s floor matches the resolution
-            # at which callers actually request durations.
             if desired_end - self._on_demand_sweep_end > 1.0:
                 self._on_demand_sweep_end = desired_end
-                # Re-flip every non-busy scanner so the radio stays
-                # active until the new end; async_request_active_window
-                # extends an open window in place when called with a
-                # longer remaining duration.
                 await self._flip_scanners_for_sweep(desired_end - now)
-            # asyncio.shield prevents joiner-task cancellation from
-            # cancelling the shared future itself: without it, a
-            # cancelled joiner would propagate CancelledError to
-            # sibling joiners and would make the leader's finally
-            # raise InvalidStateError on set_result.
             await asyncio.shield(in_flight)
             return
         future = self._loop.create_future()
@@ -976,9 +930,6 @@ class AutoScanScheduler:
         self._on_demand_sweep_end = desired_end
         try:
             await self._flip_scanners_for_sweep(duration)
-            # Sleep until the window end, re-checking each wake so a
-            # joiner extension simply pushes the end out and we sleep
-            # again.
             while True:
                 remaining = self._on_demand_sweep_end - self._loop.time()
                 if remaining <= 0:

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -926,7 +926,11 @@ class AutoScanScheduler:
         if in_flight is not None:
             if desired_end - self._on_demand_sweep_end > 1.0:
                 self._on_demand_sweep_end = desired_end
-                await self._flip_scanners_for_sweep(desired_end - now)
+                # asyncio.shield the extension flip so a cancelled
+                # joiner does not leave the shared end pushed out
+                # past a partial re-flip; either all non-busy
+                # scanners receive the longer duration or none do.
+                await asyncio.shield(self._flip_scanners_for_sweep(desired_end - now))
             await asyncio.shield(in_flight)
             return
         future = loop.create_future()

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -886,7 +886,12 @@ class AutoScanScheduler:
             return_exceptions=True,
         )
         for scanner, result in zip(targets, results, strict=True):
-            if isinstance(result, BaseException):
+            # Narrowed to Exception so a cancellation surfaced as a
+            # gather result (CancelledError / KeyboardInterrupt /
+            # SystemExit) is not mis-classified as a flip failure;
+            # matches the except-Exception convention elsewhere in
+            # this module.
+            if isinstance(result, Exception):
                 _LOGGER.warning(
                     "%s: error running on-demand active window of %.1fs: %s",
                     scanner.name,
@@ -959,7 +964,12 @@ class AutoScanScheduler:
                 # extends an open window in place when called with a
                 # longer remaining duration.
                 await self._flip_scanners_for_sweep(desired_end - now)
-            await in_flight
+            # asyncio.shield prevents joiner-task cancellation from
+            # cancelling the shared future itself: without it, a
+            # cancelled joiner would propagate CancelledError to
+            # sibling joiners and would make the leader's finally
+            # raise InvalidStateError on set_result.
+            await asyncio.shield(in_flight)
             return
         future = self._loop.create_future()
         self._on_demand_sweep_future = future

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -887,11 +887,11 @@ class AutoScanScheduler:
                     result,
                 )
 
-    async def async_request_sweep(self, duration: float) -> None:
+    async def async_request_active_scan(self, duration: float) -> None:
         """
         Flip every AUTO scanner to ACTIVE for ``duration`` seconds.
 
-        Public entry is ``BluetoothManager.async_request_sweep``
+        Public entry is ``BluetoothManager.async_request_active_scan``
         (validates finite/positive); this method clamps to
         ``[MIN, MAX]``.
 

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -83,7 +83,7 @@ DEFAULT_ACTIVE_SCAN_INTERVAL: Final = 300.0
 DEFAULT_ACTIVE_SCAN_DURATION: Final = 10.0
 
 # Default duration for an on-demand sweep triggered by
-# BluetoothManager.async_request_sweep (HA config-flow discovery).
+# BluetoothManager.async_request_active_scan (HA config-flow discovery).
 # 10s gives every device on the bus a chance to advertise during the
 # window without holding the caller too long.
 DEFAULT_ON_DEMAND_SWEEP_DURATION: Final = 10.0

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -82,6 +82,12 @@ MIN_ACTIVE_SCAN_DURATION: Final = 5.0
 DEFAULT_ACTIVE_SCAN_INTERVAL: Final = 300.0
 DEFAULT_ACTIVE_SCAN_DURATION: Final = 10.0
 
+# Default duration for an on-demand sweep triggered by
+# BluetoothManager.async_request_sweep (HA config-flow discovery).
+# 10s gives every device on the bus a chance to advertise during the
+# window without holding the caller too long.
+DEFAULT_ON_DEMAND_SWEEP_DURATION: Final = 10.0
+
 
 FAILED_ADAPTER_MAC = "00:00:00:00:00:00"
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -37,6 +37,7 @@ from .const import (
     CALLBACK_TYPE,
     DEFAULT_ACTIVE_SCAN_DURATION,
     DEFAULT_ACTIVE_SCAN_INTERVAL,
+    DEFAULT_ON_DEMAND_SWEEP_DURATION,
     FAILED_ADAPTER_MAC,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     MIN_ACTIVE_SCAN_DURATION,
@@ -1129,6 +1130,33 @@ class BluetoothManager:
         request = ActiveScanRequest(normalized, scan_interval, scan_duration)
         self._auto_scheduler.add_request(request)
         return partial(self._auto_scheduler.remove_request, request)
+
+    async def async_request_sweep(self, duration: float | None = None) -> None:
+        """
+        Run an on-demand active sweep across every AUTO scanner.
+
+        Intended for HA config-flow discovery: an integration can
+        call this to actively probe for new devices on the bus
+        rather than wait for the 12 hour rediscovery sweep.
+        Awaits ``duration`` seconds so the caller can read newly
+        discovered advertisements via the manager's history APIs
+        after this returns.
+
+        Concurrent callers share an in-flight sweep; the bus never
+        runs two on-demand windows simultaneously. Scanners with a
+        connect in progress are skipped (adjacent scanners cover the
+        same devices); ACTIVE scanners are already actively scanning
+        and need no flip. ``duration`` defaults to
+        ``DEFAULT_ON_DEMAND_SWEEP_DURATION`` (10s) and is clamped to
+        ``[AUTO_WINDOW_MIN_DURATION, AUTO_WINDOW_MAX_DURATION]`` by
+        the scheduler.
+        """
+        if duration is None:
+            duration = DEFAULT_ON_DEMAND_SWEEP_DURATION
+        if not math.isfinite(duration) or duration <= 0.0:
+            msg = "duration must be a finite positive number"
+            raise ValueError(msg)
+        await self._auto_scheduler.async_request_sweep(duration)
 
     def async_release_connection_slot(self, device: BLEDevice) -> None:
         """Release a connection slot."""

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1135,21 +1135,14 @@ class BluetoothManager:
         """
         Run an on-demand active sweep across every AUTO scanner.
 
-        Intended for HA config-flow discovery: an integration can
-        call this to actively probe for new devices on the bus
-        rather than wait for the 12 hour rediscovery sweep.
-        Awaits ``duration`` seconds so the caller can read newly
-        discovered advertisements via the manager's history APIs
-        after this returns.
-
-        Concurrent callers share an in-flight sweep; the bus never
-        runs two on-demand windows simultaneously. Scanners with a
-        connect in progress are skipped (adjacent scanners cover the
-        same devices); ACTIVE scanners are already actively scanning
-        and need no flip. ``duration`` defaults to
-        ``DEFAULT_ON_DEMAND_SWEEP_DURATION`` (10s) and is clamped to
+        Intended for HA config-flow discovery: probes the bus
+        actively without waiting for the 12 h rediscovery cadence,
+        awaits ``duration`` so the caller can then read
+        newly-discovered advertisements. Default 10s; clamped to
         ``[AUTO_WINDOW_MIN_DURATION, AUTO_WINDOW_MAX_DURATION]`` by
-        the scheduler.
+        the scheduler. Concurrent callers dedupe to one bus-wide
+        window (a longer request extends the in-flight one); see
+        ``AutoScanScheduler.async_request_sweep``.
         """
         if duration is None:
             duration = DEFAULT_ON_DEMAND_SWEEP_DURATION

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1131,7 +1131,7 @@ class BluetoothManager:
         self._auto_scheduler.add_request(request)
         return partial(self._auto_scheduler.remove_request, request)
 
-    async def async_request_sweep(self, duration: float | None = None) -> None:
+    async def async_request_active_scan(self, duration: float | None = None) -> None:
         """
         Run an on-demand active sweep across every AUTO scanner.
 
@@ -1142,14 +1142,14 @@ class BluetoothManager:
         ``[AUTO_WINDOW_MIN_DURATION, AUTO_WINDOW_MAX_DURATION]`` by
         the scheduler. Concurrent callers dedupe to one bus-wide
         window (a longer request extends the in-flight one); see
-        ``AutoScanScheduler.async_request_sweep``.
+        ``AutoScanScheduler.async_request_active_scan``.
         """
         if duration is None:
             duration = DEFAULT_ON_DEMAND_SWEEP_DURATION
         if not math.isfinite(duration) or duration <= 0.0:
             msg = "duration must be a finite positive number"
             raise ValueError(msg)
-        await self._auto_scheduler.async_request_sweep(duration)
+        await self._auto_scheduler.async_request_active_scan(duration)
 
     def async_release_connection_slot(self, device: BLEDevice) -> None:
         """Release a connection slot."""

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4354,17 +4354,30 @@ async def test_async_diagnostics() -> None:
 @contextlib.asynccontextmanager
 async def _no_real_sleep():
     """
-    Replace ``asyncio.sleep`` with an immediate no-op for sweep tests.
+    Replace ``asyncio.sleep`` with an immediate fake-time advance.
 
     Sweeps clamp duration to AUTO_WINDOW_MIN_DURATION (5s); stubbing
     the sleep keeps tests fast while preserving the call shape so we
-    can still observe what duration was requested.
+    can still observe what duration was requested. Each mocked sleep
+    also advances ``loop.time()`` by ``duration`` so the on-demand
+    sweep's sleep-until-end loop (which re-reads
+    ``_on_demand_sweep_end`` on each wake) terminates instead of
+    spinning forever against a frozen clock.
     """
+    loop = asyncio.get_running_loop()
+    real_time = loop.time
+    fake_advance = [0.0]
 
     async def _instant(duration: float) -> None:
-        return None
+        fake_advance[0] += duration
 
-    with patch("asyncio.sleep", new=_instant):
+    def _fake_time() -> float:
+        return real_time() + fake_advance[0]
+
+    with (
+        patch("asyncio.sleep", new=_instant),
+        patch.object(loop, "time", _fake_time),
+    ):
         yield
 
 
@@ -4423,6 +4436,43 @@ async def test_async_request_sweep_resets_next_sweep_time() -> None:
             await manager.async_request_sweep(duration=5.0)
         assert worker._sweep_last_completed >= before
         assert worker._sweep_last_completed <= loop.time() + 0.1
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_mixed_durations_extends_to_longest() -> None:
+    """
+    Concurrent callers asking for (10, 15, 5, 20) all wait until T0+20.
+
+    The first caller to win the check-and-set runs a 10s sweep; the 15s
+    and 20s callers extend the in-flight window (re-flipping the radio
+    with the longer remaining duration); the 5s caller fits within the
+    already-extended end and does not flip again. The scanner records
+    each flip's duration so we can verify the extension chain.
+    """
+    manager = get_manager()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        async with _no_real_sleep():
+            await asyncio.gather(
+                manager.async_request_sweep(duration=10.0),
+                manager.async_request_sweep(duration=15.0),
+                manager.async_request_sweep(duration=5.0),
+                manager.async_request_sweep(duration=20.0),
+            )
+        # Exactly three flip durations: leader's 10s + two extensions
+        # (~15s and ~20s, with sub-second drift from task-start
+        # jitter — assert the floor and the order).
+        assert len(scanner.active_window_calls) == 3
+        assert scanner.active_window_calls[0] == 10.0
+        # The two extensions are increasing and approach 15 and 20.
+        assert 14.0 <= scanner.active_window_calls[1] <= 15.0
+        assert 19.0 <= scanner.active_window_calls[2] <= 20.0
+        # The future and end are cleared once the leader finishes.
+        assert manager._auto_scheduler._on_demand_sweep_future is None
+        assert manager._auto_scheduler._on_demand_sweep_end == 0.0
     finally:
         register_cancel()
 

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4633,6 +4633,66 @@ async def test_async_request_active_scan_logs_per_scanner_flip_failures(
 
 
 @pytest.mark.asyncio
+async def test_async_request_active_scan_joiner_cancel_during_extension() -> None:
+    """
+    Joiner cancelled mid-extension still finishes the all-or-nothing re-flip.
+
+    Without ``asyncio.shield`` on the extension flip, a joiner
+    cancelled while extending would leave ``_on_demand_sweep_end``
+    pushed out past a partial re-flip, so the leader (and other
+    joiners) would sleep until the extended end believing every
+    scanner was active when some were not. With the shield, the
+    re-flip runs to completion; the scanner records both the
+    leader's original flip duration and the extension duration
+    even after the joiner is cancelled.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    with freeze_time() as frozen:
+        # Register inside freeze + stop the worker so the worker's
+        # own periodic sweep does not fire and pollute the recorded
+        # active_window_calls.
+        scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+        register_cancel = manager.async_register_scanner(scanner)
+        worker = sched._workers[scanner.source]
+        worker.stop()
+        await asyncio.sleep(0)
+        try:
+            # Block scanner flips so the leader stays in its first
+            # flip await while the joiner extends and is cancelled.
+            scanner._block_event = asyncio.Event()
+            leader = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
+            for _ in range(3):
+                await asyncio.sleep(0)
+            joiner = asyncio.create_task(
+                manager.async_request_active_scan(duration=20.0)
+            )
+            # Yield enough for the joiner to enter its shielded
+            # extension flip (which is now also blocked on the
+            # scanner's block_event).
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert len(scanner.active_window_calls) == 2
+            joiner.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await joiner
+            # Release the scanner; leader's flip returns, joiner's
+            # shielded flip also completes as an orphan task.
+            scanner._block_event.set()
+            frozen.tick(20.1)
+            await leader
+            # Both leader's 5s flip and joiner's ~20s extension
+            # recorded despite the cancel.
+            assert scanner.active_window_calls[0] == 5.0
+            assert scanner.active_window_calls[1] == pytest.approx(20.0, abs=1.0)
+            assert sched._on_demand_sweep_future is None
+        finally:
+            register_cancel()
+
+
+@pytest.mark.asyncio
 async def test_async_request_active_scan_joiner_cancel_keeps_siblings() -> None:
     """
     Cancelling one joiner must not cancel the shared future.

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -7,8 +7,10 @@ import contextlib
 import logging
 import math
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
+from freezegun import freeze_time
 
 from habluetooth import (
     BaseHaScanner,
@@ -25,6 +27,7 @@ from habluetooth.const import (
     AUTO_WINDOW_MIN_DURATION,
     DEFAULT_ACTIVE_SCAN_DURATION,
     DEFAULT_ACTIVE_SCAN_INTERVAL,
+    DEFAULT_ON_DEMAND_SWEEP_DURATION,
 )
 
 from . import generate_advertisement_data, generate_ble_device
@@ -4346,3 +4349,176 @@ async def test_async_diagnostics() -> None:
     # After cancellation the address falls out of both indexes.
     post = sched.async_diagnostics()
     assert post["requests"] == {}
+
+
+@contextlib.asynccontextmanager
+async def _no_real_sleep():
+    """
+    Replace ``asyncio.sleep`` with an immediate no-op for sweep tests.
+
+    Sweeps clamp duration to AUTO_WINDOW_MIN_DURATION (5s); stubbing
+    the sleep keeps tests fast while preserving the call shape so we
+    can still observe what duration was requested.
+    """
+
+    async def _instant(duration: float) -> None:
+        return None
+
+    with patch("asyncio.sleep", new=_instant):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_fires_active_window_on_each_auto_scanner() -> None:
+    """A sweep flips every AUTO scanner into ACTIVE for the duration."""
+    manager = get_manager()
+    a = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    b = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+    c_a = manager.async_register_scanner(a)
+    c_b = manager.async_register_scanner(b)
+    try:
+        async with _no_real_sleep():
+            await manager.async_request_sweep(duration=7.0)
+        assert a.active_window_calls == [7.0]
+        assert b.active_window_calls == [7.0]
+    finally:
+        c_a()
+        c_b()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_skips_connecting_scanner() -> None:
+    """A scanner mid-connect is skipped; non-connecting peers still flip."""
+    manager = get_manager()
+    busy = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    free = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+    c_busy = manager.async_register_scanner(busy)
+    c_free = manager.async_register_scanner(free)
+    busy._add_connecting("11:22:33:44:55:66")
+    try:
+        async with _no_real_sleep():
+            await manager.async_request_sweep(duration=5.0)
+        assert busy.active_window_calls == []
+        assert free.active_window_calls == [5.0]
+    finally:
+        busy._finished_connecting("11:22:33:44:55:66", connected=False)
+        c_busy()
+        c_free()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_resets_next_sweep_time() -> None:
+    """A sweep advances each flipped worker's _sweep_last_completed to now."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    worker = sched._workers[scanner.source]
+    # Backdate so we can observe the bump.
+    worker._sweep_last_completed = loop.time() - AUTO_REDISCOVERY_INTERVAL - 1.0
+    try:
+        before = loop.time()
+        async with _no_real_sleep():
+            await manager.async_request_sweep(duration=5.0)
+        assert worker._sweep_last_completed >= before
+        assert worker._sweep_last_completed <= loop.time() + 0.1
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_dedupes_concurrent_callers() -> None:
+    """Two concurrent sweep calls share one window; the bus flips once."""
+    manager = get_manager()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        async with _no_real_sleep():
+            await asyncio.gather(
+                manager.async_request_sweep(duration=5.0),
+                manager.async_request_sweep(duration=5.0),
+            )
+        # Only one active window despite two callers.
+        assert scanner.active_window_calls == [5.0]
+        # The deduped future is cleared once the sweep finishes.
+        assert manager._auto_scheduler._on_demand_sweep_future is None
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_default_duration_is_10s() -> None:
+    """Calling without a duration uses DEFAULT_ON_DEMAND_SWEEP_DURATION (10s)."""
+    manager = get_manager()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        async with _no_real_sleep():
+            await manager.async_request_sweep()
+        assert scanner.active_window_calls == [DEFAULT_ON_DEMAND_SWEEP_DURATION]
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_clamps_to_window_bounds() -> None:
+    """Out-of-range durations are clamped to [MIN, MAX]."""
+    manager = get_manager()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        async with _no_real_sleep():
+            await manager.async_request_sweep(duration=0.5)  # below MIN
+            await manager.async_request_sweep(duration=999.0)  # above MAX
+        assert scanner.active_window_calls == [
+            AUTO_WINDOW_MIN_DURATION,
+            AUTO_WINDOW_MAX_DURATION,
+        ]
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_rejects_invalid_duration() -> None:
+    """NaN, inf, zero, and negative durations raise ValueError."""
+    manager = get_manager()
+    for bad in (float("nan"), float("inf"), float("-inf"), 0.0, -1.0):
+        with pytest.raises(ValueError, match="finite positive"):
+            await manager.async_request_sweep(duration=bad)
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_awaits_the_full_duration() -> None:
+    """
+    The sweep awaits ``duration`` so the caller can read advertisements.
+
+    Freezegun patches ``time.monotonic`` (and thus ``loop.time``);
+    advancing the frozen clock by the requested duration lets the
+    scheduler's internal ``asyncio.sleep`` complete and the task
+    finish. The scanner is registered inside the freeze so the
+    worker's ``_sweep_last_completed`` is anchored to the frozen
+    clock; the worker's background ``_run`` task is cancelled so it
+    cannot tick during the on-demand window.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    with freeze_time() as frozen:
+        scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+        register_cancel = manager.async_register_scanner(scanner)
+        worker = sched._workers[scanner.source]
+        worker.stop()
+        await asyncio.sleep(0)
+        try:
+            task = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            # Let the task start, flip the radio, and enter asyncio.sleep.
+            for _ in range(5):
+                await asyncio.sleep(0)
+            assert scanner.active_window_calls == [5.0]
+            assert not task.done()
+            # Advance past the sweep duration; the sleep wakes up.
+            frozen.tick(5.1)
+            await task
+            assert task.done()
+        finally:
+            register_cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4382,7 +4382,9 @@ async def _no_real_sleep():
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_fires_active_window_on_each_auto_scanner() -> None:
+async def test_async_request_active_scan_fires_active_window_on_each_auto_scanner() -> (
+    None
+):
     """A sweep flips every AUTO scanner into ACTIVE for the duration."""
     manager = get_manager()
     a = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
@@ -4391,7 +4393,7 @@ async def test_async_request_sweep_fires_active_window_on_each_auto_scanner() ->
     c_b = manager.async_register_scanner(b)
     try:
         async with _no_real_sleep():
-            await manager.async_request_sweep(duration=7.0)
+            await manager.async_request_active_scan(duration=7.0)
         assert a.active_window_calls == [7.0]
         assert b.active_window_calls == [7.0]
     finally:
@@ -4400,7 +4402,7 @@ async def test_async_request_sweep_fires_active_window_on_each_auto_scanner() ->
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_skips_connecting_scanner() -> None:
+async def test_async_request_active_scan_skips_connecting_scanner() -> None:
     """A scanner mid-connect is skipped; non-connecting peers still flip."""
     manager = get_manager()
     busy = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
@@ -4410,7 +4412,7 @@ async def test_async_request_sweep_skips_connecting_scanner() -> None:
     busy._add_connecting("11:22:33:44:55:66")
     try:
         async with _no_real_sleep():
-            await manager.async_request_sweep(duration=5.0)
+            await manager.async_request_active_scan(duration=5.0)
         assert busy.active_window_calls == []
         assert free.active_window_calls == [5.0]
     finally:
@@ -4420,7 +4422,7 @@ async def test_async_request_sweep_skips_connecting_scanner() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_resets_next_sweep_time() -> None:
+async def test_async_request_active_scan_resets_next_sweep_time() -> None:
     """A sweep advances each flipped worker's _sweep_last_completed to now."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -4433,7 +4435,7 @@ async def test_async_request_sweep_resets_next_sweep_time() -> None:
     try:
         before = loop.time()
         async with _no_real_sleep():
-            await manager.async_request_sweep(duration=5.0)
+            await manager.async_request_active_scan(duration=5.0)
         assert worker._sweep_last_completed >= before
         assert worker._sweep_last_completed <= loop.time() + 0.1
     finally:
@@ -4441,7 +4443,7 @@ async def test_async_request_sweep_resets_next_sweep_time() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_mixed_durations_extends_to_longest() -> None:
+async def test_async_request_active_scan_mixed_durations_extends_to_longest() -> None:
     """
     Concurrent callers asking for (10, 15, 5, 20) all wait until T0+20.
 
@@ -4457,10 +4459,10 @@ async def test_async_request_sweep_mixed_durations_extends_to_longest() -> None:
     try:
         async with _no_real_sleep():
             await asyncio.gather(
-                manager.async_request_sweep(duration=10.0),
-                manager.async_request_sweep(duration=15.0),
-                manager.async_request_sweep(duration=5.0),
-                manager.async_request_sweep(duration=20.0),
+                manager.async_request_active_scan(duration=10.0),
+                manager.async_request_active_scan(duration=15.0),
+                manager.async_request_active_scan(duration=5.0),
+                manager.async_request_active_scan(duration=20.0),
             )
         # Exactly three flip durations: leader's 10s + two extensions
         # (approximately 15s and 20s, with sub-second drift from
@@ -4483,7 +4485,7 @@ async def test_async_request_sweep_mixed_durations_extends_to_longest() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_dedupes_concurrent_callers() -> None:
+async def test_async_request_active_scan_dedupes_concurrent_callers() -> None:
     """N concurrent sweep calls share one window; the bus flips once."""
     manager = get_manager()
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
@@ -4493,9 +4495,9 @@ async def test_async_request_sweep_dedupes_concurrent_callers() -> None:
             # Three concurrent callers, mirroring HA integrations each
             # opening their own config flow at the same time.
             await asyncio.gather(
-                manager.async_request_sweep(duration=5.0),
-                manager.async_request_sweep(duration=5.0),
-                manager.async_request_sweep(duration=5.0),
+                manager.async_request_active_scan(duration=5.0),
+                manager.async_request_active_scan(duration=5.0),
+                manager.async_request_active_scan(duration=5.0),
             )
         # Only one active window despite three callers.
         assert scanner.active_window_calls == [5.0]
@@ -4506,29 +4508,29 @@ async def test_async_request_sweep_dedupes_concurrent_callers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_default_duration_is_10s() -> None:
+async def test_async_request_active_scan_default_duration_is_10s() -> None:
     """Calling without a duration uses DEFAULT_ON_DEMAND_SWEEP_DURATION (10s)."""
     manager = get_manager()
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
         async with _no_real_sleep():
-            await manager.async_request_sweep()
+            await manager.async_request_active_scan()
         assert scanner.active_window_calls == [DEFAULT_ON_DEMAND_SWEEP_DURATION]
     finally:
         register_cancel()
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_clamps_to_window_bounds() -> None:
+async def test_async_request_active_scan_clamps_to_window_bounds() -> None:
     """Out-of-range durations are clamped to [MIN, MAX]."""
     manager = get_manager()
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
         async with _no_real_sleep():
-            await manager.async_request_sweep(duration=0.5)  # below MIN
-            await manager.async_request_sweep(duration=999.0)  # above MAX
+            await manager.async_request_active_scan(duration=0.5)  # below MIN
+            await manager.async_request_active_scan(duration=999.0)  # above MAX
         assert scanner.active_window_calls == [
             AUTO_WINDOW_MIN_DURATION,
             AUTO_WINDOW_MAX_DURATION,
@@ -4538,34 +4540,34 @@ async def test_async_request_sweep_clamps_to_window_bounds() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_rejects_invalid_duration() -> None:
+async def test_async_request_active_scan_rejects_invalid_duration() -> None:
     """NaN, inf, zero, and negative durations raise ValueError."""
     manager = get_manager()
     for bad in (float("nan"), float("inf"), float("-inf"), 0.0, -1.0):
         with pytest.raises(ValueError, match="finite positive"):
-            await manager.async_request_sweep(duration=bad)
+            await manager.async_request_active_scan(duration=bad)
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_no_op_when_scheduler_stopped() -> None:
+async def test_async_request_active_scan_no_op_when_scheduler_stopped() -> None:
     """After stop() the scheduler has no loop; the sweep returns immediately."""
     manager = get_manager()
     manager._auto_scheduler.stop()
-    await manager.async_request_sweep(duration=5.0)
+    await manager.async_request_active_scan(duration=5.0)
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_no_op_without_auto_scanners() -> None:
+async def test_async_request_active_scan_no_op_without_auto_scanners() -> None:
     """With no AUTO workers the sweep still completes its sleep cleanly."""
     manager = get_manager()
     # No scanners registered; targets is empty but the sleep still runs.
     async with _no_real_sleep():
-        await manager.async_request_sweep(duration=5.0)
+        await manager.async_request_active_scan(duration=5.0)
     assert manager._auto_scheduler._on_demand_sweep_future is None
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_awaits_the_full_duration() -> None:
+async def test_async_request_active_scan_awaits_the_full_duration() -> None:
     """
     The sweep awaits ``duration`` so the caller can read advertisements.
 
@@ -4586,7 +4588,7 @@ async def test_async_request_sweep_awaits_the_full_duration() -> None:
         worker.stop()
         await asyncio.sleep(0)
         try:
-            task = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            task = asyncio.create_task(manager.async_request_active_scan(duration=5.0))
             # Let the task start, flip the radio, and enter asyncio.sleep.
             for _ in range(5):
                 await asyncio.sleep(0)
@@ -4601,7 +4603,7 @@ async def test_async_request_sweep_awaits_the_full_duration() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_logs_per_scanner_flip_failures(
+async def test_async_request_active_scan_logs_per_scanner_flip_failures(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A scanner whose flip raises is logged; the sweep still completes."""
@@ -4619,7 +4621,7 @@ async def test_async_request_sweep_logs_per_scanner_flip_failures(
     try:
         with caplog.at_level(logging.WARNING, logger="habluetooth.auto_scheduler"):
             async with _no_real_sleep():
-                await manager.async_request_sweep(duration=5.0)
+                await manager.async_request_active_scan(duration=5.0)
         assert good.active_window_calls == [5.0]
         assert any(
             "on-demand active window" in record.message and "boom" in record.message
@@ -4631,9 +4633,7 @@ async def test_async_request_sweep_logs_per_scanner_flip_failures(
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_joiner_cancellation_does_not_break_siblings() -> (
-    None
-):
+async def test_async_request_active_scan_joiner_cancel_keeps_siblings() -> None:
     """
     Cancelling one joiner must not cancel the shared future.
 
@@ -4649,9 +4649,15 @@ async def test_async_request_sweep_joiner_cancellation_does_not_break_siblings()
     try:
         with freeze_time() as frozen:
             scanner._block_event = asyncio.Event()
-            leader = asyncio.create_task(manager.async_request_sweep(duration=5.0))
-            joiner_a = asyncio.create_task(manager.async_request_sweep(duration=5.0))
-            joiner_b = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            leader = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
+            joiner_a = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
+            joiner_b = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
             for _ in range(5):
                 await asyncio.sleep(0)
             # Cancel one joiner; siblings and leader must continue.
@@ -4670,7 +4676,7 @@ async def test_async_request_sweep_joiner_cancellation_does_not_break_siblings()
 
 
 @pytest.mark.asyncio
-async def test_async_request_sweep_leader_cancellation_releases_joiners() -> None:
+async def test_async_request_active_scan_leader_cancellation_releases_joiners() -> None:
     """
     Cancelling the leader still resolves the future so joiners do not hang.
 
@@ -4688,8 +4694,12 @@ async def test_async_request_sweep_leader_cancellation_releases_joiners() -> Non
             # we're past the gather and inside the leader's sleep when
             # we cancel.
             scanner._block_event = asyncio.Event()
-            leader = asyncio.create_task(manager.async_request_sweep(duration=5.0))
-            joiner = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            leader = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
+            joiner = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
             for _ in range(5):
                 await asyncio.sleep(0)
             # Both tasks are now waiting; joiner has latched onto the

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4463,13 +4463,18 @@ async def test_async_request_sweep_mixed_durations_extends_to_longest() -> None:
                 manager.async_request_sweep(duration=20.0),
             )
         # Exactly three flip durations: leader's 10s + two extensions
-        # (~15s and ~20s, with sub-second drift from task-start
-        # jitter — assert the floor and the order).
+        # (approximately 15s and 20s, with sub-second drift from
+        # task-start jitter — pytest.approx absorbs the drift, and
+        # the ordering pins the chain.
         assert len(scanner.active_window_calls) == 3
         assert scanner.active_window_calls[0] == 10.0
-        # The two extensions are increasing and approach 15 and 20.
-        assert 14.0 <= scanner.active_window_calls[1] <= 15.0
-        assert 19.0 <= scanner.active_window_calls[2] <= 20.0
+        assert scanner.active_window_calls[1] == pytest.approx(15.0, abs=1.0)
+        assert scanner.active_window_calls[2] == pytest.approx(20.0, abs=1.0)
+        assert (
+            scanner.active_window_calls[0]
+            < scanner.active_window_calls[1]
+            < scanner.active_window_calls[2]
+        )
         # The future and end are cleared once the leader finishes.
         assert manager._auto_scheduler._on_demand_sweep_future is None
         assert manager._auto_scheduler._on_demand_sweep_end == 0.0
@@ -4623,6 +4628,45 @@ async def test_async_request_sweep_logs_per_scanner_flip_failures(
     finally:
         c_bad()
         c_good()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_joiner_cancellation_does_not_break_siblings() -> (
+    None
+):
+    """
+    Cancelling one joiner must not cancel the shared future.
+
+    Without ``asyncio.shield`` on the joiner's await, a cancelled
+    joiner would cancel the underlying future, which then propagates
+    ``CancelledError`` to sibling joiners and makes the leader's
+    ``finally`` raise ``InvalidStateError`` on ``set_result``.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        with freeze_time() as frozen:
+            scanner._block_event = asyncio.Event()
+            leader = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            joiner_a = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            joiner_b = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            for _ in range(5):
+                await asyncio.sleep(0)
+            # Cancel one joiner; siblings and leader must continue.
+            joiner_a.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await joiner_a
+            scanner._block_event.set()
+            frozen.tick(5.1)
+            # Leader and the surviving joiner both complete normally.
+            await leader
+            await joiner_b
+            assert joiner_b.result() is None
+            assert sched._on_demand_sweep_future is None
+    finally:
+        register_cancel()
 
 
 @pytest.mark.asyncio

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4489,6 +4489,24 @@ async def test_async_request_sweep_rejects_invalid_duration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_request_sweep_no_op_when_scheduler_stopped() -> None:
+    """After stop() the scheduler has no loop; the sweep returns immediately."""
+    manager = get_manager()
+    manager._auto_scheduler.stop()
+    await manager.async_request_sweep(duration=5.0)
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_no_op_without_auto_scanners() -> None:
+    """With no AUTO workers the sweep still completes its sleep cleanly."""
+    manager = get_manager()
+    # No scanners registered; targets is empty but the sleep still runs.
+    async with _no_real_sleep():
+        await manager.async_request_sweep(duration=5.0)
+    assert manager._auto_scheduler._on_demand_sweep_future is None
+
+
+@pytest.mark.asyncio
 async def test_async_request_sweep_awaits_the_full_duration() -> None:
     """
     The sweep awaits ``duration`` so the caller can read advertisements.

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4540,3 +4540,73 @@ async def test_async_request_sweep_awaits_the_full_duration() -> None:
             assert task.done()
         finally:
             register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_logs_per_scanner_flip_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A scanner whose flip raises is logged; the sweep still completes."""
+    manager = get_manager()
+
+    class _FailingScanner(_RecordingAutoScanner):
+        async def async_request_active_window(self, duration: float) -> bool:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    bad = _FailingScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    good = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+    c_bad = manager.async_register_scanner(bad)
+    c_good = manager.async_register_scanner(good)
+    try:
+        with caplog.at_level(logging.WARNING, logger="habluetooth.auto_scheduler"):
+            async with _no_real_sleep():
+                await manager.async_request_sweep(duration=5.0)
+        assert good.active_window_calls == [5.0]
+        assert any(
+            "on-demand active window" in record.message and "boom" in record.message
+            for record in caplog.records
+        )
+    finally:
+        c_bad()
+        c_good()
+
+
+@pytest.mark.asyncio
+async def test_async_request_sweep_leader_cancellation_releases_joiners() -> None:
+    """
+    Cancelling the leader still resolves the future so joiners do not hang.
+
+    Joiners see ``None`` (no propagated ``CancelledError``) and benefit
+    from whatever radio activity already happened; a subsequent sweep can
+    run because ``_on_demand_sweep_future`` is cleared.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        with freeze_time():
+            # Block the leader inside its scanner-flip await so we know
+            # we're past the gather and inside the leader's sleep when
+            # we cancel.
+            scanner._block_event = asyncio.Event()
+            leader = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            joiner = asyncio.create_task(manager.async_request_sweep(duration=5.0))
+            for _ in range(5):
+                await asyncio.sleep(0)
+            # Both tasks are now waiting; joiner has latched onto the
+            # leader's future.
+            assert not leader.done()
+            assert not joiner.done()
+            scanner._block_event.set()
+            leader.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await leader
+            # Joiner completes normally with no exception.
+            await joiner
+            assert joiner.result() is None
+            # Future is cleared so a fresh sweep can start.
+            assert sched._on_demand_sweep_future is None
+    finally:
+        register_cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4429,17 +4429,20 @@ async def test_async_request_sweep_resets_next_sweep_time() -> None:
 
 @pytest.mark.asyncio
 async def test_async_request_sweep_dedupes_concurrent_callers() -> None:
-    """Two concurrent sweep calls share one window; the bus flips once."""
+    """N concurrent sweep calls share one window; the bus flips once."""
     manager = get_manager()
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
         async with _no_real_sleep():
+            # Three concurrent callers, mirroring HA integrations each
+            # opening their own config flow at the same time.
             await asyncio.gather(
                 manager.async_request_sweep(duration=5.0),
                 manager.async_request_sweep(duration=5.0),
+                manager.async_request_sweep(duration=5.0),
             )
-        # Only one active window despite two callers.
+        # Only one active window despite three callers.
         assert scanner.active_window_calls == [5.0]
         # The deduped future is cleared once the sweep finishes.
         assert manager._auto_scheduler._on_demand_sweep_future is None


### PR DESCRIPTION
Adds `BluetoothManager.async_request_active_scan` so Home Assistant config flows can actively probe the bus for new devices on demand rather than waiting for the 12 h rediscovery sweep; awaits the requested duration (default 10s, clamped to `[AUTO_WINDOW_MIN_DURATION, AUTO_WINDOW_MAX_DURATION]`) so callers can read newly discovered advertisements before the call returns. Each flipped scanner's periodic sweep cadence is reset via `note_window_dispatched`; scanners mid-connect are skipped (on-demand is best-effort, no fallback).

Concurrent callers dedupe to one bus-wide window via a shared future (synchronous check-and-set, atomic under cooperative scheduling). A joiner whose requested end-time exceeds the in-flight window's end extends it: re-flips the scanners with the longer remaining duration (the radio extends an open window in place) and pushes `_on_demand_sweep_end`; the leader's sleep loop re-reads it on each wake so the leader sleeps until the latest desired end. For four callers requesting (10, 15, 5, 20) the radio runs to T0+20 and every caller awaits until then.

Cancellation: leader's cancel propagates to its caller and joiners wake to `None` (best-effort, they get whatever radio activity happened). Joiner cancel uses `asyncio.shield` on the await so it cannot cancel the shared future and take down siblings or the leader's `set_result`. A concurrent `stop()` cannot AttributeError the leader's sleep loop; the loop captures the loop reference locally.