### PR TITLE
fix: report passive or active for local scanner current_mode under auto

### DIFF
--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -119,6 +119,26 @@ SCANNING_MODE_TO_BLEAK = {
     BluetoothScanningMode.AUTO: "passive",
 }
 
+
+def _resolve_radio_mode(
+    mode: BluetoothScanningMode | None,
+) -> BluetoothScanningMode | None:
+    """
+    Resolve AUTO to the underlying mode the radio actually runs in.
+
+    AUTO is a habluetooth scheduling concept, not a radio state. The
+    backend always runs in either passive or active. current_mode is
+    supposed to reflect that real state so diagnostics and the manager
+    callbacks line up with what remote scanners (e.g. ESPHome) already
+    report; otherwise local adapters look stuck on "auto" forever.
+    """
+    if mode is BluetoothScanningMode.AUTO:
+        return (
+            BluetoothScanningMode.ACTIVE if IS_MACOS else BluetoothScanningMode.PASSIVE
+        )
+    return mode
+
+
 # The minimum number of seconds to know
 # the adapter has not had advertisements
 # and we already tried to restart the scanner
@@ -411,7 +431,8 @@ class HaScanner(BaseHaScanner):
         ), "Loop is not set, call async_setup first"
 
         effective_mode = self._effective_mode()
-        self.set_current_mode(effective_mode)
+        radio_mode = _resolve_radio_mode(effective_mode)
+        self.set_current_mode(radio_mode)
         # 1st attempt - no auto reset
         # 2nd attempt - try to reset the adapter and wait a bit
         # 3th attempt - no auto reset
@@ -420,7 +441,7 @@ class HaScanner(BaseHaScanner):
         if (
             IS_LINUX
             and attempt == START_ATTEMPTS
-            and effective_mode is BluetoothScanningMode.ACTIVE
+            and radio_mode is BluetoothScanningMode.ACTIVE
         ):
             _LOGGER.debug(
                 "%s: Falling back to passive scanning mode "
@@ -512,7 +533,7 @@ class HaScanner(BaseHaScanner):
         finally:
             self._start_future = None
 
-        self._log_start_success(attempt, effective_mode)
+        self._log_start_success(attempt, radio_mode)
         self._on_start_success()
         return True
 
@@ -525,14 +546,14 @@ class HaScanner(BaseHaScanner):
         )
 
     def _log_start_success(
-        self, attempt: int, effective_mode: BluetoothScanningMode | None
+        self, attempt: int, radio_mode: BluetoothScanningMode | None
     ) -> None:
-        # Compare against the mode we *tried* to start in (effective_mode)
-        # rather than requested_mode: an AUTO scanner mid-active-window
-        # has requested_mode=AUTO but effective_mode=ACTIVE, and we
+        # Compare against the resolved radio mode we *tried* to start
+        # in rather than requested_mode: an AUTO scanner mid-active-
+        # window has requested_mode=AUTO but radio_mode=ACTIVE, and we
         # don't want to warn "fell back to passive" when the active
         # restart actually succeeded.
-        if self.current_mode is not effective_mode:
+        if self.current_mode is not radio_mode:
             _LOGGER.warning(
                 "%s: Successful fall-back to passive scanning mode "
                 "after active scanning failed (%s/%s)",
@@ -956,7 +977,7 @@ class HaScanner(BaseHaScanner):
             self.scanning = False
             return False
         self.scanning = True
-        self.set_current_mode(effective_mode)
+        self.set_current_mode(_resolve_radio_mode(effective_mode))
         return True
 
     async def _async_stop_scanner(self) -> None:

--- a/src/habluetooth/scanner.py
+++ b/src/habluetooth/scanner.py
@@ -110,19 +110,10 @@ START_ATTEMPTS = 4
 SCANNING_MODE_TO_BLEAK = {
     BluetoothScanningMode.ACTIVE: "active",
     BluetoothScanningMode.PASSIVE: "passive",
-    # AUTO starts in passive; the scheduler will request transient ACTIVE
-    # windows by calling HaScanner.async_request_active_window.
-    # On macOS, create_bleak_scanner translates AUTO -> ACTIVE before
-    # the dict lookup since CoreBluetooth doesn't support passive;
-    # async_request_active_window is a no-op there because the radio
-    # is already active.
-    BluetoothScanningMode.AUTO: "passive",
 }
 
 
-def _resolve_radio_mode(
-    mode: BluetoothScanningMode | None,
-) -> BluetoothScanningMode | None:
+def _resolve_radio_mode(mode: BluetoothScanningMode) -> BluetoothScanningMode:
     """
     Resolve AUTO to the underlying mode the radio actually runs in.
 
@@ -131,6 +122,11 @@ def _resolve_radio_mode(
     supposed to reflect that real state so diagnostics and the manager
     callbacks line up with what remote scanners (e.g. ESPHome) already
     report; otherwise local adapters look stuck on "auto" forever.
+
+    Single source of truth for the AUTO -> radio mapping; both
+    create_bleak_scanner and the active-window toggle defer here so a
+    future platform change (or a new platform) only needs to update
+    this one function.
     """
     if mode is BluetoothScanningMode.AUTO:
         return (
@@ -163,11 +159,13 @@ def create_bleak_scanner(
     adapter: str | None,
 ) -> bleak.BleakScanner:
     """Create a Bleak scanner."""
-    # CoreBluetooth doesn't support passive scanning, so AUTO maps to
-    # ACTIVE on macOS (the radio just stays in active mode and
-    # async_request_active_window is a no-op).
-    if scanning_mode is BluetoothScanningMode.AUTO and IS_MACOS:
-        scanning_mode = BluetoothScanningMode.ACTIVE
+    # Resolve AUTO before doing anything else so the rest of this
+    # function only ever sees ACTIVE or PASSIVE; CoreBluetooth has no
+    # passive mode so AUTO collapses to ACTIVE on macOS (the radio
+    # just stays in active and async_request_active_window is a no-op
+    # there), and Linux/other platforms start AUTO in passive with
+    # the scheduler flipping to active on demand.
+    scanning_mode = _resolve_radio_mode(scanning_mode)
     scanner_kwargs: dict[str, Any] = {
         "scanning_mode": SCANNING_MODE_TO_BLEAK[scanning_mode],
     }
@@ -176,17 +174,12 @@ def create_bleak_scanner(
     if IS_LINUX:
         # Only Linux supports multiple adapters
         bluez_args: BlueZScannerArgs = {}
-        # PASSIVE and AUTO both start the scanner in passive mode on
-        # Linux; bleak's passive scanner needs at least one or_pattern
-        # matcher or it won't start, so AUTO has to set PASSIVE_SCANNER_ARGS
-        # too. (AUTO gets flipped to active on demand by the scheduler
-        # via async_request_active_window, which restarts with
-        # scan_mode_override=ACTIVE so this branch is skipped for those
-        # restarts.)
-        if scanning_mode in (
-            BluetoothScanningMode.PASSIVE,
-            BluetoothScanningMode.AUTO,
-        ):
+        # bleak's passive scanner needs at least one or_pattern matcher
+        # or it won't start. AUTO has been resolved to PASSIVE above on
+        # Linux (the scheduler restarts with scan_mode_override=ACTIVE
+        # to flip to active on demand, which lands here as ACTIVE and
+        # skips this branch).
+        if scanning_mode is BluetoothScanningMode.PASSIVE:
             bluez_args = dict(PASSIVE_SCANNER_ARGS)
         if adapter:
             # bleak 3.0 deprecated the top-level ``adapter`` kwarg in favor of
@@ -431,7 +424,9 @@ class HaScanner(BaseHaScanner):
         ), "Loop is not set, call async_setup first"
 
         effective_mode = self._effective_mode()
-        radio_mode = _resolve_radio_mode(effective_mode)
+        radio_mode = (
+            _resolve_radio_mode(effective_mode) if effective_mode is not None else None
+        )
         self.set_current_mode(radio_mode)
         # 1st attempt - no auto reset
         # 2nd attempt - try to reset the adapter and wait a bit
@@ -932,7 +927,8 @@ class HaScanner(BaseHaScanner):
         effective_mode = self._effective_mode()
         if TYPE_CHECKING:
             assert effective_mode is not None
-        mode_str = SCANNING_MODE_TO_BLEAK[effective_mode]
+        radio_mode = _resolve_radio_mode(effective_mode)
+        mode_str = SCANNING_MODE_TO_BLEAK[radio_mode]
         try:
             async with asyncio.timeout(STOP_TIMEOUT):
                 await self.scanner.stop()
@@ -977,7 +973,7 @@ class HaScanner(BaseHaScanner):
             self.scanning = False
             return False
         self.scanning = True
-        self.set_current_mode(_resolve_radio_mode(effective_mode))
+        self.set_current_mode(radio_mode)
         return True
 
     async def _async_stop_scanner(self) -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2913,3 +2913,87 @@ async def test_scanner_watchdog_log_includes_side_channel_state(
             assert "MGMT side channel up but hci0 unregistered" in caplog.text
         finally:
             await ha_scanner.async_stop()
+
+
+@pytest.mark.usefixtures("force_linux_scanner_mode")
+@pytest.mark.asyncio
+async def test_auto_scanner_current_mode_reports_passive_on_linux() -> None:
+    """
+    AUTO must surface as PASSIVE in current_mode on Linux.
+
+    AUTO is a habluetooth scheduling concept; the BlueZ radio is
+    actually running in passive until the scheduler opens an active
+    window. Remote scanners (ESPHome) already report the real radio
+    state, and local adapters used to report AUTO and look stuck.
+    """
+    with patch_bleak_scanner_factory(MockBleakScanner):
+        ha_scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:A0")
+        ha_scanner.async_setup()
+        await ha_scanner.async_start()
+        try:
+            assert ha_scanner.requested_mode is BluetoothScanningMode.AUTO
+            assert ha_scanner.current_mode is BluetoothScanningMode.PASSIVE
+        finally:
+            await ha_scanner.async_stop()
+
+
+@pytest.fixture
+def force_macos_scanner_mode() -> Generator[None, None, None]:
+    """Force scanner.IS_LINUX=False / IS_MACOS=True for the AUTO->ACTIVE path."""
+    with (
+        patch("habluetooth.scanner.IS_LINUX", False),
+        patch("habluetooth.scanner.IS_MACOS", True),
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("force_macos_scanner_mode")
+@pytest.mark.asyncio
+async def test_auto_scanner_current_mode_reports_active_on_macos() -> None:
+    """
+    AUTO must surface as ACTIVE in current_mode on macOS.
+
+    CoreBluetooth has no passive mode so AUTO collapses to permanent
+    active; current_mode should reflect that, not the AUTO scheduling
+    label.
+    """
+    with patch_bleak_scanner_factory(MockBleakScanner):
+        ha_scanner = HaScanner(
+            BluetoothScanningMode.AUTO, "Core Bluetooth", "AA:BB:CC:DD:EE:A1"
+        )
+        ha_scanner.async_setup()
+        await ha_scanner.async_start()
+        try:
+            assert ha_scanner.requested_mode is BluetoothScanningMode.AUTO
+            assert ha_scanner.current_mode is BluetoothScanningMode.ACTIVE
+        finally:
+            await ha_scanner.async_stop()
+
+
+@pytest.mark.usefixtures("force_linux_scanner_mode")
+@pytest.mark.asyncio
+async def test_auto_scanner_current_mode_passive_after_active_window() -> None:
+    """
+    After an AUTO active window ends current_mode returns to PASSIVE.
+
+    The end-of-window toggle restores the real radio state, which on
+    Linux/BlueZ is passive. current_mode must follow the radio rather
+    than reverting to the AUTO label.
+    """
+    with patch(
+        "habluetooth.scanner.OriginalBleakScanner",
+        side_effect=lambda *_a, **_kw: MockBleakScanner(),
+    ):
+        ha_scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:A2")
+        ha_scanner.async_setup()
+        await ha_scanner.async_start()
+        try:
+            assert ha_scanner.current_mode is BluetoothScanningMode.PASSIVE
+            assert await ha_scanner.async_request_active_window(1e-9) is True
+            assert ha_scanner.current_mode is BluetoothScanningMode.ACTIVE
+            for _ in range(6):  # type: ignore[unreachable]
+                await asyncio.sleep(0)
+            assert ha_scanner.current_mode is BluetoothScanningMode.PASSIVE
+            assert ha_scanner._scan_mode_override is None
+        finally:
+            await ha_scanner.async_stop()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2972,6 +2972,30 @@ async def test_auto_scanner_current_mode_reports_active_on_macos() -> None:
 
 @pytest.mark.usefixtures("force_linux_scanner_mode")
 @pytest.mark.asyncio
+async def test_auto_scanner_current_mode_active_during_active_window() -> None:
+    """
+    Opening an AUTO active window flips current_mode to ACTIVE.
+
+    Split from the post-window assertion to avoid mypy narrowing
+    ``current_mode`` to a single literal across both transitions.
+    """
+    with patch(
+        "habluetooth.scanner.OriginalBleakScanner",
+        side_effect=lambda *_a, **_kw: MockBleakScanner(),
+    ):
+        ha_scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:A2")
+        ha_scanner.async_setup()
+        await ha_scanner.async_start()
+        try:
+            assert await ha_scanner.async_request_active_window(10.0) is True
+            assert ha_scanner.current_mode is BluetoothScanningMode.ACTIVE
+            assert ha_scanner._scan_mode_override is BluetoothScanningMode.ACTIVE
+        finally:
+            await ha_scanner.async_stop()
+
+
+@pytest.mark.usefixtures("force_linux_scanner_mode")
+@pytest.mark.asyncio
 async def test_auto_scanner_current_mode_passive_after_active_window() -> None:
     """
     After an AUTO active window ends current_mode returns to PASSIVE.
@@ -2984,14 +3008,12 @@ async def test_auto_scanner_current_mode_passive_after_active_window() -> None:
         "habluetooth.scanner.OriginalBleakScanner",
         side_effect=lambda *_a, **_kw: MockBleakScanner(),
     ):
-        ha_scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:A2")
+        ha_scanner = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:A3")
         ha_scanner.async_setup()
         await ha_scanner.async_start()
         try:
-            assert ha_scanner.current_mode is BluetoothScanningMode.PASSIVE
             assert await ha_scanner.async_request_active_window(1e-9) is True
-            assert ha_scanner.current_mode is BluetoothScanningMode.ACTIVE
-            for _ in range(6):  # type: ignore[unreachable]
+            for _ in range(6):
                 await asyncio.sleep(0)
             assert ha_scanner.current_mode is BluetoothScanningMode.PASSIVE
             assert ha_scanner._scan_mode_override is None


### PR DESCRIPTION
When the auto scheduler flips a local adapter into AUTO `HaScanner` never resolves `current_mode` to the live radio state, so the manager keeps reporting `current_mode: "auto"` for `hci0` while every ESPHome proxy on the same install correctly reports `passive` / `active`. AUTO is a habluetooth scheduling concept; the radio is always passive or active, and `current_mode` is supposed to mirror that.

`set_current_mode` now receives the resolved radio mode in `_async_start_attempt` and `_async_toggle_active_window_mode`; passive on Linux, active on macOS (CoreBluetooth has no passive). `requested_mode` is untouched, only `current_mode` reflects the live state. The fall-back warning compares against the resolved mode so it still fires only on a real ACTIVE to PASSIVE fall-back.

Mirrors the same fix on the Shelly proxy side in home-assistant-libs/aioshelly#1154.