### PR TITLE
fix(auto-scheduler): fast-return when on-demand sweep dispatches nothing

### DIFF
--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -908,6 +908,16 @@ class AutoScanScheduler:
         declined / raised scanner does not stay locked out of its
         own ticks for the on-demand duration with no actual radio
         window open.
+
+        Best-effort caveat (concurrent revert): when a leader's flip
+        and a joiner's extension flip both visit the same worker and
+        both decline, the leader's exact-equality revert guard sees
+        the joiner's bump and skips, while the joiner's revert
+        restores to its observed ``previous_window_end`` (the
+        leader's bumped value). The worker stays bumped to the
+        leader's intended end despite no radio window opening; it
+        self-heals on the next tick at that end. Symmetric to the
+        ``_window_end`` caveat in ``note_window_dispatched``.
         """
         if TYPE_CHECKING:
             assert self._loop is not None

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -903,32 +903,49 @@ class AutoScanScheduler:
         tick during the window; ``_sweep_last_completed`` is bumped
         post-await only on ``True`` so a declined/raised flip leaves
         the 12 h rediscovery floor unsatisfied for that scanner.
+        Per-target ``_window_end`` is reverted to its pre-bump value
+        on a non-``True`` result (when our bump still holds) so a
+        declined / raised scanner does not stay locked out of its
+        own ticks for the on-demand duration with no actual radio
+        window open.
         """
         if TYPE_CHECKING:
             assert self._loop is not None
         now = self._loop.time()
         window_end = now + duration
-        targets: list[tuple[_ScannerWorker, BaseHaScanner]] = []
+        targets: list[tuple[_ScannerWorker, BaseHaScanner, float]] = []
         for worker in self._workers.values():
             scanner = worker._scanner
             if scanner._connections_in_progress() > 0:
                 continue
-            if worker._window_end < window_end:
+            previous_window_end = worker._window_end
+            if previous_window_end < window_end:
                 worker._window_end = window_end
-            targets.append((worker, scanner))
+            targets.append((worker, scanner, previous_window_end))
         if not targets:
             return False
         results = await asyncio.gather(
-            *(scanner.async_request_active_window(duration) for _, scanner in targets),
+            *(
+                scanner.async_request_active_window(duration)
+                for _, scanner, _ in targets
+            ),
             return_exceptions=True,
         )
         any_opened = False
-        for (worker, scanner), result in zip(targets, results, strict=True):
+        for (worker, scanner, previous_window_end), result in zip(
+            targets, results, strict=True
+        ):
             if result is True:
                 any_opened = True
                 if worker._sweep_last_completed < now:
                     worker._sweep_last_completed = now
                 continue
+            # No window opened for this scanner; if our bump still
+            # holds, revert so the worker can tick normally. A
+            # concurrent extension that pushed past us, or a _tick
+            # finally that cleared to 0, is left alone.
+            if worker._window_end == window_end:
+                worker._window_end = previous_window_end
             if isinstance(result, Exception):
                 _LOGGER.warning(
                     "%s: error running on-demand active window of %.1fs: %s",

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -878,9 +878,14 @@ class AutoScanScheduler:
             )
         )
 
-    async def _flip_scanners_for_sweep(self, duration: float) -> None:  # noqa: C901
+    async def _flip_scanners_for_sweep(self, duration: float) -> bool:  # noqa: C901
         """
         Flip every non-busy AUTO scanner into a ``duration``-second window.
+
+        Returns ``True`` if at least one eligible scanner was
+        dispatched to (regardless of per-scanner outcome), ``False``
+        if no AUTO workers are registered or every one is mid-connect
+        so the caller can short-circuit any post-flip sleep.
 
         ``return_exceptions=True`` plus the per-scanner log keeps one
         stuck adapter from aborting the bus-wide sweep while still
@@ -910,7 +915,7 @@ class AutoScanScheduler:
                 worker._window_end = window_end
             targets.append((worker, scanner))
         if not targets:
-            return
+            return False
         results = await asyncio.gather(
             *(scanner.async_request_active_window(duration) for _, scanner in targets),
             return_exceptions=True,
@@ -942,6 +947,7 @@ class AutoScanScheduler:
                     scanner.name,
                     duration,
                 )
+        return True
 
     async def async_request_active_scan(self, duration: float) -> None:
         """
@@ -968,6 +974,13 @@ class AutoScanScheduler:
         the future so a cancelled joiner cannot cancel the shared
         future and take down the siblings or the leader's
         ``set_result``.
+
+        Fast-return: when the leader's flip dispatches no targets
+        (no AUTO workers, or every one mid-connect) it skips the
+        sleep loop and returns immediately rather than blocking the
+        caller for a window that never opens; an extension whose
+        re-flip dispatches nothing reverts its eager
+        ``_on_demand_sweep_end`` push for the same reason.
         """
         # Capture loop locally so a concurrent stop() (which nulls
         # self._loop) during the sleep loop or the flip-await cannot
@@ -981,19 +994,34 @@ class AutoScanScheduler:
         in_flight = self._on_demand_sweep_future
         if in_flight is not None:
             if desired_end - self._on_demand_sweep_end > _ON_DEMAND_EXTENSION_SLOP:
+                previous_end = self._on_demand_sweep_end
                 self._on_demand_sweep_end = desired_end
                 # asyncio.shield the extension flip so a cancelled
                 # joiner does not leave the shared end pushed out
                 # past a partial re-flip; either all non-busy
                 # scanners receive the longer duration or none do.
-                await asyncio.shield(self._flip_scanners_for_sweep(desired_end - now))
+                flipped = await asyncio.shield(
+                    self._flip_scanners_for_sweep(desired_end - now)
+                )
+                # No targets accepted the extension (every worker is
+                # now mid-connect); revert the eager push so the
+                # leader does not sleep past the in-flight radio
+                # window for nothing. Guarded so a peer joiner that
+                # pushed end further during our shielded await is
+                # not clobbered.
+                if not flipped and self._on_demand_sweep_end == desired_end:
+                    self._on_demand_sweep_end = previous_end
             await asyncio.shield(in_flight)
             return
         future = loop.create_future()
         self._on_demand_sweep_future = future
         self._on_demand_sweep_end = desired_end
         try:
-            await self._flip_scanners_for_sweep(duration)
+            if not await self._flip_scanners_for_sweep(duration):
+                # No AUTO workers, or every one is mid-connect; no
+                # radio activity was kicked off so awaiting `duration`
+                # would block callers for a window that never opens.
+                return
             while True:
                 remaining = self._on_demand_sweep_end - loop.time()
                 if remaining <= 0:

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -996,11 +996,14 @@ class AutoScanScheduler:
         future and take down the siblings or the leader's
         ``set_result``.
 
-        Fast-return: when the leader's flip dispatches no targets
-        (no AUTO workers, or every one mid-connect) it skips the
-        sleep loop and returns immediately rather than blocking the
-        caller for a window that never opens; an extension whose
-        re-flip dispatches nothing reverts its eager
+        Fast-return: when the leader's flip neither opens a window
+        itself (no AUTO workers, every one mid-connect, or every
+        dispatched scanner declined / raised) nor sees a concurrent
+        joiner that did (``_on_demand_sweep_end`` was not pushed
+        past the leader's ``desired_end`` during the await), it
+        skips the sleep loop and returns immediately rather than
+        blocking the caller for a window that never opens. An
+        extension whose re-flip opens nothing reverts its eager
         ``_on_demand_sweep_end`` push for the same reason.
         """
         # Capture loop locally so a concurrent stop() (which nulls
@@ -1024,12 +1027,13 @@ class AutoScanScheduler:
                 flipped = await asyncio.shield(
                     self._flip_scanners_for_sweep(desired_end - now)
                 )
-                # No targets accepted the extension (every worker is
-                # now mid-connect); revert the eager push so the
-                # leader does not sleep past the in-flight radio
-                # window for nothing. Guarded so a peer joiner that
-                # pushed end further during our shielded await is
-                # not clobbered.
+                # No scanner opened or extended a window for us
+                # (every worker mid-connect, or every dispatched
+                # scanner declined / raised); revert the eager push
+                # so the leader does not sleep past the in-flight
+                # radio window for nothing. Guarded so a peer joiner
+                # that pushed end further during our shielded await
+                # is not clobbered.
                 if not flipped and self._on_demand_sweep_end == desired_end:
                     self._on_demand_sweep_end = previous_end
             await asyncio.shield(in_flight)
@@ -1038,10 +1042,20 @@ class AutoScanScheduler:
         self._on_demand_sweep_future = future
         self._on_demand_sweep_end = desired_end
         try:
-            if not await self._flip_scanners_for_sweep(duration):
-                # No AUTO workers, or every one is mid-connect; no
-                # radio activity was kicked off so awaiting `duration`
-                # would block callers for a window that never opens.
+            flipped = await self._flip_scanners_for_sweep(duration)
+            if not flipped and self._on_demand_sweep_end <= desired_end:
+                # No scanner opened a window bus-wide (no AUTO
+                # workers, every one mid-connect, or every dispatched
+                # scanner declined / raised) and no joiner that
+                # interleaved during our await opened or extended a
+                # window past our end; skip the sleep loop rather
+                # than block callers for a window that never opens.
+                # A joiner that succeeded would have pushed
+                # `_on_demand_sweep_end` past `desired_end`; honor it
+                # by falling through to the sleep loop so the leader
+                # sleeps until that joiner's end (the joiner is
+                # parked on the shared future and would otherwise be
+                # cut short by the leader's finally).
                 return
             while True:
                 remaining = self._on_demand_sweep_end - loop.time()

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -882,10 +882,12 @@ class AutoScanScheduler:
         """
         Flip every non-busy AUTO scanner into a ``duration``-second window.
 
-        Returns ``True`` if at least one eligible scanner was
-        dispatched to (regardless of per-scanner outcome), ``False``
-        if no AUTO workers are registered or every one is mid-connect
-        so the caller can short-circuit any post-flip sleep.
+        Returns ``True`` if at least one scanner actually opened a
+        window (per-scanner result was ``True``), ``False`` if no
+        AUTO workers are registered, every one is mid-connect, or
+        every dispatched scanner declined / raised so the caller
+        can short-circuit any post-flip sleep on a window that
+        never opened.
 
         ``return_exceptions=True`` plus the per-scanner log keeps one
         stuck adapter from aborting the bus-wide sweep while still
@@ -920,8 +922,10 @@ class AutoScanScheduler:
             *(scanner.async_request_active_window(duration) for _, scanner in targets),
             return_exceptions=True,
         )
+        any_opened = False
         for (worker, scanner), result in zip(targets, results, strict=True):
             if result is True:
+                any_opened = True
                 if worker._sweep_last_completed < now:
                     worker._sweep_last_completed = now
                 continue
@@ -947,7 +951,7 @@ class AutoScanScheduler:
                     scanner.name,
                     duration,
                 )
-        return True
+        return any_opened
 
     async def async_request_active_scan(self, duration: float) -> None:
         """

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -721,13 +721,22 @@ class BaseHaScanner:
         Run an active scan for ``duration`` seconds, then restore prior mode.
 
         Default no-op returning False. Subclasses that can flip the
-        underlying adapter / proxy into active scanning on demand should
-        override; ``True`` indicates the override actually flipped the
-        radio, ``False`` that the request was ignored. The current
-        scheduler does not branch on the return value (entries advance
-        by ``scan_interval`` regardless to avoid busy-looping a stuck
-        scanner), but the contract leaves room for callers that want
-        to surface a failed window.
+        underlying adapter / proxy into active scanning on demand
+        should override; ``True`` indicates the override actually
+        flipped the radio, ``False`` that the request was ignored.
+
+        The auto scheduler branches on the return value: per-device
+        ``_needs`` entries still advance by ``scan_interval``
+        regardless (to avoid busy-looping a stuck scanner), but a
+        ``True`` is what advances ``_sweep_last_completed`` (satisfies
+        the 12 h rediscovery floor) and counts toward the on-demand
+        sweep's "at least one window opened" predicate that lets the
+        leader's caller actually wait for the window. A ``False`` /
+        raised result reverts the on-demand pre-bumped
+        ``_window_end`` so the worker is not locked out of its own
+        ticks for a window that never opened. Implementations should
+        therefore return ``True`` only when the radio actually
+        entered active mode for the requested duration.
         """
         _LOGGER.debug(
             "%s: scanner does not support on-demand active windows", self.name

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4959,6 +4959,52 @@ async def test_async_request_active_scan_logs_per_scanner_flip_failures(
 
 
 @pytest.mark.asyncio
+async def test_async_request_active_scan_no_op_when_every_dispatch_declines() -> None:
+    """
+    All-False / all-raise from dispatched scanners is the same NOOP as no targets.
+
+    The flip dispatches but every scanner declines or raises so no
+    radio window actually opens; the leader must skip the sleep loop
+    rather than block on a window that never opened.
+    """
+    manager = get_manager()
+    loop = asyncio.get_running_loop()
+
+    class _DecliningScanner(_RecordingAutoScanner):
+        async def async_request_active_window(self, duration: float) -> bool:
+            self.active_window_calls.append(duration)
+            return False
+
+    class _FailingScanner(_RecordingAutoScanner):
+        async def async_request_active_window(self, duration: float) -> bool:
+            self.active_window_calls.append(duration)
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    decliner = _DecliningScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    raiser = _FailingScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+    c_dec = manager.async_register_scanner(decliner)
+    c_raise = manager.async_register_scanner(raiser)
+
+    async def _fail_on_sleep(delay: float) -> None:
+        pytest.fail(f"async_request_active_scan slept for {delay}s on NOOP")
+
+    try:
+        before = loop.time()
+        with patch("asyncio.sleep", new=_fail_on_sleep):
+            await manager.async_request_active_scan(duration=5.0)
+        # Both scanners were dispatched to; neither opened a window.
+        assert decliner.active_window_calls == [5.0]
+        assert raiser.active_window_calls == [5.0]
+        assert loop.time() - before < 0.5
+        assert manager._auto_scheduler._on_demand_sweep_future is None
+        assert manager._auto_scheduler._on_demand_sweep_end == 0.0
+    finally:
+        c_dec()
+        c_raise()
+
+
+@pytest.mark.asyncio
 async def test_async_request_active_scan_joiner_cancel_during_extension() -> None:
     """
     Joiner cancelled mid-extension still finishes the all-or-nothing re-flip.

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -5079,6 +5079,88 @@ async def test_async_request_active_scan_window_end_kept_for_succeeding() -> Non
 
 
 @pytest.mark.asyncio
+async def test_async_request_active_scan_leader_honors_joiner_success_on_decline() -> (
+    None
+):
+    """
+    Leader's all-declined flip must not wipe state while a joiner has opened a window.
+
+    Sequence:
+    1. Leader flips X (eligible, blocks on its window call); Y is
+       mid-connect and skipped.
+    2. While leader is parked in its gather, Y finishes connecting
+       and a joiner arrives wanting a longer window. The joiner
+       extends ``_on_demand_sweep_end`` and re-flips; Y returns
+       True, the joiner does not revert, then parks on the shared
+       future.
+    3. X unblocks and returns False; the leader's flip therefore
+       returns False (only X was dispatched, X declined).
+    4. ``_on_demand_sweep_end`` was pushed past the leader's
+       ``desired_end`` by the joiner, so the leader must NOT
+       fast-return: it falls through to the sleep loop and sleeps
+       until the joiner's end, otherwise the joiner is cut short
+       and the radio window is orphaned from scheduler bookkeeping.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    with freeze_time() as frozen:
+        x = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+        y = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+        x._return_value = False
+        x._block_event = asyncio.Event()
+        c_x = manager.async_register_scanner(x)
+        c_y = manager.async_register_scanner(y)
+        wx = sched._workers[x.source]
+        wy = sched._workers[y.source]
+        # Silence each worker's own tick so it cannot pollute
+        # active_window_calls during the on-demand sweep.
+        wx.stop()
+        wy.stop()
+        await asyncio.sleep(0)
+        # Y starts mid-connect so the leader's flip skips it entirely.
+        y._add_connecting("11:22:33:44:55:66")
+        try:
+            leader = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
+            for _ in range(3):
+                await asyncio.sleep(0)
+            # Leader is now blocked inside X's flip; Y was skipped.
+            assert x.active_window_calls == [5.0]
+            assert y.active_window_calls == []
+            # Free Y so a joiner can dispatch it.
+            y._finished_connecting("11:22:33:44:55:66", connected=False)
+            joiner = asyncio.create_task(
+                manager.async_request_active_scan(duration=20.0)
+            )
+            for _ in range(3):
+                await asyncio.sleep(0)
+            # Joiner extended end and dispatched Y; Y opened a window.
+            assert y.active_window_calls == [20.0]
+            joiner_end = sched._on_demand_sweep_end
+            assert joiner_end > 0.0
+            # Unblock X; leader's flip resolves with all-declined.
+            x._block_event.set()
+            for _ in range(5):
+                await asyncio.sleep(0)
+            # Without the joiner-extension guard, the leader would
+            # have fast-returned and zeroed _on_demand_sweep_end /
+            # resolved the shared future. With the guard, both tasks
+            # are still parked and the end is intact.
+            assert not leader.done()
+            assert not joiner.done()
+            assert sched._on_demand_sweep_end == joiner_end
+            # Advance past the joiner's end; both tasks complete.
+            frozen.tick(20.1)
+            await leader
+            await joiner
+            assert sched._on_demand_sweep_future is None
+        finally:
+            c_x()
+            c_y()
+
+
+@pytest.mark.asyncio
 async def test_async_request_active_scan_joiner_cancel_during_extension() -> None:
     """
     Joiner cancelled mid-extension still finishes the all-or-nothing re-flip.

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4792,18 +4792,16 @@ async def test_async_request_active_scan_no_op_without_auto_scanners() -> None:
     """With no AUTO workers the sweep returns immediately, no sleep."""
     manager = get_manager()
     loop = asyncio.get_running_loop()
-    sleep_calls: list[float] = []
-    real_sleep = asyncio.sleep
 
-    async def _recording_sleep(delay: float) -> None:
-        sleep_calls.append(delay)
-        await real_sleep(0)
+    async def _fail_on_sleep(delay: float) -> None:
+        # Surface a regression as a clean assertion instead of a
+        # pytest-timeout: if the leader's sleep loop runs at all,
+        # fail now rather than spin / block on the patched sleep.
+        pytest.fail(f"async_request_active_scan slept for {delay}s on NOOP")
 
     before = loop.time()
-    with patch("asyncio.sleep", new=_recording_sleep):
+    with patch("asyncio.sleep", new=_fail_on_sleep):
         await manager.async_request_active_scan(duration=5.0)
-    # Fast-return: no asyncio.sleep call from the leader's sleep loop.
-    assert sleep_calls == []
     # Bounded wall time confirms we did not block on the 5s duration.
     assert loop.time() - before < 0.5
     assert manager._auto_scheduler._on_demand_sweep_future is None
@@ -4821,20 +4819,16 @@ async def test_async_request_active_scan_no_op_when_all_scanners_connecting() ->
     c_b = manager.async_register_scanner(busy_b)
     busy_a._add_connecting("11:22:33:44:55:66")
     busy_b._add_connecting("11:22:33:44:55:77")
-    sleep_calls: list[float] = []
-    real_sleep = asyncio.sleep
 
-    async def _recording_sleep(delay: float) -> None:
-        sleep_calls.append(delay)
-        await real_sleep(0)
+    async def _fail_on_sleep(delay: float) -> None:
+        pytest.fail(f"async_request_active_scan slept for {delay}s on NOOP")
 
     try:
         before = loop.time()
-        with patch("asyncio.sleep", new=_recording_sleep):
+        with patch("asyncio.sleep", new=_fail_on_sleep):
             await manager.async_request_active_scan(duration=5.0)
         assert busy_a.active_window_calls == []
         assert busy_b.active_window_calls == []
-        assert sleep_calls == []
         assert loop.time() - before < 0.5
         assert manager._auto_scheduler._on_demand_sweep_future is None
         assert manager._auto_scheduler._on_demand_sweep_end == 0.0

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4989,6 +4989,9 @@ async def test_async_request_active_scan_no_op_when_every_dispatch_declines() ->
     async def _fail_on_sleep(delay: float) -> None:
         pytest.fail(f"async_request_active_scan slept for {delay}s on NOOP")
 
+    sched = manager._auto_scheduler
+    dec_worker = sched._workers[decliner.source]
+    raise_worker = sched._workers[raiser.source]
     try:
         before = loop.time()
         with patch("asyncio.sleep", new=_fail_on_sleep):
@@ -4999,9 +5002,51 @@ async def test_async_request_active_scan_no_op_when_every_dispatch_declines() ->
         assert loop.time() - before < 0.5
         assert manager._auto_scheduler._on_demand_sweep_future is None
         assert manager._auto_scheduler._on_demand_sweep_end == 0.0
+        # _window_end was pre-bumped for each worker but reverted post-result
+        # so the worker is not locked out of its own ticks. New workers start
+        # with _window_end == 0.0 and the flip should leave them there.
+        assert dec_worker._window_end == 0.0
+        assert raise_worker._window_end == 0.0
     finally:
         c_dec()
         c_raise()
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_scan_window_end_kept_for_succeeding() -> None:
+    """
+    Mixed True/False results: the True scanner keeps its bumped _window_end.
+
+    A decliner runs alongside a scanner that returns True. The
+    decliner's pre-bumped _window_end is reverted while the True
+    scanner keeps the bump so its periodic worker tick stays
+    suppressed for the duration of the real radio window.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+
+    class _DecliningScanner(_RecordingAutoScanner):
+        async def async_request_active_window(self, duration: float) -> bool:
+            self.active_window_calls.append(duration)
+            return False
+
+    decliner = _DecliningScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    good = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+    c_dec = manager.async_register_scanner(decliner)
+    c_good = manager.async_register_scanner(good)
+    dec_worker = sched._workers[decliner.source]
+    good_worker = sched._workers[good.source]
+    try:
+        async with _no_real_sleep():
+            await manager.async_request_active_scan(duration=5.0)
+        assert decliner.active_window_calls == [5.0]
+        assert good.active_window_calls == [5.0]
+        # Decliner reverted to 0.0; succeeding scanner retains the bump.
+        assert dec_worker._window_end == 0.0
+        assert good_worker._window_end > 0.0
+    finally:
+        c_dec()
+        c_good()
 
 
 @pytest.mark.asyncio

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4789,12 +4789,60 @@ async def test_async_request_active_scan_no_op_when_scheduler_stopped() -> None:
 
 @pytest.mark.asyncio
 async def test_async_request_active_scan_no_op_without_auto_scanners() -> None:
-    """With no AUTO workers the sweep still completes its sleep cleanly."""
+    """With no AUTO workers the sweep returns immediately, no sleep."""
     manager = get_manager()
-    # No scanners registered; targets is empty but the sleep still runs.
-    async with _no_real_sleep():
+    loop = asyncio.get_running_loop()
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _recording_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        await real_sleep(0)
+
+    before = loop.time()
+    with patch("asyncio.sleep", new=_recording_sleep):
         await manager.async_request_active_scan(duration=5.0)
+    # Fast-return: no asyncio.sleep call from the leader's sleep loop.
+    assert sleep_calls == []
+    # Bounded wall time confirms we did not block on the 5s duration.
+    assert loop.time() - before < 0.5
     assert manager._auto_scheduler._on_demand_sweep_future is None
+    assert manager._auto_scheduler._on_demand_sweep_end == 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_scan_no_op_when_all_scanners_connecting() -> None:
+    """Every AUTO scanner mid-connect is the same NOOP; no sleep, fast-return."""
+    manager = get_manager()
+    loop = asyncio.get_running_loop()
+    busy_a = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    busy_b = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.AUTO)
+    c_a = manager.async_register_scanner(busy_a)
+    c_b = manager.async_register_scanner(busy_b)
+    busy_a._add_connecting("11:22:33:44:55:66")
+    busy_b._add_connecting("11:22:33:44:55:77")
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _recording_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        await real_sleep(0)
+
+    try:
+        before = loop.time()
+        with patch("asyncio.sleep", new=_recording_sleep):
+            await manager.async_request_active_scan(duration=5.0)
+        assert busy_a.active_window_calls == []
+        assert busy_b.active_window_calls == []
+        assert sleep_calls == []
+        assert loop.time() - before < 0.5
+        assert manager._auto_scheduler._on_demand_sweep_future is None
+        assert manager._auto_scheduler._on_demand_sweep_end == 0.0
+    finally:
+        busy_a._finished_connecting("11:22:33:44:55:66", connected=False)
+        busy_b._finished_connecting("11:22:33:44:55:77", connected=False)
+        c_a()
+        c_b()
 
 
 @pytest.mark.asyncio
@@ -4829,6 +4877,59 @@ async def test_async_request_active_scan_awaits_the_full_duration() -> None:
             frozen.tick(5.1)
             await task
             assert task.done()
+        finally:
+            register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_scan_extension_reverts_end_when_no_targets() -> (
+    None
+):
+    """
+    A joiner extension that finds every worker busy reverts the end push.
+
+    Leader dispatches successfully and parks in its sleep loop. The
+    only scanner then goes mid-connect; the joiner's extension flip
+    has no eligible targets and returns False. The eager
+    ``_on_demand_sweep_end`` push must be reverted to the leader's
+    original end so the leader does not sleep past the in-flight
+    radio window for nothing.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    with freeze_time() as frozen:
+        scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+        register_cancel = manager.async_register_scanner(scanner)
+        worker = sched._workers[scanner.source]
+        worker.stop()
+        await asyncio.sleep(0)
+        try:
+            leader = asyncio.create_task(
+                manager.async_request_active_scan(duration=5.0)
+            )
+            for _ in range(5):
+                await asyncio.sleep(0)
+            assert scanner.active_window_calls == [5.0]
+            leader_end = sched._on_demand_sweep_end
+            # Mark the only worker busy before the joiner extension fires.
+            scanner._add_connecting("11:22:33:44:55:66")
+            try:
+                joiner = asyncio.create_task(
+                    manager.async_request_active_scan(duration=20.0)
+                )
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                # Joiner's extension dispatched nothing; only the leader's
+                # flip is recorded and the eager push was reverted.
+                assert scanner.active_window_calls == [5.0]
+                assert sched._on_demand_sweep_end == leader_end
+            finally:
+                scanner._finished_connecting("11:22:33:44:55:66", connected=False)
+            # Advance past the leader's end; leader and joiner both wake.
+            frozen.tick(5.1)
+            await leader
+            await joiner
+            assert sched._on_demand_sweep_future is None
         finally:
             register_cancel()
 

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import logging
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -5010,6 +5010,35 @@ async def test_async_request_active_scan_no_op_when_every_dispatch_declines() ->
     finally:
         c_dec()
         c_raise()
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_scan_revert_skipped_on_concurrent_push() -> None:
+    """A concurrent _window_end push past our bump is not clobbered on revert."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    holder: list[Any] = []
+
+    class _MutatingScanner(_RecordingAutoScanner):
+        async def async_request_active_window(self, duration: float) -> bool:
+            self.active_window_calls.append(duration)
+            # Simulate a concurrent extension pushing _window_end out
+            # past the on-demand bump between pre-bump and result; the
+            # revert guard must observe the mismatch and leave it alone.
+            holder[0]._window_end = 1.0e12
+            return False
+
+    scanner = _MutatingScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    holder.append(sched._workers[scanner.source])
+    try:
+        async with _no_real_sleep():
+            await manager.async_request_active_scan(duration=5.0)
+        # The concurrent push survived our revert (guarded by exact
+        # equality on the value we set).
+        assert holder[0]._window_end == 1.0e12
+    finally:
+        register_cancel()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`async_request_active_scan` previously slept for the full clamped duration even when no AUTO scanner was eligible, so a caller with no AUTO workers registered (or every one mid-connect) blocked for a window that never opened.

`_flip_scanners_for_sweep` now returns a bool; the leader skips its sleep loop when the initial flip dispatched no targets, and an extension joiner reverts its eager `_on_demand_sweep_end` push when the re-flip also finds nothing so the leader does not outlive the in-flight radio window. The revert is guarded so a peer joiner that pushed `_on_demand_sweep_end` further during the shielded await is not clobbered.