### PR TITLE
fix(auto-scheduler): coalesce near-future due entries into the current window

### DIFF
--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -8,6 +8,7 @@ cdef double _AUTO_REDISCOVERY_SWEEP_DURATION
 cdef double _AUTO_WINDOW_MAX_DURATION
 cdef double _AUTO_WINDOW_MIN_DURATION
 cdef double _AUTO_CONNECTING_DEFER
+cdef double _AUTO_COALESCE_LOOKAHEAD
 cdef int NO_RSSI_VALUE
 
 
@@ -59,6 +60,9 @@ cdef class _ScannerWorker:
         due=list,
         due_buckets=list,
         all_due=list,
+        threshold=double,
+        any_immediate=bint,
+        t=double,
     )
     cpdef tuple _collect_due_buckets(self, double now)
 

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -395,7 +395,7 @@ class _ScannerWorker:
                 continue
             if history.source != source:
                 continue
-            due = []
+            due: list[ActiveScanRequest] = []
             for r, t in entries.items():
                 if t <= threshold:
                     due.append(r)

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -351,24 +351,30 @@ class _ScannerWorker:
     ) -> tuple[
         list[tuple[str, dict[ActiveScanRequest, float], list[ActiveScanRequest]]],
         list[ActiveScanRequest],
+        bool,
     ]:
         """
-        Return (due_buckets, all_due) for addresses this scanner owns.
+        Return (due_buckets, all_due, any_immediate) for addresses owned.
 
         ``due_buckets`` is the (address, entries, due) triples to
         advance after the window; ``all_due`` is the flattened list
-        used to coalesce the window duration. The address is carried
-        in each tuple so the connecting-fallback path in ``_tick`` can
-        look up an alternate scanner per address without re-walking
-        ``_needs``. Prunes orphan ``_needs`` entries (history None) in
-        passing.
+        used to coalesce the window duration; ``any_immediate`` is
+        True iff at least one collected entry is ``t <= now``.
+        Prunes orphan ``_needs`` entries (history None) in passing.
 
-        Lookahead: entries due within ``_AUTO_COALESCE_LOOKAHEAD``
-        seconds of ``now`` are also collected and advanced so devices
-        registered at staggered times do not trigger back-to-back
-        active flips a few seconds apart. The bucket is only returned
-        if at least one entry is immediately due (``t <= now``); a
-        scanner that only has soon-due entries does not tick early.
+        Lookahead: every entry due within
+        ``_AUTO_COALESCE_LOOKAHEAD`` seconds of ``now`` is collected
+        regardless of ``any_immediate``. Caller decides whether to
+        fire — typically when ``any_immediate or sweep_due`` — so
+        soon-due entries also ride a sweep window when it fires
+        alone (any active radio captures every advertiser in range,
+        so pulling them in is free). A scanner with only soon-due
+        entries does not tick early on its own; ``_tick``'s gate
+        enforces that.
+
+        Invariant: ``_AUTO_COALESCE_LOOKAHEAD >= max window
+        duration`` so a window can never outlive its lookahead and
+        leave a device overdue when it ends.
         """
         source = self._scanner.source
         needs = self._scheduler._needs
@@ -399,9 +405,7 @@ class _ScannerWorker:
                 continue
             due_buckets.append((address, entries, due))
             all_due.extend(due)
-        if not any_immediate:
-            return [], []
-        return due_buckets, all_due
+        return due_buckets, all_due, any_immediate
 
     def _advance_due(
         self,
@@ -445,9 +449,12 @@ class _ScannerWorker:
             return
         self._window_end = 0.0
         try:
-            due_buckets, all_due = self._collect_due_buckets(now)
+            due_buckets, all_due, any_immediate = self._collect_due_buckets(now)
             sweep_due = now >= self._sweep_last_completed + _AUTO_REDISCOVERY_INTERVAL
-            if not all_due and not sweep_due:
+            # Gate on any_immediate (per-device hit now) or sweep_due
+            # (12 h floor). Soon-due-only entries ride a window that
+            # one of those triggers, but never trigger one alone.
+            if not any_immediate and not sweep_due:
                 return
             if self._scanner._connections_in_progress() > 0:
                 # Per-address advance happens inside _dispatch_to_fallback

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -147,6 +147,7 @@ from typing import TYPE_CHECKING, Any
 from bleak_retry_connector import NO_RSSI_VALUE
 
 from .const import (
+    AUTO_COALESCE_LOOKAHEAD,
     AUTO_INITIAL_SWEEP_DELAY,
     AUTO_REDISCOVERY_INTERVAL,
     AUTO_REDISCOVERY_SWEEP_DURATION,
@@ -167,6 +168,7 @@ _AUTO_REDISCOVERY_INTERVAL = AUTO_REDISCOVERY_INTERVAL
 _AUTO_REDISCOVERY_SWEEP_DURATION = AUTO_REDISCOVERY_SWEEP_DURATION
 _AUTO_WINDOW_MAX_DURATION = AUTO_WINDOW_MAX_DURATION
 _AUTO_WINDOW_MIN_DURATION = AUTO_WINDOW_MIN_DURATION
+_AUTO_COALESCE_LOOKAHEAD = AUTO_COALESCE_LOOKAHEAD
 
 # Retry delay when the owner is mid-connect: short enough that we
 # retry shortly after a typical connect completes (~10s), long enough
@@ -360,14 +362,23 @@ class _ScannerWorker:
         look up an alternate scanner per address without re-walking
         ``_needs``. Prunes orphan ``_needs`` entries (history None) in
         passing.
+
+        Lookahead: entries due within ``_AUTO_COALESCE_LOOKAHEAD``
+        seconds of ``now`` are also collected and advanced so devices
+        registered at staggered times do not trigger back-to-back
+        active flips a few seconds apart. The bucket is only returned
+        if at least one entry is immediately due (``t <= now``); a
+        scanner that only has soon-due entries does not tick early.
         """
         source = self._scanner.source
         needs = self._scheduler._needs
         last_service_info = self._manager.async_last_service_info
+        threshold = now + _AUTO_COALESCE_LOOKAHEAD
         due_buckets: list[
             tuple[str, dict[ActiveScanRequest, float], list[ActiveScanRequest]]
         ] = []
         all_due: list[ActiveScanRequest] = []
+        any_immediate = False
         for address in list(needs):
             entries = needs.get(address)
             if not entries:
@@ -378,11 +389,18 @@ class _ScannerWorker:
                 continue
             if history.source != source:
                 continue
-            due = [r for r, t in entries.items() if t <= now]
+            due = []
+            for r, t in entries.items():
+                if t <= threshold:
+                    due.append(r)
+                    if t <= now:
+                        any_immediate = True
             if not due:
                 continue
             due_buckets.append((address, entries, due))
             all_due.extend(due)
+        if not any_immediate:
+            return [], []
         return due_buckets, all_due
 
     def _advance_due(

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -356,25 +356,17 @@ class _ScannerWorker:
         """
         Return (due_buckets, all_due, any_immediate) for addresses owned.
 
-        ``due_buckets`` is the (address, entries, due) triples to
-        advance after the window; ``all_due`` is the flattened list
-        used to coalesce the window duration; ``any_immediate`` is
-        True iff at least one collected entry is ``t <= now``.
-        Prunes orphan ``_needs`` entries (history None) in passing.
+        Collects entries due within ``_AUTO_COALESCE_LOOKAHEAD`` of
+        ``now`` regardless of ``any_immediate``, so soon-due entries
+        ride a window the caller decides to open (a per-device hit
+        or the 12 h sweep). Caller must gate on
+        ``any_immediate or sweep_due`` — a scanner with only
+        soon-due entries must not tick early on its own. Prunes
+        orphan entries (history None) in passing.
 
-        Lookahead: every entry due within
-        ``_AUTO_COALESCE_LOOKAHEAD`` seconds of ``now`` is collected
-        regardless of ``any_immediate``. Caller decides whether to
-        fire — typically when ``any_immediate or sweep_due`` — so
-        soon-due entries also ride a sweep window when it fires
-        alone (any active radio captures every advertiser in range,
-        so pulling them in is free). A scanner with only soon-due
-        entries does not tick early on its own; ``_tick``'s gate
-        enforces that.
-
-        Invariant: ``_AUTO_COALESCE_LOOKAHEAD >= max window
-        duration`` so a window can never outlive its lookahead and
-        leave a device overdue when it ends.
+        Invariant: ``_AUTO_COALESCE_LOOKAHEAD > max window duration``
+        so a window cannot outlive its lookahead and leave a device
+        overdue when it ends.
         """
         source = self._scanner.source
         needs = self._scheduler._needs

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -67,23 +67,13 @@ AUTO_REDISCOVERY_SWEEP_DURATION: Final = 15.0
 AUTO_WINDOW_MIN_DURATION: Final = 5.0
 AUTO_WINDOW_MAX_DURATION: Final = 30.0
 
-# When the worker ticks, also pull in per-device entries due within
-# this many seconds so devices registered at staggered times coalesce
-# into one window instead of triggering back-to-back active flips
-# seconds apart. Devices pulled forward are scanned slightly early
-# (at most AUTO_COALESCE_LOOKAHEAD seconds) on this tick; their
-# next_due is advanced from now, so they sync up with the rest of
-# the bucket on subsequent ticks.
-#
-# Slop added to the coalesce lookahead so a device due exactly at
-# AUTO_WINDOW_MAX_DURATION away is still pulled in despite loop.time()
-# drifting forward between bucket collection and window open.
+# Per-device entries due within AUTO_COALESCE_LOOKAHEAD of now are
+# pulled into the current window so staggered registrations sync up
+# instead of triggering back-to-back active flips. Must exceed
+# AUTO_WINDOW_MAX_DURATION so a window can never outlive its
+# lookahead; the slop absorbs loop.time drift between bucket
+# collection and window open under a blocked event loop.
 AUTO_COALESCE_LOOKAHEAD_SLOP: Final = 5.0
-
-# Invariant: must be > AUTO_WINDOW_MAX_DURATION so a window can
-# never outlive the lookahead. If it did, a device due in the gap
-# would be left overdue when the window ends and fire a back-to-back
-# active flip — exactly the bug this coalescing is meant to prevent.
 AUTO_COALESCE_LOOKAHEAD: Final = AUTO_WINDOW_MAX_DURATION + AUTO_COALESCE_LOOKAHEAD_SLOP
 
 # Minimum values accepted by async_register_active_scan. Anything

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -67,6 +67,15 @@ AUTO_REDISCOVERY_SWEEP_DURATION: Final = 15.0
 AUTO_WINDOW_MIN_DURATION: Final = 5.0
 AUTO_WINDOW_MAX_DURATION: Final = 30.0
 
+# When the worker ticks, also pull in per-device entries due within
+# this many seconds so devices registered at staggered times coalesce
+# into one window instead of triggering back-to-back active flips
+# seconds apart. Devices pulled forward are scanned slightly early
+# (at most AUTO_COALESCE_LOOKAHEAD seconds) on this tick; their
+# next_due is advanced from now, so they sync up with the rest of
+# the bucket on subsequent ticks.
+AUTO_COALESCE_LOOKAHEAD: Final = 15.0
+
 # Minimum values accepted by async_register_active_scan. Anything
 # shorter would just churn the radio without giving the device time to
 # respond on its scan response.

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -74,7 +74,17 @@ AUTO_WINDOW_MAX_DURATION: Final = 30.0
 # (at most AUTO_COALESCE_LOOKAHEAD seconds) on this tick; their
 # next_due is advanced from now, so they sync up with the rest of
 # the bucket on subsequent ticks.
-AUTO_COALESCE_LOOKAHEAD: Final = 15.0
+#
+# Slop added to the coalesce lookahead so a device due exactly at
+# AUTO_WINDOW_MAX_DURATION away is still pulled in despite loop.time()
+# drifting forward between bucket collection and window open.
+AUTO_COALESCE_LOOKAHEAD_SLOP: Final = 5.0
+
+# Invariant: must be > AUTO_WINDOW_MAX_DURATION so a window can
+# never outlive the lookahead. If it did, a device due in the gap
+# would be left overdue when the window ends and fire a back-to-back
+# active flip — exactly the bug this coalescing is meant to prevent.
+AUTO_COALESCE_LOOKAHEAD: Final = AUTO_WINDOW_MAX_DURATION + AUTO_COALESCE_LOOKAHEAD_SLOP
 
 # Minimum values accepted by async_register_active_scan. Anything
 # shorter would just churn the radio without giving the device time to

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -295,6 +295,93 @@ async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> No
 
 
 @pytest.mark.asyncio
+async def test_worker_tick_coalesces_when_window_longer_than_short_lookahead() -> None:
+    """
+    Lookahead covers the maximum window so long windows do not cascade.
+
+    A scan_duration of 30s (the public-boundary clamp ceiling)
+    opens a 30s window. With the lookahead bounded by max window +
+    slop, a second device due at now+25 — past the previous 15s
+    lookahead but inside the new one — is pulled into the same
+    window and advances together, avoiding the back-to-back flip
+    when the 30s window ends.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    addr_a = "11:22:33:44:55:01"
+    addr_b = "11:22:33:44:55:02"
+    cancel_a = manager.async_register_active_scan(
+        addr_a, scan_interval=300.0, scan_duration=30.0
+    )
+    cancel_b = manager.async_register_active_scan(
+        addr_b, scan_interval=300.0, scan_duration=30.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, addr_a)
+        _inject(scanner, addr_b)
+        now = loop.time()
+        entries_a = sched._needs[addr_a]
+        entries_b = sched._needs[addr_b]
+        for req in entries_a:
+            entries_a[req] = now - 1.0
+        for req in entries_b:
+            entries_b[req] = now + 25.0
+        await _run_worker_tick(sched, scanner.source)
+        # One 30s window covers both.
+        assert scanner.active_window_calls == [30.0]
+    finally:
+        cancel_a()
+        cancel_b()
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_sweep_alone_pulls_in_soon_due_entries() -> None:
+    """
+    When the 12 h sweep fires with no immediate entry, soon-due ride it.
+
+    Without this, a sweep-only tick would open the rediscovery
+    window and any entry due within the lookahead would be left
+    overdue, firing a back-to-back active flip after the sweep
+    ended. Every active scan captures every advertiser in range so
+    riding the sweep is free.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(
+        address, scan_interval=300.0, scan_duration=10.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        worker = sched._workers[scanner.source]
+        # Make the sweep due; per-device entry is soon-due but not
+        # immediate.
+        worker._sweep_last_completed = loop.time() - AUTO_REDISCOVERY_INTERVAL - 1.0
+        entries = sched._needs[address]
+        soon_due_at = loop.time() + 5.0
+        for req in entries:
+            entries[req] = soon_due_at
+        await _run_worker_tick(sched, scanner.source)
+        # Sweep fired; the soon-due entry was advanced so it does
+        # not trigger a back-to-back flip after the sweep ends.
+        assert len(scanner.active_window_calls) == 1
+        post_tick_now = loop.time()
+        new_due = next(iter(entries.values()))
+        assert new_due > soon_due_at
+        assert new_due == pytest.approx(post_tick_now + 300.0, abs=1.0)
+    finally:
+        cancel()
+        register_cancel()
+
+
+@pytest.mark.asyncio
 async def test_worker_tick_coalesces_overlapping_requests() -> None:
     """Multiple requests for the same address coalesce on max scan_duration."""
     manager = get_manager()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -343,9 +343,10 @@ async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
         for req in entries_b:
             entries_b[req] = now + 10.0
         await _run_worker_tick(sched, owner.source)
-        # Owner is mid-connect; fallback gets the call(s).
+        # Owner is mid-connect; fallback gets exactly one coalesced
+        # call covering both addresses (both scan_duration=10).
         assert owner.active_window_calls == []
-        assert len(fallback.active_window_calls) >= 1
+        assert fallback.active_window_calls == [10.0]
         # Both addresses advanced by their scan_interval — soon-due
         # rode the fallback dispatch instead of firing separately.
         post_tick_now = loop.time()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -207,18 +207,7 @@ async def test_worker_tick_advances_by_scan_interval_from_window_start() -> None
 
 @pytest.mark.asyncio
 async def test_worker_tick_coalesces_near_future_due_entries() -> None:
-    """
-    Entries due within AUTO_COALESCE_LOOKAHEAD seconds ride the current window.
-
-    Without lookahead, two devices owned by the same scanner with
-    next_due staggered by ~10s (typical of integrations registered a
-    few seconds apart) trigger back-to-back radio flips: the first
-    tick fires for device A, returns, the worker re-ticks immediately
-    because B's next_due is now in the past, and the radio cycles
-    active->passive->active within milliseconds. With lookahead, B's
-    near-future entry is pulled into A's bucket and both advance to
-    now + scan_interval, syncing them up permanently after the shift.
-    """
+    """Staggered registrations sync to one window instead of back-to-back flips."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()
@@ -263,14 +252,7 @@ async def test_worker_tick_coalesces_near_future_due_entries() -> None:
 
 @pytest.mark.asyncio
 async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> None:
-    """
-    Soon-due entries alone do not trigger an early tick.
-
-    The lookahead pulls in near-future entries when there is already
-    an immediately-due entry to scan for; it must not fire a fresh
-    window early when nothing is immediately due (otherwise a single
-    registered device would trigger continuously).
-    """
+    """Soon-due entries alone do not trigger an early tick."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()
@@ -296,16 +278,7 @@ async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> No
 
 @pytest.mark.asyncio
 async def test_worker_tick_coalesces_near_max_window_boundary() -> None:
-    """
-    Lookahead covers the max window so a 30s window never outlives it.
-
-    A scan_duration of 30s (the public-boundary clamp ceiling) opens
-    a 30s window. The lookahead invariant
-    ``AUTO_COALESCE_LOOKAHEAD > AUTO_WINDOW_MAX_DURATION`` guarantees
-    a second device due at now+25 is still inside the lookahead and
-    rides this window, so the worker does not re-tick milliseconds
-    after passive transition.
-    """
+    """A 30s window pulls in a device due at now+25; lookahead > max window."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()
@@ -340,15 +313,7 @@ async def test_worker_tick_coalesces_near_max_window_boundary() -> None:
 
 @pytest.mark.asyncio
 async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
-    """
-    Soon-due entries coalesce into the connecting-fallback dispatch too.
-
-    When the owner is mid-connect, the fallback gets the immediate
-    address's flip; a second address that is only soon-due (within
-    the lookahead) should ride that same dispatch so it does not
-    fire its own back-to-back window after the fallback's flip ends.
-    The soon-due entry is advanced by its full ``scan_interval``.
-    """
+    """Soon-due entries coalesce into the connecting-fallback dispatch."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()
@@ -398,15 +363,7 @@ async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
 
 @pytest.mark.asyncio
 async def test_worker_tick_sweep_alone_pulls_in_soon_due_entries() -> None:
-    """
-    When the 12 h sweep fires with no immediate entry, soon-due ride it.
-
-    Without this, a sweep-only tick would open the rediscovery
-    window and any entry due within the lookahead would be left
-    overdue, firing a back-to-back active flip after the sweep
-    ended. Every active scan captures every advertiser in range so
-    riding the sweep is free.
-    """
+    """A sweep-only tick pulls in soon-due entries so they don't fire after."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -235,8 +235,8 @@ async def test_worker_tick_coalesces_near_future_due_entries() -> None:
     try:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
-        # A is due now; B is due 10s from now (within the 15s
-        # lookahead). One tick should serve both.
+        # A is due now; B is due 10s from now (within the lookahead).
+        # One tick should serve both.
         now = loop.time()
         entries_a = sched._needs[addr_a]
         entries_b = sched._needs[addr_b]
@@ -295,16 +295,16 @@ async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> No
 
 
 @pytest.mark.asyncio
-async def test_worker_tick_coalesces_when_window_longer_than_short_lookahead() -> None:
+async def test_worker_tick_coalesces_near_max_window_boundary() -> None:
     """
-    Lookahead covers the maximum window so long windows do not cascade.
+    Lookahead covers the max window so a 30s window never outlives it.
 
-    A scan_duration of 30s (the public-boundary clamp ceiling)
-    opens a 30s window. With the lookahead bounded by max window +
-    slop, a second device due at now+25 — past the previous 15s
-    lookahead but inside the new one — is pulled into the same
-    window and advances together, avoiding the back-to-back flip
-    when the 30s window ends.
+    A scan_duration of 30s (the public-boundary clamp ceiling) opens
+    a 30s window. The lookahead invariant
+    ``AUTO_COALESCE_LOOKAHEAD > AUTO_WINDOW_MAX_DURATION`` guarantees
+    a second device due at now+25 is still inside the lookahead and
+    rides this window, so the worker does not re-tick milliseconds
+    after passive transition.
     """
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -336,6 +336,64 @@ async def test_worker_tick_coalesces_when_window_longer_than_short_lookahead() -
         cancel_a()
         cancel_b()
         register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
+    """
+    Soon-due entries coalesce into the connecting-fallback dispatch too.
+
+    When the owner is mid-connect, the fallback gets the immediate
+    address's flip; a second address that is only soon-due (within
+    the lookahead) should ride that same dispatch so it does not
+    fire its own back-to-back window after the fallback's flip ends.
+    The soon-due entry is advanced by its full ``scan_interval``.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    addr_a = "11:22:33:44:55:01"
+    addr_b = "11:22:33:44:55:02"
+    cancel_a = manager.async_register_active_scan(
+        addr_a, scan_interval=300.0, scan_duration=10.0
+    )
+    cancel_b = manager.async_register_active_scan(
+        addr_b, scan_interval=300.0, scan_duration=10.0
+    )
+    owner = _DiscoverableAutoScanner("AA:00:00:00:01:01", BluetoothScanningMode.AUTO)
+    fallback = _DiscoverableAutoScanner("AA:00:00:00:01:02", BluetoothScanningMode.AUTO)
+    c_owner = manager.async_register_scanner(owner)
+    c_fallback = manager.async_register_scanner(fallback)
+    try:
+        _inject_with_rssi(owner, addr_a, rssi=-50)
+        _inject_with_rssi(owner, addr_b, rssi=-50)
+        fallback.add_discovered(addr_a, rssi=-70)
+        fallback.add_discovered(addr_b, rssi=-70)
+        owner._add_connecting(addr_a)
+        now = loop.time()
+        entries_a = sched._needs[addr_a]
+        entries_b = sched._needs[addr_b]
+        for req in entries_a:
+            entries_a[req] = now - 1.0
+        for req in entries_b:
+            entries_b[req] = now + 10.0
+        await _run_worker_tick(sched, owner.source)
+        # Owner is mid-connect; fallback gets the call(s).
+        assert owner.active_window_calls == []
+        assert len(fallback.active_window_calls) >= 1
+        # Both addresses advanced by their scan_interval — soon-due
+        # rode the fallback dispatch instead of firing separately.
+        post_tick_now = loop.time()
+        a_new_due = next(iter(entries_a.values()))
+        b_new_due = next(iter(entries_b.values()))
+        assert a_new_due == pytest.approx(post_tick_now + 300.0, abs=1.0)
+        assert b_new_due == pytest.approx(post_tick_now + 300.0, abs=1.0)
+    finally:
+        owner._finished_connecting(addr_a, connected=False)
+        cancel_a()
+        cancel_b()
+        c_owner()
+        c_fallback()
 
 
 @pytest.mark.asyncio

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -206,6 +206,95 @@ async def test_worker_tick_advances_by_scan_interval_from_window_start() -> None
 
 
 @pytest.mark.asyncio
+async def test_worker_tick_coalesces_near_future_due_entries() -> None:
+    """
+    Entries due within AUTO_COALESCE_LOOKAHEAD seconds ride the current window.
+
+    Without lookahead, two devices owned by the same scanner with
+    next_due staggered by ~10s (typical of integrations registered a
+    few seconds apart) trigger back-to-back radio flips: the first
+    tick fires for device A, returns, the worker re-ticks immediately
+    because B's next_due is now in the past, and the radio cycles
+    active->passive->active within milliseconds. With lookahead, B's
+    near-future entry is pulled into A's bucket and both advance to
+    now + scan_interval, syncing them up permanently after the shift.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    addr_a = "11:22:33:44:55:01"
+    addr_b = "11:22:33:44:55:02"
+    cancel_a = manager.async_register_active_scan(
+        addr_a, scan_interval=300.0, scan_duration=10.0
+    )
+    cancel_b = manager.async_register_active_scan(
+        addr_b, scan_interval=300.0, scan_duration=10.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, addr_a)
+        _inject(scanner, addr_b)
+        # A is due now; B is due 10s from now (within the 15s
+        # lookahead). One tick should serve both.
+        now = loop.time()
+        entries_a = sched._needs[addr_a]
+        entries_b = sched._needs[addr_b]
+        for req in entries_a:
+            entries_a[req] = now - 1.0
+        for req in entries_b:
+            entries_b[req] = now + 10.0
+        await _run_worker_tick(sched, scanner.source)
+        # One window covers both — not two back-to-back.
+        assert scanner.active_window_calls == [10.0]
+        # Both advanced from now (~now + 300), so they coalesce again
+        # next tick rather than staying 10s apart forever.
+        post_tick_now = loop.time()
+        a_next = next(iter(entries_a.values()))
+        b_next = next(iter(entries_b.values()))
+        assert a_next == pytest.approx(post_tick_now + 300.0, abs=1.0)
+        assert b_next == pytest.approx(post_tick_now + 300.0, abs=1.0)
+        assert abs(a_next - b_next) < 0.5
+    finally:
+        cancel_a()
+        cancel_b()
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> None:
+    """
+    Soon-due entries alone do not trigger an early tick.
+
+    The lookahead pulls in near-future entries when there is already
+    an immediately-due entry to scan for; it must not fire a fresh
+    window early when nothing is immediately due (otherwise a single
+    registered device would trigger continuously).
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(
+        address, scan_interval=300.0, scan_duration=10.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        entries = sched._needs[address]
+        # Set next_due 5s in the future — within the lookahead but
+        # not immediately due.
+        for req in entries:
+            entries[req] = loop.time() + 5.0
+        await _run_worker_tick(sched, scanner.source)
+        assert scanner.active_window_calls == []
+    finally:
+        cancel()
+        register_cancel()
+
+
+@pytest.mark.asyncio
 async def test_worker_tick_coalesces_overlapping_requests() -> None:
     """Multiple requests for the same address coalesce on max scan_duration."""
     manager = get_manager()


### PR DESCRIPTION
Devices registered at staggered times kept their next_due offsets forever; each tick fired a 10s active window for the first-due device and then re-ticked milliseconds after passive transition because the next device was now in the past. On ESPHome proxies this surfaced as `Cannot stop scan: STOPPING` when the second window started before the first had finished returning to passive; the user's config_entry diagnostics had one owner with 5 devices spread across 20s of next_due times.

`_collect_due_buckets` now also collects entries due within `AUTO_COALESCE_LOOKAHEAD` of now and advances them with the rest of the bucket; staggered registrations sync after a single one-time shift. The lookahead is `AUTO_WINDOW_MAX_DURATION + AUTO_COALESCE_LOOKAHEAD_SLOP` (30s + 5s) so a window can never outlive its lookahead; the slop absorbs loop.time drift between bucket collection and the radio flip, which matters when the loop is blocked or under task pressure.

`_collect_due_buckets` returns an extra `any_immediate` flag; `_tick` gates firing on `any_immediate or sweep_due`. Soon-due entries ride a window that one of those triggers but never trigger one alone, and they correctly ride a 12 h sweep-only window (every active scan captures every advertiser in range, so coalescing onto the sweep is free).