### PR TITLE
perf(auto_scheduler): per-worker owned-due-at view for O(owned) wakes

### DIFF
--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -72,10 +72,6 @@ cdef class _OwnershipIndex:
     cdef public dict _workers
     cdef public dict _owner_by_address
 
-    cdef void _attach(self, _ScannerWorker worker, str address)
-
-    cdef void _detach(self, str address, str source)
-
     cpdef void assign(self, str address, str new_source)
 
     cpdef void unown(self, str address)

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -83,6 +83,34 @@ cdef class _OwnershipIndex:
     cdef public dict _workers
     cdef public dict _owner_by_address
 
+    @cython.locals(
+        old_source=str,
+        old_worker=_ScannerWorker,
+        new_worker=_ScannerWorker,
+        entries=dict,
+    )
+    cpdef void assign(self, str address, object new_source)
+
+    @cython.locals(
+        owner_by_address=dict,
+        needs=dict,
+        address=str,
+        worker=_ScannerWorker,
+    )
+    cpdef void clear_source(self, str source)
+
+    @cython.locals(
+        worker=_ScannerWorker,
+        owned_needs=dict,
+        needs=dict,
+        address=str,
+        owner=str,
+        entries=dict,
+    )
+    cpdef void hook_worker(self, str source)
+
+    cpdef void clear(self)
+
 
 cdef class AutoScanScheduler:
 

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -82,7 +82,7 @@ cdef class _ScanSchedule:
 
     cpdef void clear_source(self, str source)
 
-    cpdef void hook_worker(self, str source)
+    cpdef void attach_worker(self, str source)
 
     cpdef void clear(self)
 

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -66,7 +66,7 @@ cdef class _ScannerWorker:
     cpdef void _advance_due(self, list due_buckets, double from_time)
 
 
-cdef class _OwnershipIndex:
+cdef class _ScanSchedule:
 
     cdef public dict _due_at
     cdef public dict _workers
@@ -91,7 +91,7 @@ cdef class AutoScanScheduler:
 
     cdef public object _manager
     cdef public dict _requests_by_address
-    cdef public _OwnershipIndex _ownership
+    cdef public _ScanSchedule _schedule
     cdef public dict _workers
     cdef public object _loop
     cdef public bint _running

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -72,6 +72,10 @@ cdef class _OwnershipIndex:
     cdef public dict _workers
     cdef public dict _owner_by_address
 
+    cpdef bint seed(self, str address, ActiveScanRequest request, double due_time)
+
+    cpdef void drop(self, str address, ActiveScanRequest request)
+
     cpdef void assign(self, str address, str new_source)
 
     cpdef void unown(self, str address)
@@ -87,7 +91,6 @@ cdef class AutoScanScheduler:
 
     cdef public object _manager
     cdef public dict _requests_by_address
-    cdef public dict _due_at
     cdef public _OwnershipIndex _ownership
     cdef public dict _workers
     cdef public object _loop
@@ -95,9 +98,6 @@ cdef class AutoScanScheduler:
     cdef public object _on_demand_sweep_future
     cdef public double _on_demand_sweep_end
 
-    @cython.locals(
-        existing=dict,
-    )
     cpdef void add_request(self, ActiveScanRequest request)
 
     cpdef void remove_request(self, ActiveScanRequest request)
@@ -116,7 +116,6 @@ cdef class AutoScanScheduler:
     cpdef void on_advertisement(self, BluetoothServiceInfoBleak service_info)
 
     @cython.locals(
-        existing=dict,
         request=ActiveScanRequest,
     )
     cpdef void _seed_requests(

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -85,8 +85,8 @@ cdef class _OwnershipIndex:
 
     @cython.locals(
         old_source=str,
-        old_worker=_ScannerWorker,
-        new_worker=_ScannerWorker,
+        old_worker=object,
+        new_worker=object,
         entries=dict,
     )
     cpdef void assign(self, str address, object new_source)
@@ -95,12 +95,12 @@ cdef class _OwnershipIndex:
         owner_by_address=dict,
         needs=dict,
         address=str,
-        worker=_ScannerWorker,
+        worker=object,
     )
     cpdef void clear_source(self, str source)
 
     @cython.locals(
-        worker=_ScannerWorker,
+        worker=object,
         owned_needs=dict,
         needs=dict,
         address=str,

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -72,6 +72,10 @@ cdef class _OwnershipIndex:
     cdef public dict _workers
     cdef public dict _owner_by_address
 
+    cdef void _attach(self, object worker, str address)
+
+    cdef void _detach(self, str address, object source)
+
     cpdef void assign(self, str address, str new_source)
 
     cpdef void unown(self, str address)

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -51,35 +51,18 @@ cdef class _ScannerWorker:
     cpdef void note_window_dispatched(self, double window_end, double now)
 
     @cython.locals(
-        entries=dict,
         next_at=double,
         earliest=double,
     )
     cpdef double _next_event_at(self, double now)
 
     @cython.locals(
-        source=str,
-        scheduler=AutoScanScheduler,
-        ownership=_OwnershipIndex,
-        needs=dict,
-        owned=dict,
-        address=str,
-        entries=dict,
-        due=list,
-        due_buckets=list,
-        all_due=list,
         threshold=double,
         any_immediate=bint,
         t=double,
     )
     cpdef tuple _collect_due_buckets(self, double now)
 
-    @cython.locals(
-        _address=str,
-        entries=dict,
-        due=list,
-        request=ActiveScanRequest,
-    )
     cpdef void _advance_due(self, list due_buckets, double from_time)
 
 
@@ -89,40 +72,14 @@ cdef class _OwnershipIndex:
     cdef public dict _workers
     cdef public dict _owner_by_address
 
-    @cython.locals(
-        old_source=str,
-        old_worker=object,
-        new_worker=object,
-        entries=dict,
-    )
     cpdef void assign(self, str address, str new_source)
 
-    @cython.locals(
-        old_source=str,
-        old_worker=object,
-    )
     cpdef void unown(self, str address)
 
-    @cython.locals(
-        owner_by_address=dict,
-        needs=dict,
-        address=str,
-        worker=object,
-    )
     cpdef void clear_source(self, str source)
 
-    @cython.locals(
-        worker=object,
-        needs=dict,
-        address=str,
-        owner=str,
-        entries=dict,
-    )
     cpdef void hook_worker(self, str source)
 
-    @cython.locals(
-        worker=object,
-    )
     cpdef void clear(self)
 
 

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -34,7 +34,7 @@ cdef class _ScannerWorker:
     cdef public double _sweep_last_completed
     cdef public bint _failed_window
     cdef public bint _warned_no_fallback
-    cdef public dict _owned_needs
+    cdef public dict _owned_due_at
 
     cpdef void start(self, object loop, double initial_offset=*)
 
@@ -68,13 +68,13 @@ cdef class _ScannerWorker:
 
 cdef class _OwnershipIndex:
 
-    cdef public dict _needs
+    cdef public dict _due_at
     cdef public dict _workers
     cdef public dict _owner_by_address
 
-    cdef void _attach(self, object worker, str address)
+    cdef void _attach(self, _ScannerWorker worker, str address)
 
-    cdef void _detach(self, str address, object source)
+    cdef void _detach(self, str address, str source)
 
     cpdef void assign(self, str address, str new_source)
 
@@ -91,7 +91,7 @@ cdef class AutoScanScheduler:
 
     cdef public object _manager
     cdef public dict _requests_by_address
-    cdef public dict _needs
+    cdef public dict _due_at
     cdef public _OwnershipIndex _ownership
     cdef public dict _workers
     cdef public object _loop

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -42,6 +42,12 @@ cdef class _ScannerWorker:
 
     cpdef void wake(self)
 
+    cpdef void _attach_owned(self, str address, dict entries)
+
+    cpdef void _detach_owned(self, str address)
+
+    cpdef void _clear_owned(self)
+
     cpdef void note_window_dispatched(self, double window_end, double now)
 
     @cython.locals(
@@ -89,7 +95,35 @@ cdef class _OwnershipIndex:
         new_worker=object,
         entries=dict,
     )
-    cpdef void assign(self, str address, object new_source)
+    cpdef void assign(self, str address, str new_source)
+
+    @cython.locals(
+        old_source=str,
+        old_worker=object,
+    )
+    cpdef void unown(self, str address)
+
+    @cython.locals(
+        owner_by_address=dict,
+        needs=dict,
+        address=str,
+        worker=object,
+    )
+    cpdef void clear_source(self, str source)
+
+    @cython.locals(
+        worker=object,
+        needs=dict,
+        address=str,
+        owner=str,
+        entries=dict,
+    )
+    cpdef void hook_worker(self, str source)
+
+    @cython.locals(
+        worker=object,
+    )
+    cpdef void clear(self)
 
 
 cdef class AutoScanScheduler:

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -54,6 +54,7 @@ cdef class _ScannerWorker:
     @cython.locals(
         source=str,
         scheduler=AutoScanScheduler,
+        ownership=_OwnershipIndex,
         needs=dict,
         owned=dict,
         address=str,
@@ -76,12 +77,19 @@ cdef class _ScannerWorker:
     cpdef void _advance_due(self, list due_buckets, double from_time)
 
 
+cdef class _OwnershipIndex:
+
+    cdef public dict _needs
+    cdef public dict _workers
+    cdef public dict _owner_by_address
+
+
 cdef class AutoScanScheduler:
 
     cdef public object _manager
     cdef public dict _requests_by_address
     cdef public dict _needs
-    cdef public dict _owner_by_address
+    cdef public _OwnershipIndex _ownership
     cdef public dict _workers
     cdef public object _loop
     cdef public bint _running
@@ -99,7 +107,6 @@ cdef class AutoScanScheduler:
 
     @cython.locals(
         source=str,
-        address=str,
     )
     cpdef void remove_scanner(self, object scanner)
 

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -34,6 +34,7 @@ cdef class _ScannerWorker:
     cdef public double _sweep_last_completed
     cdef public bint _failed_window
     cdef public bint _warned_no_fallback
+    cdef public dict _owned_needs
 
     cpdef void start(self, object loop, double initial_offset=*)
 
@@ -44,9 +45,6 @@ cdef class _ScannerWorker:
     cpdef void note_window_dispatched(self, double window_end, double now)
 
     @cython.locals(
-        source=str,
-        needs=dict,
-        address=str,
         entries=dict,
         next_at=double,
         earliest=double,
@@ -55,7 +53,9 @@ cdef class _ScannerWorker:
 
     @cython.locals(
         source=str,
+        scheduler=AutoScanScheduler,
         needs=dict,
+        owned=dict,
         address=str,
         entries=dict,
         due=list,
@@ -81,6 +81,7 @@ cdef class AutoScanScheduler:
     cdef public object _manager
     cdef public dict _requests_by_address
     cdef public dict _needs
+    cdef public dict _owner_by_address
     cdef public dict _workers
     cdef public object _loop
     cdef public bint _running

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -91,26 +91,6 @@ cdef class _OwnershipIndex:
     )
     cpdef void assign(self, str address, object new_source)
 
-    @cython.locals(
-        owner_by_address=dict,
-        needs=dict,
-        address=str,
-        worker=object,
-    )
-    cpdef void clear_source(self, str source)
-
-    @cython.locals(
-        worker=object,
-        owned_needs=dict,
-        needs=dict,
-        address=str,
-        owner=str,
-        entries=dict,
-    )
-    cpdef void hook_worker(self, str source)
-
-    cpdef void clear(self)
-
 
 cdef class AutoScanScheduler:
 

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -25,8 +25,8 @@ Flow
 
                   add_request(req)           on_advertisement(adv)
                        |                            |
-                       | _ownership.seed(...)       | _ownership.seed(...) per req;
-                       | _ownership.assign(addr,    | _ownership.assign(addr,
+                       | _schedule.seed(...)        | _schedule.seed(...) per req;
+                       | _schedule.assign(addr,     | _schedule.assign(addr,
                        |   history.source)          |   adv.source) wakes owner
                        v                            v
               +----------------------------------------------+
@@ -35,7 +35,7 @@ Flow
               |       addr -> set of ActiveScanRequest       |
               |    _workers                                  |
               |       source -> _ScannerWorker               |
-              |    _ownership: _OwnershipIndex               |
+              |    _schedule: _ScanSchedule                  |
               |       _due_at                                |
               |          addr -> {request: next_due_time}    |
               |       _owner_by_address                      |
@@ -87,7 +87,7 @@ up the new owner without any address-level rescheduling:
    and then calls ``auto_scheduler.on_advertisement(service_info)``
    *before* the same-payload short-circuit, so the flip is visible to
    the scheduler even for static-payload beacons.
-2. ``on_advertisement`` calls ``_ownership.assign(adv.address,
+2. ``on_advertisement`` calls ``_schedule.assign(adv.address,
    adv.source)``. The index detaches the entry from A's
    ``_owned_due_at``, attaches it to B's ``_owned_due_at`` (same dict
    object, just a different worker holds the alias), and wakes B's
@@ -259,7 +259,7 @@ class _ScannerWorker:
         self._warned_no_fallback: bool = False
         # Subset of _due_at owned by this worker; inner dicts aliased so
         # in-place advances stay visible. Mutated only via _attach_owned
-        # / _detach_owned / _clear_owned, driven by _OwnershipIndex.
+        # / _detach_owned / _clear_owned, driven by _ScanSchedule.
         self._owned_due_at: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
@@ -291,15 +291,15 @@ class _ScannerWorker:
     def _attach_owned(
         self, address: str, entries: dict[ActiveScanRequest, float]
     ) -> None:
-        """Attach an owned ``_due_at`` bucket; called only by _OwnershipIndex."""
+        """Attach an owned ``_due_at`` bucket; called only by _ScanSchedule."""
         self._owned_due_at[address] = entries
 
     def _detach_owned(self, address: str) -> None:
-        """Detach an owned bucket; called only by _OwnershipIndex."""
+        """Detach an owned bucket; called only by _ScanSchedule."""
         self._owned_due_at.pop(address, None)
 
     def _clear_owned(self) -> None:
-        """Drop all owned buckets; called only by _OwnershipIndex."""
+        """Drop all owned buckets; called only by _ScanSchedule."""
         self._owned_due_at.clear()
 
     def note_window_dispatched(self, window_end: float, now: float) -> None:
@@ -397,10 +397,10 @@ class _ScannerWorker:
             entries = self._owned_due_at[address]
             history = last_service_info(address, False)
             if history is None:
-                self._scheduler._ownership.unown(address)
+                self._scheduler._schedule.unown(address)
                 continue
             if history.source != source:
-                self._scheduler._ownership.assign(address, history.source)
+                self._scheduler._schedule.assign(address, history.source)
                 continue
             due: list[ActiveScanRequest] = []
             for r, t in entries.items():
@@ -622,8 +622,15 @@ class _ScannerWorker:
                 )
 
 
-class _OwnershipIndex:
-    """Owns ``_due_at``, ``_owner_by_address``, and the per-worker view."""
+class _ScanSchedule:
+    """
+    Per-address scan schedule: due times, owner, and per-worker view.
+
+    Owns ``_due_at`` (when each request is due), ``_owner_by_address``
+    (which scanner currently sees each address), and maintains an aliased
+    subset of ``_due_at`` on each worker's ``_owned_due_at`` so workers
+    iterate only the addresses they actually own.
+    """
 
     __slots__ = ("_due_at", "_owner_by_address", "_workers")
 
@@ -705,9 +712,9 @@ class AutoScanScheduler:
         "_manager",
         "_on_demand_sweep_end",
         "_on_demand_sweep_future",
-        "_ownership",
         "_requests_by_address",
         "_running",
+        "_schedule",
         "_workers",
     )
 
@@ -716,7 +723,7 @@ class AutoScanScheduler:
         self._manager = manager
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
         self._workers: dict[str, _ScannerWorker] = {}
-        self._ownership = _OwnershipIndex(self._workers)
+        self._schedule = _ScanSchedule(self._workers)
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
@@ -750,7 +757,7 @@ class AutoScanScheduler:
             if history is None:
                 continue
             self._seed_requests(address, requests, now)
-            self._ownership.assign(address, history.source)
+            self._schedule.assign(address, history.source)
 
     def stop(self) -> None:
         """
@@ -776,7 +783,7 @@ class AutoScanScheduler:
         self._running = False
         for worker in self._workers.values():
             worker.stop()
-        self._ownership.clear()
+        self._schedule.clear()
         self._workers.clear()
         # done() guard mirrors the leader's finally for symmetry;
         # a future left non-None after completion would otherwise
@@ -811,7 +818,7 @@ class AutoScanScheduler:
         entry pinned until the next history flip / age-out.
         """
         source = scanner.source
-        self._ownership.clear_source(source)
+        self._schedule.clear_source(source)
         worker = self._workers.pop(source, None)
         if worker is not None:
             worker.stop()
@@ -832,7 +839,7 @@ class AutoScanScheduler:
         source = scanner.source
         self._workers[source] = worker
         # Attach entries pre-assigned before this scanner registered.
-        self._ownership.hook_worker(source)
+        self._schedule.hook_worker(source)
 
     def add_request(self, request: ActiveScanRequest) -> None:
         """
@@ -855,11 +862,11 @@ class AutoScanScheduler:
             # it anyway); on_advertisement will bootstrap on first
             # sight.
             return
-        if not self._ownership.seed(
+        if not self._schedule.seed(
             request.address, request, self._loop.time() + request.scan_interval
         ):
             return
-        self._ownership.assign(request.address, history.source)
+        self._schedule.assign(request.address, history.source)
 
     def remove_request(self, request: ActiveScanRequest) -> None:
         """Drop the request from the index and from any pending tracking."""
@@ -867,7 +874,7 @@ class AutoScanScheduler:
             bucket.discard(request)
             if not bucket:
                 del self._requests_by_address[request.address]
-        self._ownership.drop(request.address, request)
+        self._schedule.drop(request.address, request)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
         """
@@ -886,7 +893,7 @@ class AutoScanScheduler:
         if requests is None:
             return
         self._seed_requests(address, requests, self._loop.time())
-        self._ownership.assign(address, service_info.source)
+        self._schedule.assign(address, service_info.source)
 
     def _seed_requests(
         self,
@@ -901,7 +908,7 @@ class AutoScanScheduler:
         loop. Leaves existing entries' due times untouched.
         """
         for request in requests:
-            self._ownership.seed(address, request, now + request.scan_interval)
+            self._schedule.seed(address, request, now + request.scan_interval)
 
     def _resolve_fallback_for_address(
         self, address: str, exclude_source: str
@@ -1187,7 +1194,7 @@ class AutoScanScheduler:
         last_service_info = self._manager.async_last_service_info
         requests: dict[str, list[dict[str, Any]]] = {}
         for address, bucket in self._requests_by_address.items():
-            entries = self._ownership._due_at.get(address, {})
+            entries = self._schedule._due_at.get(address, {})
             history = last_service_info(address, False)
             owner_source = history.source if history is not None else None
             requests[address] = [

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -246,11 +246,8 @@ class _ScannerWorker:
         self._sweep_last_completed: float = 0.0
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
-        # Per-worker view of self._scheduler._needs filtered to addresses
-        # this scanner currently owns. Inner dicts are aliases of the
-        # same dict in _needs, so in-place mutations by _advance_due /
-        # _dispatch_to_fallback are visible without bookkeeping. The
-        # scheduler's _assign_owner is the single mutation point.
+        # Owned subset of _needs; inner dicts aliased so in-place
+        # advances stay visible. Mutated only by _assign_owner.
         self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
@@ -320,10 +317,7 @@ class _ScannerWorker:
         """
         Return the earliest loop-time at which this worker has work.
 
-        O(M) over *owned* addresses (entries this scanner currently
-        owns), not the global _needs map. Ownership transitions are
-        maintained eagerly by AutoScanScheduler._assign_owner; this
-        path makes no async_last_service_info calls.
+        O(owned), no async_last_service_info call.
         """
         if self._window_end > now:
             return self._window_end
@@ -363,21 +357,13 @@ class _ScannerWorker:
         """
         Return (due_buckets, all_due, any_immediate) for addresses owned.
 
-        Iterates the per-worker owned-needs view (maintained eagerly
-        by AutoScanScheduler._assign_owner) instead of the global
-        _needs map. Collects entries due within
-        ``_AUTO_COALESCE_LOOKAHEAD`` of ``now`` regardless of
-        ``any_immediate``, so soon-due entries ride a window the
-        caller decides to open (a per-device hit or the 12 h sweep).
-        Caller must gate on ``any_immediate or sweep_due`` — a
-        scanner with only soon-due entries must not tick early on its
-        own. Prunes orphan entries (history None) and resyncs entries
-        whose manager-side owner has flipped without an
-        on_advertisement notification (defense-in-depth).
+        Iterates the owned view. Collects entries due within
+        ``_AUTO_COALESCE_LOOKAHEAD`` so soon-due entries ride a window
+        the caller opens; caller must gate on
+        ``any_immediate or sweep_due``. Prunes orphans (history None)
+        and resyncs on owner drift.
 
-        Invariant: ``_AUTO_COALESCE_LOOKAHEAD > max window duration``
-        so a window cannot outlive its lookahead and leave a device
-        overdue when it ends.
+        Invariant: ``_AUTO_COALESCE_LOOKAHEAD > max window duration``.
         """
         source = self._scanner.source
         scheduler = self._scheduler
@@ -396,17 +382,12 @@ class _ScannerWorker:
                 continue
             history = last_service_info(address, False)
             if history is None:
-                # Orphan: history aged out. Drop from owner index and
-                # the global needs map.
+                # Orphan: history aged out.
                 scheduler._assign_owner(address, None)
                 needs.pop(address, None)
                 continue
             if history.source != source:
-                # Owned view is out of sync with manager history
-                # (should be unreachable since on_advertisement keeps
-                # them aligned, but the manager has other histories
-                # mutation paths). Re-sync and skip this tick — the
-                # rightful owner will pick it up.
+                # Owner drifted; rightful owner picks it up next tick.
                 scheduler._assign_owner(address, history.source)
                 continue
             due: list[ActiveScanRequest] = []
@@ -649,9 +630,7 @@ class AutoScanScheduler:
         self._manager = manager
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
         self._needs: dict[str, dict[ActiveScanRequest, float]] = {}
-        # Address -> source string identifying the worker that
-        # currently owns the address. Single source of truth for the
-        # per-worker _owned_needs view; updated only by _assign_owner.
+        # address -> owning source; updated only by _assign_owner.
         self._owner_by_address: dict[str, str] = {}
         self._workers: dict[str, _ScannerWorker] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -774,10 +753,7 @@ class AutoScanScheduler:
         worker.start(self._loop, offset)
         source = scanner.source
         self._workers[source] = worker
-        # Hook up entries already owned by this source (e.g., an
-        # on_advertisement that arrived before the scanner registered,
-        # or the start() replay loop seeding requests before workers
-        # were created in some other ordering).
+        # Attach entries pre-assigned before this scanner registered.
         for address, owner in self._owner_by_address.items():
             if owner == source:
                 self._attach_to_worker(source, address)
@@ -865,13 +841,7 @@ class AutoScanScheduler:
             worker.wake()
 
     def _assign_owner(self, address: str, new_source: str | None) -> None:
-        """
-        Move address ownership to ``new_source`` (or clear if None).
-
-        Thin coordinator: tracks the transition in
-        ``_owner_by_address`` and delegates the per-worker view
-        touches to ``_detach_from_worker`` / ``_attach_to_worker``.
-        """
+        """Move address ownership to ``new_source`` (or clear if None)."""
         old_source = self._owner_by_address.get(address)
         if old_source == new_source:
             return
@@ -884,30 +854,13 @@ class AutoScanScheduler:
         self._attach_to_worker(new_source, address)
 
     def _detach_from_worker(self, source: str, address: str) -> None:
-        """
-        Drop ``address`` from ``source``'s per-worker owned view.
-
-        Tolerates a missing worker (e.g., the scanner was removed
-        and its worker popped from ``_workers`` before the address
-        ownership got reassigned).
-        """
+        """Drop ``address`` from ``source``'s owned view, if worker exists."""
         worker = self._workers.get(source)
         if worker is not None:
             worker._owned_needs.pop(address, None)
 
     def _attach_to_worker(self, source: str, address: str) -> None:
-        """
-        Hook ``address`` into ``source``'s per-worker owned view.
-
-        The aliased inner dict is the same object as
-        ``_needs[address]``, so in-place mutations of due-times by
-        ``_advance_due`` / ``_dispatch_to_fallback`` stay visible
-        through both views. Tolerates a missing ``_needs`` entry
-        (e.g., owner pre-assigned via ``on_advertisement`` before
-        any request was registered) and a missing worker
-        (e.g., ``new_source`` not yet spawned at ``start()`` time —
-        ``_spawn_worker`` will hook the entry on registration).
-        """
+        """Alias ``_needs[address]`` into ``source``'s owned view."""
         entries = self._needs.get(address)
         if entries is None:
             return

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -613,19 +613,32 @@ class _ScannerWorker:
 
 
 class _OwnershipIndex:
-    """Per-address scanner ownership and per-worker owned-due-at view."""
+    """Owns ``_due_at``, ``_owner_by_address``, and the per-worker view."""
 
     __slots__ = ("_due_at", "_owner_by_address", "_workers")
 
-    def __init__(
-        self,
-        due_at: dict[str, dict[ActiveScanRequest, float]],
-        workers: dict[str, _ScannerWorker],
-    ) -> None:
-        """Bind to the scheduler's ``_due_at`` and ``_workers`` dicts."""
-        self._due_at = due_at
+    def __init__(self, workers: dict[str, _ScannerWorker]) -> None:
+        """Bind to the scheduler's ``_workers`` dict."""
         self._workers = workers
+        self._due_at: dict[str, dict[ActiveScanRequest, float]] = {}
         self._owner_by_address: dict[str, str] = {}
+
+    def seed(self, address: str, request: ActiveScanRequest, due_time: float) -> bool:
+        """Seed ``request`` at ``address``; return True if newly inserted."""
+        existing = self._due_at.setdefault(address, {})
+        if request in existing:
+            return False
+        existing[request] = due_time
+        return True
+
+    def drop(self, address: str, request: ActiveScanRequest) -> None:
+        """Drop ``request`` at ``address``; ``unown`` if it was the last one."""
+        entries = self._due_at.get(address)
+        if entries is None:
+            return
+        entries.pop(request, None)
+        if not entries:
+            self.unown(address)
 
     def assign(self, address: str, new_source: str) -> None:
         """Move ownership of ``address`` to ``new_source`` and wake its worker."""
@@ -678,7 +691,6 @@ class AutoScanScheduler:
     """Coordinates on-demand active windows across AUTO-mode scanners."""
 
     __slots__ = (
-        "_due_at",
         "_loop",
         "_manager",
         "_on_demand_sweep_end",
@@ -693,9 +705,8 @@ class AutoScanScheduler:
         """Initialize the scheduler bound to a manager."""
         self._manager = manager
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
-        self._due_at: dict[str, dict[ActiveScanRequest, float]] = {}
         self._workers: dict[str, _ScannerWorker] = {}
-        self._ownership = _OwnershipIndex(self._due_at, self._workers)
+        self._ownership = _OwnershipIndex(self._workers)
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
@@ -834,10 +845,10 @@ class AutoScanScheduler:
             # it anyway); on_advertisement will bootstrap on first
             # sight.
             return
-        existing = self._due_at.setdefault(request.address, {})
-        if request in existing:
+        if not self._ownership.seed(
+            request.address, request, self._loop.time() + request.scan_interval
+        ):
             return
-        existing[request] = self._loop.time() + request.scan_interval
         self._ownership.assign(request.address, history.source)
 
     def remove_request(self, request: ActiveScanRequest) -> None:
@@ -846,10 +857,7 @@ class AutoScanScheduler:
             bucket.discard(request)
             if not bucket:
                 del self._requests_by_address[request.address]
-        if (entries := self._due_at.get(request.address)) is not None:
-            entries.pop(request, None)
-            if not entries:
-                self._ownership.unown(request.address)
+        self._ownership.drop(request.address, request)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
         """
@@ -882,10 +890,8 @@ class AutoScanScheduler:
         Shared by ``on_advertisement`` and the ``start()`` replay
         loop. Leaves existing entries' due times untouched.
         """
-        existing = self._due_at.setdefault(address, {})
         for request in requests:
-            if request not in existing:
-                existing[request] = now + request.scan_interval
+            self._ownership.seed(address, request, now + request.scan_interval)
 
     def _resolve_fallback_for_address(
         self, address: str, exclude_source: str
@@ -1171,7 +1177,7 @@ class AutoScanScheduler:
         last_service_info = self._manager.async_last_service_info
         requests: dict[str, list[dict[str, Any]]] = {}
         for address, bucket in self._requests_by_address.items():
-            entries = self._due_at.get(address, {})
+            entries = self._ownership._due_at.get(address, {})
             history = last_service_info(address, False)
             owner_source = history.source if history is not None else None
             requests[address] = [

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -631,32 +631,37 @@ class _OwnershipIndex:
         self._workers = workers
         self._owner_by_address: dict[str, str] = {}
 
+    def _attach(self, worker: Any, address: str) -> None:
+        """Attach the ``_needs`` bucket for ``address`` to ``worker``, if both exist."""
+        if worker is None:
+            return
+        entries = self._needs.get(address)
+        if entries is not None:
+            worker._attach_owned(address, entries)
+
+    def _detach(self, address: str, source: str | None) -> None:
+        """Detach ``address`` from the worker for ``source``, if both exist."""
+        if source is None:
+            return
+        worker = self._workers.get(source)
+        if worker is not None:
+            worker._detach_owned(address)
+
     def assign(self, address: str, new_source: str) -> None:
         """Move ownership of ``address`` to ``new_source`` and wake its worker."""
         new_worker = self._workers.get(new_source)
         old_source = self._owner_by_address.get(address)
         if old_source != new_source:
-            if old_source is not None:
-                old_worker = self._workers.get(old_source)
-                if old_worker is not None:
-                    old_worker._detach_owned(address)
+            self._detach(address, old_source)
             self._owner_by_address[address] = new_source
-            if new_worker is not None:
-                entries = self._needs.get(address)
-                if entries is not None:
-                    new_worker._attach_owned(address, entries)
+            self._attach(new_worker, address)
         if new_worker is not None:
             new_worker.wake()
 
     def unown(self, address: str) -> None:
         """Forget ``address`` entirely; drops needs, owner, and worker view."""
         self._needs.pop(address, None)
-        old_source = self._owner_by_address.pop(address, None)
-        if old_source is None:
-            return
-        old_worker = self._workers.get(old_source)
-        if old_worker is not None:
-            old_worker._detach_owned(address)
+        self._detach(address, self._owner_by_address.pop(address, None))
 
     def clear_source(self, source: str) -> None:
         """Drop owner mappings and ``_needs`` entries owned by ``source``."""
@@ -675,15 +680,14 @@ class _OwnershipIndex:
             return
         for address, owner in self._owner_by_address.items():
             if owner == source:
-                entries = self._needs.get(address)
-                if entries is not None:
-                    worker._attach_owned(address, entries)
+                self._attach(worker, address)
 
     def clear(self) -> None:
-        """Reset the index and every worker's owned view."""
+        """Reset the index, every worker's owned view, and ``_needs``."""
         for worker in self._workers.values():
             worker._clear_owned()
         self._owner_by_address.clear()
+        self._needs.clear()
 
 
 class AutoScanScheduler:
@@ -769,7 +773,6 @@ class AutoScanScheduler:
             worker.stop()
         self._ownership.clear()
         self._workers.clear()
-        self._needs.clear()
         # done() guard mirrors the leader's finally for symmetry;
         # a future left non-None after completion would otherwise
         # raise InvalidStateError here.

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -247,8 +247,7 @@ class _ScannerWorker:
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
         # Owned subset of _needs; inner dicts aliased so in-place
-        # advances stay visible. Populated/updated via _assign_owner;
-        # cleared on stop/remove_scanner.
+        # advances stay visible. Maintained by _OwnershipIndex.
         self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
@@ -368,6 +367,7 @@ class _ScannerWorker:
         """
         source = self._scanner.source
         scheduler = self._scheduler
+        ownership = scheduler._ownership
         needs = scheduler._needs
         owned = self._owned_needs
         last_service_info = self._manager.async_last_service_info
@@ -384,13 +384,13 @@ class _ScannerWorker:
             history = last_service_info(address, False)
             if history is None:
                 # Orphan: history aged out.
-                scheduler._assign_owner(address, None)
+                ownership.assign(address, None)
                 needs.pop(address, None)
                 continue
             if history.source != source:
                 # Owner drifted; reassign and wake the new owner so it
                 # can re-evaluate its next event time promptly.
-                scheduler._assign_owner(address, history.source)
+                ownership.assign(address, history.source)
                 scheduler._wake_worker(history.source)
                 continue
             due: list[ActiveScanRequest] = []
@@ -613,6 +613,80 @@ class _ScannerWorker:
                 )
 
 
+class _OwnershipIndex:
+    """
+    Per-address scanner ownership and per-worker owned-needs view.
+
+    Single source of truth for which scanner owns each address and
+    for the aliased subset of ``_needs`` each owner's worker sees on
+    its hot path. Invariant: an address has an owner iff
+    ``_needs[address]`` is non-empty.
+    """
+
+    __slots__ = ("_needs", "_owner_by_address", "_workers")
+
+    def __init__(
+        self,
+        needs: dict[str, dict[ActiveScanRequest, float]],
+        workers: dict[str, _ScannerWorker],
+    ) -> None:
+        """Bind to the scheduler's ``_needs`` and ``_workers`` dicts."""
+        self._needs = needs
+        self._workers = workers
+        self._owner_by_address: dict[str, str] = {}
+
+    def assign(self, address: str, new_source: str | None) -> None:
+        """Move ownership of ``address`` to ``new_source`` (None clears)."""
+        old_source = self._owner_by_address.get(address)
+        if old_source == new_source:
+            return
+        if old_source is not None:
+            old_worker = self._workers.get(old_source)
+            if old_worker is not None:
+                old_worker._owned_needs.pop(address, None)
+        if new_source is None:
+            self._owner_by_address.pop(address, None)
+            return
+        self._owner_by_address[address] = new_source
+        entries = self._needs.get(address)
+        if entries is None:
+            return
+        new_worker = self._workers.get(new_source)
+        if new_worker is not None:
+            new_worker._owned_needs[address] = entries
+
+    def clear_source(self, source: str) -> None:
+        """Drop owner mappings and ``_needs`` entries owned by ``source``."""
+        owner_by_address = self._owner_by_address
+        needs = self._needs
+        for address in list(owner_by_address):
+            if owner_by_address[address] == source:
+                del owner_by_address[address]
+                needs.pop(address, None)
+        worker = self._workers.get(source)
+        if worker is not None:
+            worker._owned_needs.clear()
+
+    def hook_worker(self, source: str) -> None:
+        """Attach pre-assigned entries to a newly-registered worker."""
+        worker = self._workers.get(source)
+        if worker is None:
+            return
+        owned_needs = worker._owned_needs
+        needs = self._needs
+        for address, owner in self._owner_by_address.items():
+            if owner == source:
+                entries = needs.get(address)
+                if entries is not None:
+                    owned_needs[address] = entries
+
+    def clear(self) -> None:
+        """Reset the index and every worker's owned view."""
+        for worker in self._workers.values():
+            worker._owned_needs.clear()
+        self._owner_by_address.clear()
+
+
 class AutoScanScheduler:
     """Coordinates on-demand active windows across AUTO-mode scanners."""
 
@@ -622,7 +696,7 @@ class AutoScanScheduler:
         "_needs",
         "_on_demand_sweep_end",
         "_on_demand_sweep_future",
-        "_owner_by_address",
+        "_ownership",
         "_requests_by_address",
         "_running",
         "_workers",
@@ -633,9 +707,8 @@ class AutoScanScheduler:
         self._manager = manager
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
         self._needs: dict[str, dict[ActiveScanRequest, float]] = {}
-        # address -> owning source; updated only by _assign_owner.
-        self._owner_by_address: dict[str, str] = {}
         self._workers: dict[str, _ScannerWorker] = {}
+        self._ownership = _OwnershipIndex(self._needs, self._workers)
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
@@ -669,7 +742,7 @@ class AutoScanScheduler:
             if history is None:
                 continue
             self._seed_requests(address, requests, now)
-            self._assign_owner(address, history.source)
+            self._ownership.assign(address, history.source)
 
     def stop(self) -> None:
         """
@@ -695,10 +768,9 @@ class AutoScanScheduler:
         self._running = False
         for worker in self._workers.values():
             worker.stop()
-            worker._owned_needs.clear()
+        self._ownership.clear()
         self._workers.clear()
         self._needs.clear()
-        self._owner_by_address.clear()
         # done() guard mirrors the leader's finally for symmetry;
         # a future left non-None after completion would otherwise
         # raise InvalidStateError here.
@@ -732,14 +804,10 @@ class AutoScanScheduler:
         entry pinned until the next history flip / age-out.
         """
         source = scanner.source
+        self._ownership.clear_source(source)
         worker = self._workers.pop(source, None)
         if worker is not None:
             worker.stop()
-            worker._owned_needs.clear()
-        for address in list(self._owner_by_address):
-            if self._owner_by_address[address] == source:
-                del self._owner_by_address[address]
-                self._needs.pop(address, None)
 
     def _spawn_worker(self, scanner: BaseHaScanner) -> None:
         assert self._loop is not None  # noqa: S101
@@ -757,9 +825,7 @@ class AutoScanScheduler:
         source = scanner.source
         self._workers[source] = worker
         # Attach entries pre-assigned before this scanner registered.
-        for address, owner in self._owner_by_address.items():
-            if owner == source:
-                self._attach_to_worker(source, address)
+        self._ownership.hook_worker(source)
 
     def add_request(self, request: ActiveScanRequest) -> None:
         """
@@ -786,7 +852,7 @@ class AutoScanScheduler:
         if request in existing:
             return
         existing[request] = self._loop.time() + request.scan_interval
-        self._assign_owner(request.address, history.source)
+        self._ownership.assign(request.address, history.source)
         self._wake_worker(history.source)
 
     def remove_request(self, request: ActiveScanRequest) -> None:
@@ -799,7 +865,7 @@ class AutoScanScheduler:
             entries.pop(request, None)
             if not entries:
                 del self._needs[request.address]
-                self._assign_owner(request.address, None)
+                self._ownership.assign(request.address, None)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
         """
@@ -818,7 +884,7 @@ class AutoScanScheduler:
         if requests is None:
             return
         self._seed_requests(address, requests, self._loop.time())
-        self._assign_owner(address, service_info.source)
+        self._ownership.assign(address, service_info.source)
         self._wake_worker(service_info.source)
 
     def _seed_requests(
@@ -842,34 +908,6 @@ class AutoScanScheduler:
         """Wake the worker for ``source`` if one is registered."""
         if (worker := self._workers.get(source)) is not None:
             worker.wake()
-
-    def _assign_owner(self, address: str, new_source: str | None) -> None:
-        """Move address ownership to ``new_source`` (or clear if None)."""
-        old_source = self._owner_by_address.get(address)
-        if old_source == new_source:
-            return
-        if old_source is not None:
-            self._detach_from_worker(old_source, address)
-        if new_source is None:
-            self._owner_by_address.pop(address, None)
-            return
-        self._owner_by_address[address] = new_source
-        self._attach_to_worker(new_source, address)
-
-    def _detach_from_worker(self, source: str, address: str) -> None:
-        """Drop ``address`` from ``source``'s owned view, if worker exists."""
-        worker = self._workers.get(source)
-        if worker is not None:
-            worker._owned_needs.pop(address, None)
-
-    def _attach_to_worker(self, source: str, address: str) -> None:
-        """Alias ``_needs[address]`` into ``source``'s owned view."""
-        entries = self._needs.get(address)
-        if entries is None:
-            return
-        worker = self._workers.get(source)
-        if worker is not None:
-            worker._owned_needs[address] = entries
 
     def _resolve_fallback_for_address(
         self, address: str, exclude_source: str

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -296,7 +296,7 @@ class _ScannerWorker:
 
     def _detach_owned(self, address: str) -> None:
         """Detach an owned bucket; called only by _ScanSchedule."""
-        self._owned_due_at.pop(address, None)
+        del self._owned_due_at[address]
 
     def _clear_owned(self) -> None:
         """Drop all owned buckets; called only by _ScanSchedule."""

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -88,7 +88,7 @@ up the new owner without any address-level rescheduling:
    *before* the same-payload short-circuit, so the flip is visible to
    the scheduler even for static-payload beacons.
 2. ``on_advertisement`` calls ``_schedule.assign(adv.address,
-   adv.source)``. The index detaches the entry from A's
+   adv.source)``. The schedule detaches the entry from A's
    ``_owned_due_at``, attaches it to B's ``_owned_due_at`` (same dict
    object, just a different worker holds the alias), and wakes B's
    worker. A's worker no longer sees the address at all; B's does.
@@ -141,7 +141,7 @@ Invariants
   sweep therefore fires only on AUTO scanners that haven't had
   *any* active scan in ``AUTO_REDISCOVERY_INTERVAL`` (12 h).
 * A registration kick-starts tracking immediately; ``on_advertisement``
-  is the fallback that re-creates the entry if the worker pruned it
+  is the fallback that re-creates the entry if a worker ``unown``'d it
   because the device's history was missing at tick time.
 * Every accepted advertisement on a tracked address wakes the source's
   worker so an ownership flip on the same scanner triggers a
@@ -689,7 +689,7 @@ class _ScanSchedule:
         if worker is not None:
             worker._clear_owned()
 
-    def hook_worker(self, source: str) -> None:
+    def attach_worker(self, source: str) -> None:
         """Attach pre-assigned entries to a newly-registered worker."""
         worker = self._workers[source]
         for address, owner in self._owner_by_address.items():
@@ -839,7 +839,7 @@ class AutoScanScheduler:
         source = scanner.source
         self._workers[source] = worker
         # Attach entries pre-assigned before this scanner registered.
-        self._schedule.hook_worker(source)
+        self._schedule.attach_worker(source)
 
     def add_request(self, request: ActiveScanRequest) -> None:
         """
@@ -869,7 +869,7 @@ class AutoScanScheduler:
         self._schedule.assign(request.address, history.source)
 
     def remove_request(self, request: ActiveScanRequest) -> None:
-        """Drop the request from the index and from any pending tracking."""
+        """Drop the request from ``_requests_by_address`` and the schedule."""
         if (bucket := self._requests_by_address.get(request.address)) is not None:
             bucket.discard(request)
             if not bucket:

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -627,33 +627,27 @@ class _OwnershipIndex:
         self._workers = workers
         self._owner_by_address: dict[str, str] = {}
 
-    def _attach(self, worker: _ScannerWorker, address: str) -> None:
-        """Attach the ``_due_at`` bucket for ``address`` to ``worker``."""
-        worker._attach_owned(address, self._due_at[address])
-
-    def _detach(self, address: str, source: str) -> None:
-        """Detach ``address`` from the worker for ``source``, if it exists."""
-        worker = self._workers.get(source)
-        if worker is not None:
-            worker._detach_owned(address)
-
     def assign(self, address: str, new_source: str) -> None:
         """Move ownership of ``address`` to ``new_source`` and wake its worker."""
         new_worker = self._workers.get(new_source)
         old_source = self._owner_by_address.get(address)
         if old_source != new_source:
             if old_source is not None:
-                self._detach(address, old_source)
+                old_worker = self._workers.get(old_source)
+                if old_worker is not None:
+                    old_worker._detach_owned(address)
             self._owner_by_address[address] = new_source
             if new_worker is not None:
-                self._attach(new_worker, address)
+                new_worker._attach_owned(address, self._due_at[address])
         if new_worker is not None:
             new_worker.wake()
 
     def unown(self, address: str) -> None:
         """Forget ``address`` entirely; drops due_at, owner, and worker view."""
         del self._due_at[address]
-        self._detach(address, self._owner_by_address.pop(address))
+        old_worker = self._workers.get(self._owner_by_address.pop(address))
+        if old_worker is not None:
+            old_worker._detach_owned(address)
 
     def clear_source(self, source: str) -> None:
         """Drop owner mappings and ``_due_at`` entries owned by ``source``."""
@@ -670,7 +664,7 @@ class _OwnershipIndex:
         worker = self._workers[source]
         for address, owner in self._owner_by_address.items():
             if owner == source:
-                self._attach(worker, address)
+                worker._attach_owned(address, self._due_at[address])
 
     def clear(self) -> None:
         """Reset the index, every worker's owned view, and ``_due_at``."""

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -247,7 +247,8 @@ class _ScannerWorker:
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
         # Owned subset of _needs; inner dicts aliased so in-place
-        # advances stay visible. Mutated only by _assign_owner.
+        # advances stay visible. Populated/updated via _assign_owner;
+        # cleared on stop/remove_scanner.
         self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
@@ -387,8 +388,10 @@ class _ScannerWorker:
                 needs.pop(address, None)
                 continue
             if history.source != source:
-                # Owner drifted; rightful owner picks it up next tick.
+                # Owner drifted; reassign and wake the new owner so it
+                # can re-evaluate its next event time promptly.
                 scheduler._assign_owner(address, history.source)
+                scheduler._wake_worker(history.source)
                 continue
             due: list[ActiveScanRequest] = []
             for r, t in entries.items():

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -25,7 +25,7 @@ Flow
 
                      add_request(req)            on_advertisement(adv)
                         |                            |
-                        | seed _needs[addr][req]     | seed if pruned;
+                        | seed _due_at[addr][req]     | seed if pruned;
                         | = now + scan_interval      | always wake
                         | wake address's owner       | adv.source's worker
                         v                            v
@@ -33,7 +33,7 @@ Flow
                   |  AutoScanScheduler                       |
                   |    _requests_by_address                  |
                   |       addr -> set of ActiveScanRequest   |
-                  |    _needs                                |
+                  |    _due_at                                |
                   |       addr -> {request: next_due_time}   |
                   |    _workers                              |
                   |       source -> _ScannerWorker           |
@@ -222,7 +222,7 @@ class _ScannerWorker:
     __slots__ = (
         "_failed_window",
         "_manager",
-        "_owned_needs",
+        "_owned_due_at",
         "_scanner",
         "_scheduler",
         "_sweep_last_completed",
@@ -247,10 +247,10 @@ class _ScannerWorker:
         self._sweep_last_completed: float = 0.0
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
-        # Subset of _needs owned by this worker; inner dicts aliased so
+        # Subset of _due_at owned by this worker; inner dicts aliased so
         # in-place advances stay visible. Mutated only via _attach_owned
         # / _detach_owned / _clear_owned, driven by _OwnershipIndex.
-        self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
+        self._owned_due_at: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
         self, loop: asyncio.AbstractEventLoop, initial_offset: float = 0.0
@@ -281,16 +281,16 @@ class _ScannerWorker:
     def _attach_owned(
         self, address: str, entries: dict[ActiveScanRequest, float]
     ) -> None:
-        """Attach an owned ``_needs`` bucket; called only by _OwnershipIndex."""
-        self._owned_needs[address] = entries
+        """Attach an owned ``_due_at`` bucket; called only by _OwnershipIndex."""
+        self._owned_due_at[address] = entries
 
     def _detach_owned(self, address: str) -> None:
         """Detach an owned bucket; called only by _OwnershipIndex."""
-        self._owned_needs.pop(address, None)
+        self._owned_due_at.pop(address, None)
 
     def _clear_owned(self) -> None:
         """Drop all owned buckets; called only by _OwnershipIndex."""
-        self._owned_needs.clear()
+        self._owned_due_at.clear()
 
     def note_window_dispatched(self, window_end: float, now: float) -> None:
         """
@@ -309,7 +309,7 @@ class _ScannerWorker:
           our bump. The optimization is then skipped: this worker
           ticks normally during the delegated window. Correctness is
           preserved (scanner-level ``_active_window_handle`` extends
-          the radio window idempotently; ``_needs`` is advanced
+          the radio window idempotently; ``_due_at`` is advanced
           per-address by each worker on its own tick), only the
           intended "skip your own ticks during my window" hint is
           lost. ``_sweep_last_completed`` lives outside the
@@ -338,7 +338,7 @@ class _ScannerWorker:
         if self._window_end > now:
             return self._window_end
         next_at = self._sweep_last_completed + _AUTO_REDISCOVERY_INTERVAL
-        for entries in self._owned_needs.values():
+        for entries in self._owned_due_at.values():
             if not entries:
                 continue
             earliest = min(entries.values())
@@ -385,8 +385,8 @@ class _ScannerWorker:
         ] = []
         all_due: list[ActiveScanRequest] = []
         any_immediate = False
-        for address in list(self._owned_needs):
-            entries = self._owned_needs.get(address)
+        for address in list(self._owned_due_at):
+            entries = self._owned_due_at.get(address)
             if not entries:
                 continue
             history = last_service_info(address, False)
@@ -433,7 +433,7 @@ class _ScannerWorker:
         window duration is the max of every due per-device duration
         and (if sweep is due) the sweep duration. ``scan_interval``
         runs from window start (now), not window end. Failure of the
-        scanner call still advances ``_needs`` so a stuck scanner
+        scanner call still advances ``_due_at`` so a stuck scanner
         can't busy-loop the worker.
 
         If the owner is mid-connect at tick time, dispatch is routed
@@ -617,32 +617,28 @@ class _ScannerWorker:
 
 
 class _OwnershipIndex:
-    """Per-address scanner ownership and per-worker owned-needs view."""
+    """Per-address scanner ownership and per-worker owned-due-at view."""
 
-    __slots__ = ("_needs", "_owner_by_address", "_workers")
+    __slots__ = ("_due_at", "_owner_by_address", "_workers")
 
     def __init__(
         self,
-        needs: dict[str, dict[ActiveScanRequest, float]],
+        due_at: dict[str, dict[ActiveScanRequest, float]],
         workers: dict[str, _ScannerWorker],
     ) -> None:
-        """Bind to the scheduler's ``_needs`` and ``_workers`` dicts."""
-        self._needs = needs
+        """Bind to the scheduler's ``_due_at`` and ``_workers`` dicts."""
+        self._due_at = due_at
         self._workers = workers
         self._owner_by_address: dict[str, str] = {}
 
-    def _attach(self, worker: Any, address: str) -> None:
-        """Attach the ``_needs`` bucket for ``address`` to ``worker``, if both exist."""
-        if worker is None:
-            return
-        entries = self._needs.get(address)
+    def _attach(self, worker: _ScannerWorker, address: str) -> None:
+        """Attach the ``_due_at`` bucket for ``address`` to ``worker``, if any."""
+        entries = self._due_at.get(address)
         if entries is not None:
             worker._attach_owned(address, entries)
 
-    def _detach(self, address: str, source: str | None) -> None:
-        """Detach ``address`` from the worker for ``source``, if both exist."""
-        if source is None:
-            return
+    def _detach(self, address: str, source: str) -> None:
+        """Detach ``address`` from the worker for ``source``, if it exists."""
         worker = self._workers.get(source)
         if worker is not None:
             worker._detach_owned(address)
@@ -652,23 +648,27 @@ class _OwnershipIndex:
         new_worker = self._workers.get(new_source)
         old_source = self._owner_by_address.get(address)
         if old_source != new_source:
-            self._detach(address, old_source)
+            if old_source is not None:
+                self._detach(address, old_source)
             self._owner_by_address[address] = new_source
-            self._attach(new_worker, address)
+            if new_worker is not None:
+                self._attach(new_worker, address)
         if new_worker is not None:
             new_worker.wake()
 
     def unown(self, address: str) -> None:
-        """Forget ``address`` entirely; drops needs, owner, and worker view."""
-        self._needs.pop(address, None)
-        self._detach(address, self._owner_by_address.pop(address, None))
+        """Forget ``address`` entirely; drops due_at, owner, and worker view."""
+        self._due_at.pop(address, None)
+        old_source = self._owner_by_address.pop(address, None)
+        if old_source is not None:
+            self._detach(address, old_source)
 
     def clear_source(self, source: str) -> None:
-        """Drop owner mappings and ``_needs`` entries owned by ``source``."""
+        """Drop owner mappings and ``_due_at`` entries owned by ``source``."""
         for address in list(self._owner_by_address):
             if self._owner_by_address[address] == source:
                 del self._owner_by_address[address]
-                self._needs.pop(address, None)
+                self._due_at.pop(address, None)
         worker = self._workers.get(source)
         if worker is not None:
             worker._clear_owned()
@@ -683,20 +683,20 @@ class _OwnershipIndex:
                 self._attach(worker, address)
 
     def clear(self) -> None:
-        """Reset the index, every worker's owned view, and ``_needs``."""
+        """Reset the index, every worker's owned view, and ``_due_at``."""
         for worker in self._workers.values():
             worker._clear_owned()
         self._owner_by_address.clear()
-        self._needs.clear()
+        self._due_at.clear()
 
 
 class AutoScanScheduler:
     """Coordinates on-demand active windows across AUTO-mode scanners."""
 
     __slots__ = (
+        "_due_at",
         "_loop",
         "_manager",
-        "_needs",
         "_on_demand_sweep_end",
         "_on_demand_sweep_future",
         "_ownership",
@@ -709,9 +709,9 @@ class AutoScanScheduler:
         """Initialize the scheduler bound to a manager."""
         self._manager = manager
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
-        self._needs: dict[str, dict[ActiveScanRequest, float]] = {}
+        self._due_at: dict[str, dict[ActiveScanRequest, float]] = {}
         self._workers: dict[str, _ScannerWorker] = {}
-        self._ownership = _OwnershipIndex(self._needs, self._workers)
+        self._ownership = _OwnershipIndex(self._due_at, self._workers)
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
@@ -724,7 +724,7 @@ class AutoScanScheduler:
         Idempotent: no-op if already running. A genuine restart is
         ``stop()`` (which flips ``_running`` to False) then
         ``start(new_loop)``. Also replays any pre-start
-        ``_requests_by_address`` into ``_needs`` so embedders that
+        ``_requests_by_address`` into ``_due_at`` so embedders that
         register before ``async_setup`` still get the kick-start
         cadence; same history-gating as ``add_request``.
         """
@@ -754,8 +754,8 @@ class AutoScanScheduler:
         Sync to match ``BluetoothManager.async_stop``;
         ``worker.stop()`` cancels without awaiting. Nulls ``_loop``
         too so post-stop ``add_request`` / ``on_advertisement`` fall
-        back to the record-only path instead of seeding ``_needs``
-        with timestamps from the cancelled loop. Clears ``_needs``
+        back to the record-only path instead of seeding ``_due_at``
+        with timestamps from the cancelled loop. Clears ``_due_at``
         so a later ``start(new_loop)`` re-seeds from
         ``_requests_by_address`` against the new loop's clock base;
         leaving stale due-times would let them fire instantly (or
@@ -801,7 +801,7 @@ class AutoScanScheduler:
         """
         Stop the worker for a scanner leaving the manager.
 
-        Also prunes ``_needs`` entries the scanner currently owns so
+        Also prunes ``_due_at`` entries the scanner currently owns so
         a removed-and-not-rediscovered device doesn't keep a tracked
         entry pinned until the next history flip / age-out.
         """
@@ -850,7 +850,7 @@ class AutoScanScheduler:
             # it anyway); on_advertisement will bootstrap on first
             # sight.
             return
-        existing = self._needs.setdefault(request.address, {})
+        existing = self._due_at.setdefault(request.address, {})
         if request in existing:
             return
         existing[request] = self._loop.time() + request.scan_interval
@@ -862,7 +862,7 @@ class AutoScanScheduler:
             bucket.discard(request)
             if not bucket:
                 del self._requests_by_address[request.address]
-        if (entries := self._needs.get(request.address)) is not None:
+        if (entries := self._due_at.get(request.address)) is not None:
             entries.pop(request, None)
             if not entries:
                 self._ownership.unown(request.address)
@@ -898,7 +898,7 @@ class AutoScanScheduler:
         Shared by ``on_advertisement`` and the ``start()`` replay
         loop. Leaves existing entries' due times untouched.
         """
-        existing = self._needs.setdefault(address, {})
+        existing = self._due_at.setdefault(address, {})
         for request in requests:
             if request not in existing:
                 existing[request] = now + request.scan_interval
@@ -1187,7 +1187,7 @@ class AutoScanScheduler:
         last_service_info = self._manager.async_last_service_info
         requests: dict[str, list[dict[str, Any]]] = {}
         for address, bucket in self._requests_by_address.items():
-            entries = self._needs.get(address, {})
+            entries = self._due_at.get(address, {})
             history = last_service_info(address, False)
             owner_source = history.source if history is not None else None
             requests[address] = [

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -221,6 +221,7 @@ class _ScannerWorker:
     __slots__ = (
         "_failed_window",
         "_manager",
+        "_owned_needs",
         "_scanner",
         "_scheduler",
         "_sweep_last_completed",
@@ -245,6 +246,12 @@ class _ScannerWorker:
         self._sweep_last_completed: float = 0.0
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
+        # Per-worker view of self._scheduler._needs filtered to addresses
+        # this scanner currently owns. Inner dicts are aliases of the
+        # same dict in _needs, so in-place mutations by _advance_due /
+        # _dispatch_to_fallback are visible without bookkeeping. The
+        # scheduler's _assign_owner is the single mutation point.
+        self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
         self, loop: asyncio.AbstractEventLoop, initial_offset: float = 0.0
@@ -313,21 +320,16 @@ class _ScannerWorker:
         """
         Return the earliest loop-time at which this worker has work.
 
-        O(M) over tracked addresses per wake. Fine at HA scale (a few
-        dozen devices); replace with a per-worker invariant maintained
-        at add_request/on_advertisement/_advance_due time if M grows.
+        O(M) over *owned* addresses (entries this scanner currently
+        owns), not the global _needs map. Ownership transitions are
+        maintained eagerly by AutoScanScheduler._assign_owner; this
+        path makes no async_last_service_info calls.
         """
         if self._window_end > now:
             return self._window_end
         next_at = self._sweep_last_completed + _AUTO_REDISCOVERY_INTERVAL
-        source = self._scanner.source
-        needs = self._scheduler._needs
-        last_service_info = self._manager.async_last_service_info
-        for address, entries in needs.items():
+        for entries in self._owned_needs.values():
             if not entries:
-                continue
-            history = last_service_info(address, False)
-            if history is None or history.source != source:
                 continue
             earliest = min(entries.values())
             if earliest < next_at:
@@ -361,20 +363,26 @@ class _ScannerWorker:
         """
         Return (due_buckets, all_due, any_immediate) for addresses owned.
 
-        Collects entries due within ``_AUTO_COALESCE_LOOKAHEAD`` of
-        ``now`` regardless of ``any_immediate``, so soon-due entries
-        ride a window the caller decides to open (a per-device hit
-        or the 12 h sweep). Caller must gate on
-        ``any_immediate or sweep_due`` — a scanner with only
-        soon-due entries must not tick early on its own. Prunes
-        orphan entries (history None) in passing.
+        Iterates the per-worker owned-needs view (maintained eagerly
+        by AutoScanScheduler._assign_owner) instead of the global
+        _needs map. Collects entries due within
+        ``_AUTO_COALESCE_LOOKAHEAD`` of ``now`` regardless of
+        ``any_immediate``, so soon-due entries ride a window the
+        caller decides to open (a per-device hit or the 12 h sweep).
+        Caller must gate on ``any_immediate or sweep_due`` — a
+        scanner with only soon-due entries must not tick early on its
+        own. Prunes orphan entries (history None) and resyncs entries
+        whose manager-side owner has flipped without an
+        on_advertisement notification (defense-in-depth).
 
         Invariant: ``_AUTO_COALESCE_LOOKAHEAD > max window duration``
         so a window cannot outlive its lookahead and leave a device
         overdue when it ends.
         """
         source = self._scanner.source
-        needs = self._scheduler._needs
+        scheduler = self._scheduler
+        needs = scheduler._needs
+        owned = self._owned_needs
         last_service_info = self._manager.async_last_service_info
         threshold = now + _AUTO_COALESCE_LOOKAHEAD
         due_buckets: list[
@@ -382,15 +390,24 @@ class _ScannerWorker:
         ] = []
         all_due: list[ActiveScanRequest] = []
         any_immediate = False
-        for address in list(needs):
-            entries = needs.get(address)
+        for address in list(owned):
+            entries = owned.get(address)
             if not entries:
                 continue
             history = last_service_info(address, False)
             if history is None:
-                del needs[address]
+                # Orphan: history aged out. Drop from owner index and
+                # the global needs map.
+                scheduler._assign_owner(address, None)
+                needs.pop(address, None)
                 continue
             if history.source != source:
+                # Owned view is out of sync with manager history
+                # (should be unreachable since on_advertisement keeps
+                # them aligned, but the manager has other histories
+                # mutation paths). Re-sync and skip this tick — the
+                # rightful owner will pick it up.
+                scheduler._assign_owner(address, history.source)
                 continue
             due: list[ActiveScanRequest] = []
             for r, t in entries.items():
@@ -621,6 +638,7 @@ class AutoScanScheduler:
         "_needs",
         "_on_demand_sweep_end",
         "_on_demand_sweep_future",
+        "_owner_by_address",
         "_requests_by_address",
         "_running",
         "_workers",
@@ -631,6 +649,10 @@ class AutoScanScheduler:
         self._manager = manager
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
         self._needs: dict[str, dict[ActiveScanRequest, float]] = {}
+        # Address -> source string identifying the worker that
+        # currently owns the address. Single source of truth for the
+        # per-worker _owned_needs view; updated only by _assign_owner.
+        self._owner_by_address: dict[str, str] = {}
         self._workers: dict[str, _ScannerWorker] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
@@ -661,9 +683,11 @@ class AutoScanScheduler:
         now = loop.time()
         last_service_info = self._manager.async_last_service_info
         for address, requests in self._requests_by_address.items():
-            if last_service_info(address, False) is None:
+            history = last_service_info(address, False)
+            if history is None:
                 continue
             self._seed_requests(address, requests, now)
+            self._assign_owner(address, history.source)
 
     def stop(self) -> None:
         """
@@ -689,8 +713,10 @@ class AutoScanScheduler:
         self._running = False
         for worker in self._workers.values():
             worker.stop()
+            worker._owned_needs.clear()
         self._workers.clear()
         self._needs.clear()
+        self._owner_by_address.clear()
         # done() guard mirrors the leader's finally for symmetry;
         # a future left non-None after completion would otherwise
         # raise InvalidStateError here.
@@ -727,11 +753,11 @@ class AutoScanScheduler:
         worker = self._workers.pop(source, None)
         if worker is not None:
             worker.stop()
-        last_service_info = self._manager.async_last_service_info
-        for address in list(self._needs):
-            history = last_service_info(address, False)
-            if history is not None and history.source == source:
-                del self._needs[address]
+            worker._owned_needs.clear()
+        for address in list(self._owner_by_address):
+            if self._owner_by_address[address] == source:
+                del self._owner_by_address[address]
+                self._needs.pop(address, None)
 
     def _spawn_worker(self, scanner: BaseHaScanner) -> None:
         assert self._loop is not None  # noqa: S101
@@ -747,6 +773,19 @@ class AutoScanScheduler:
         ) % _AUTO_INITIAL_SWEEP_DELAY
         worker.start(self._loop, offset)
         self._workers[scanner.source] = worker
+        # Hook up entries already owned by this source (e.g., an
+        # on_advertisement that arrived before the scanner registered,
+        # or the start() replay loop seeding requests before workers
+        # were created in some other ordering).
+        source = scanner.source
+        owned_needs = worker._owned_needs
+        needs = self._needs
+        for address, owner in self._owner_by_address.items():
+            if owner != source:
+                continue
+            entries = needs.get(address)
+            if entries is not None:
+                owned_needs[address] = entries
 
     def add_request(self, request: ActiveScanRequest) -> None:
         """
@@ -773,6 +812,7 @@ class AutoScanScheduler:
         if request in existing:
             return
         existing[request] = self._loop.time() + request.scan_interval
+        self._assign_owner(request.address, history.source)
         self._wake_worker(history.source)
 
     def remove_request(self, request: ActiveScanRequest) -> None:
@@ -785,6 +825,7 @@ class AutoScanScheduler:
             entries.pop(request, None)
             if not entries:
                 del self._needs[request.address]
+                self._assign_owner(request.address, None)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
         """
@@ -803,6 +844,7 @@ class AutoScanScheduler:
         if requests is None:
             return
         self._seed_requests(address, requests, self._loop.time())
+        self._assign_owner(address, service_info.source)
         self._wake_worker(service_info.source)
 
     def _seed_requests(
@@ -826,6 +868,39 @@ class AutoScanScheduler:
         """Wake the worker for ``source`` if one is registered."""
         if (worker := self._workers.get(source)) is not None:
             worker.wake()
+
+    def _assign_owner(self, address: str, new_source: str | None) -> None:
+        """
+        Move address ownership to ``new_source`` (or clear if None).
+
+        Single mutation point for ``_owner_by_address`` and the
+        per-worker ``_owned_needs`` view. The inner dict aliased into
+        ``_owned_needs`` is the same object as ``_needs[address]``,
+        so in-place mutations of due-times remain visible.
+
+        Tolerates a missing worker for ``new_source`` (e.g., a worker
+        not yet spawned at start-time); ``_owner_by_address`` is set
+        unconditionally so ``_spawn_worker`` can hook the entry on
+        registration. Tolerates a missing ``_needs`` entry (e.g.,
+        ownership cleared via remove_request before reassignment).
+        """
+        old_source = self._owner_by_address.get(address)
+        if old_source == new_source:
+            return
+        if old_source is not None:
+            old_worker = self._workers.get(old_source)
+            if old_worker is not None:
+                old_worker._owned_needs.pop(address, None)
+        if new_source is None:
+            self._owner_by_address.pop(address, None)
+            return
+        self._owner_by_address[address] = new_source
+        entries = self._needs.get(address)
+        if entries is None:
+            return
+        new_worker = self._workers.get(new_source)
+        if new_worker is not None:
+            new_worker._owned_needs[address] = entries
 
     def _resolve_fallback_for_address(
         self, address: str, exclude_source: str

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -680,13 +680,21 @@ class _ScanSchedule:
 
     def clear_source(self, source: str) -> None:
         """Drop owner mappings and ``_due_at`` entries owned by ``source``."""
+        worker = self._workers.get(source)
+        if worker is not None:
+            # AUTO source: iterate the worker's own view, O(owned-by-source).
+            for address in list(worker._owned_due_at):
+                del self._owner_by_address[address]
+                del self._due_at[address]
+            worker._clear_owned()
+            return
+        # Non-AUTO source (no worker): a PASSIVE / ACTIVE scanner can
+        # still own an address via ``on_advertisement``, so scan
+        # ``_owner_by_address`` to find what it owns.
         for address in list(self._owner_by_address):
             if self._owner_by_address[address] == source:
                 del self._owner_by_address[address]
-                self._due_at.pop(address, None)
-        worker = self._workers.get(source)
-        if worker is not None:
-            worker._clear_owned()
+                del self._due_at[address]
 
     def attach_worker(self, source: str) -> None:
         """Attach pre-assigned entries to a newly-registered worker."""

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -80,8 +80,9 @@ up the new owner without any address-level rescheduling:
    and then calls ``auto_scheduler.on_advertisement(service_info)``
    *before* the same-payload short-circuit, so the flip is visible to
    the scheduler even for static-payload beacons.
-2. ``on_advertisement`` always calls ``_wake_worker(adv.source)`` when
-   the address has registered requests. B's worker wakes up.
+2. ``on_advertisement`` always calls ``_ownership.assign(adv.address,
+   adv.source)`` when the address has registered requests, which wakes
+   B's worker as part of the assignment.
 3. On B's next ``_tick``, ``_collect_due_buckets`` reads
    ``last_service_info(addr).source`` and sees B; the entry is
    collected and dispatched. A's worker on its own next tick sees
@@ -391,11 +392,9 @@ class _ScannerWorker:
             history = last_service_info(address, False)
             if history is None:
                 self._scheduler._ownership.unown(address)
-                self._scheduler._needs.pop(address, None)
                 continue
             if history.source != source:
                 self._scheduler._ownership.assign(address, history.source)
-                self._scheduler._wake_worker(history.source)
                 continue
             due: list[ActiveScanRequest] = []
             for r, t in entries.items():
@@ -633,24 +632,25 @@ class _OwnershipIndex:
         self._owner_by_address: dict[str, str] = {}
 
     def assign(self, address: str, new_source: str) -> None:
-        """Move ownership of ``address`` to ``new_source``."""
-        old_source = self._owner_by_address.get(address)
-        if old_source == new_source:
-            return
-        if old_source is not None:
-            old_worker = self._workers.get(old_source)
-            if old_worker is not None:
-                old_worker._detach_owned(address)
-        self._owner_by_address[address] = new_source
-        entries = self._needs.get(address)
-        if entries is None:
-            return
+        """Move ownership of ``address`` to ``new_source`` and wake its worker."""
         new_worker = self._workers.get(new_source)
+        old_source = self._owner_by_address.get(address)
+        if old_source != new_source:
+            if old_source is not None:
+                old_worker = self._workers.get(old_source)
+                if old_worker is not None:
+                    old_worker._detach_owned(address)
+            self._owner_by_address[address] = new_source
+            if new_worker is not None:
+                entries = self._needs.get(address)
+                if entries is not None:
+                    new_worker._attach_owned(address, entries)
         if new_worker is not None:
-            new_worker._attach_owned(address, entries)
+            new_worker.wake()
 
     def unown(self, address: str) -> None:
-        """Drop the owner mapping for ``address``."""
+        """Forget ``address`` entirely; drops needs, owner, and worker view."""
+        self._needs.pop(address, None)
         old_source = self._owner_by_address.pop(address, None)
         if old_source is None:
             return
@@ -852,7 +852,6 @@ class AutoScanScheduler:
             return
         existing[request] = self._loop.time() + request.scan_interval
         self._ownership.assign(request.address, history.source)
-        self._wake_worker(history.source)
 
     def remove_request(self, request: ActiveScanRequest) -> None:
         """Drop the request from the index and from any pending tracking."""
@@ -863,7 +862,6 @@ class AutoScanScheduler:
         if (entries := self._needs.get(request.address)) is not None:
             entries.pop(request, None)
             if not entries:
-                del self._needs[request.address]
                 self._ownership.unown(request.address)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
@@ -884,7 +882,6 @@ class AutoScanScheduler:
             return
         self._seed_requests(address, requests, self._loop.time())
         self._ownership.assign(address, service_info.source)
-        self._wake_worker(service_info.source)
 
     def _seed_requests(
         self,
@@ -902,11 +899,6 @@ class AutoScanScheduler:
         for request in requests:
             if request not in existing:
                 existing[request] = now + request.scan_interval
-
-    def _wake_worker(self, source: str) -> None:
-        """Wake the worker for ``source`` if one is registered."""
-        if (worker := self._workers.get(source)) is not None:
-            worker.wake()
 
     def _resolve_fallback_for_address(
         self, address: str, exclude_source: str

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -393,8 +393,7 @@ class _ScannerWorker:
         ] = []
         all_due: list[ActiveScanRequest] = []
         any_immediate = False
-        for address in list(self._owned_due_at):
-            entries = self._owned_due_at[address]
+        for address, entries in self._owned_due_at.copy().items():
             history = last_service_info(address, False)
             if history is None:
                 self._scheduler._schedule.unown(address)

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -355,15 +355,11 @@ class _ScannerWorker:
         bool,
     ]:
         """
-        Return (due_buckets, all_due, any_immediate) for addresses owned.
+        Return (due_buckets, all_due, any_immediate) for owned addresses.
 
-        Iterates the owned view. Collects entries due within
-        ``_AUTO_COALESCE_LOOKAHEAD`` so soon-due entries ride a window
-        the caller opens; caller must gate on
-        ``any_immediate or sweep_due``. Prunes orphans (history None)
-        and resyncs on owner drift.
-
-        Invariant: ``_AUTO_COALESCE_LOOKAHEAD > max window duration``.
+        Collects entries due within ``_AUTO_COALESCE_LOOKAHEAD``; caller
+        gates on ``any_immediate or sweep_due``. Prunes orphans and
+        resyncs on owner drift.
         """
         source = self._scanner.source
         scheduler = self._scheduler
@@ -383,18 +379,14 @@ class _ScannerWorker:
                 continue
             history = last_service_info(address, False)
             if history is None:
-                # Orphan: history aged out. Drop from this worker's
-                # view explicitly: assign(None) may early-return if
-                # _owner_by_address disagrees, leaving a stale entry.
+                # Orphan: history aged out. Drop from owned explicitly;
+                # assign(None) may early-return on owner mismatch.
                 ownership.assign(address, None)
                 owned.pop(address, None)
                 needs.pop(address, None)
                 continue
             if history.source != source:
-                # Owner drifted; reassign and wake the new owner so it
-                # can re-evaluate its next event time promptly. Drop
-                # from this worker's view explicitly for the same
-                # early-return reason as the orphan branch.
+                # Owner drifted; reassign, drop locally, wake new owner.
                 ownership.assign(address, history.source)
                 owned.pop(address, None)
                 scheduler._wake_worker(history.source)
@@ -620,17 +612,7 @@ class _ScannerWorker:
 
 
 class _OwnershipIndex:
-    """
-    Per-address scanner ownership and per-worker owned-needs view.
-
-    Single source of truth for which scanner owns each address and
-    for the aliased subset of ``_needs`` each owner's worker sees on
-    its hot path. Owner mappings track the manager's history-reported
-    source for each address; the aliased per-worker entry only exists
-    when ``_needs[address]`` is non-empty (assign() records the owner
-    either way, but skips attaching an entry when ``_needs`` is empty
-    so the worker view stays consistent with what ``_needs`` holds).
-    """
+    """Per-address scanner ownership and per-worker owned-needs view."""
 
     __slots__ = ("_needs", "_owner_by_address", "_workers")
 
@@ -644,10 +626,9 @@ class _OwnershipIndex:
         self._workers = workers
         self._owner_by_address: dict[str, str] = {}
 
-    # `Optional[str]` (not `str | None`) for the .pxd `cpdef` cross-check:
-    # under `from __future__ import annotations` Cython 3 treats the PEP 604
-    # form as a non-nullable `str`, which conflicts with the `object` param
-    # in the matching .pxd signature.
+    # ``Optional[str]`` (not ``str | None``): PEP 604 under future
+    # annotations parses as non-nullable ``str`` and clashes with the
+    # ``object`` param in the .pxd ``cpdef`` signature.
     def assign(
         self,
         address: str,

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -772,20 +772,15 @@ class AutoScanScheduler:
             len(self._workers) * _AUTO_REDISCOVERY_SWEEP_DURATION
         ) % _AUTO_INITIAL_SWEEP_DELAY
         worker.start(self._loop, offset)
-        self._workers[scanner.source] = worker
+        source = scanner.source
+        self._workers[source] = worker
         # Hook up entries already owned by this source (e.g., an
         # on_advertisement that arrived before the scanner registered,
         # or the start() replay loop seeding requests before workers
         # were created in some other ordering).
-        source = scanner.source
-        owned_needs = worker._owned_needs
-        needs = self._needs
         for address, owner in self._owner_by_address.items():
-            if owner != source:
-                continue
-            entries = needs.get(address)
-            if entries is not None:
-                owned_needs[address] = entries
+            if owner == source:
+                self._attach_to_worker(source, address)
 
     def add_request(self, request: ActiveScanRequest) -> None:
         """
@@ -873,34 +868,52 @@ class AutoScanScheduler:
         """
         Move address ownership to ``new_source`` (or clear if None).
 
-        Single mutation point for ``_owner_by_address`` and the
-        per-worker ``_owned_needs`` view. The inner dict aliased into
-        ``_owned_needs`` is the same object as ``_needs[address]``,
-        so in-place mutations of due-times remain visible.
-
-        Tolerates a missing worker for ``new_source`` (e.g., a worker
-        not yet spawned at start-time); ``_owner_by_address`` is set
-        unconditionally so ``_spawn_worker`` can hook the entry on
-        registration. Tolerates a missing ``_needs`` entry (e.g.,
-        ownership cleared via remove_request before reassignment).
+        Thin coordinator: tracks the transition in
+        ``_owner_by_address`` and delegates the per-worker view
+        touches to ``_detach_from_worker`` / ``_attach_to_worker``.
         """
         old_source = self._owner_by_address.get(address)
         if old_source == new_source:
             return
         if old_source is not None:
-            old_worker = self._workers.get(old_source)
-            if old_worker is not None:
-                old_worker._owned_needs.pop(address, None)
+            self._detach_from_worker(old_source, address)
         if new_source is None:
             self._owner_by_address.pop(address, None)
             return
         self._owner_by_address[address] = new_source
+        self._attach_to_worker(new_source, address)
+
+    def _detach_from_worker(self, source: str, address: str) -> None:
+        """
+        Drop ``address`` from ``source``'s per-worker owned view.
+
+        Tolerates a missing worker (e.g., the scanner was removed
+        and its worker popped from ``_workers`` before the address
+        ownership got reassigned).
+        """
+        worker = self._workers.get(source)
+        if worker is not None:
+            worker._owned_needs.pop(address, None)
+
+    def _attach_to_worker(self, source: str, address: str) -> None:
+        """
+        Hook ``address`` into ``source``'s per-worker owned view.
+
+        The aliased inner dict is the same object as
+        ``_needs[address]``, so in-place mutations of due-times by
+        ``_advance_due`` / ``_dispatch_to_fallback`` stay visible
+        through both views. Tolerates a missing ``_needs`` entry
+        (e.g., owner pre-assigned via ``on_advertisement`` before
+        any request was registered) and a missing worker
+        (e.g., ``new_source`` not yet spawned at ``start()`` time —
+        ``_spawn_worker`` will hook the entry on registration).
+        """
         entries = self._needs.get(address)
         if entries is None:
             return
-        new_worker = self._workers.get(new_source)
-        if new_worker is not None:
-            new_worker._owned_needs[address] = entries
+        worker = self._workers.get(source)
+        if worker is not None:
+            worker._owned_needs[address] = entries
 
     def _resolve_fallback_for_address(
         self, address: str, exclude_source: str

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -23,50 +23,57 @@ would otherwise stay idle.
 Flow
 ====
 
-                     add_request(req)            on_advertisement(adv)
-                        |                            |
-                        | seed _due_at[addr][req]     | seed if pruned;
-                        | = now + scan_interval      | always wake
-                        | wake address's owner       | adv.source's worker
-                        v                            v
-                  +------------------------------------------+
-                  |  AutoScanScheduler                       |
-                  |    _requests_by_address                  |
-                  |       addr -> set of ActiveScanRequest   |
-                  |    _due_at                                |
-                  |       addr -> {request: next_due_time}   |
-                  |    _workers                              |
-                  |       source -> _ScannerWorker           |
-                  +------------------------------------------+
-                                    |
-                                    | one task per AUTO scanner
-                                    v
-                  +------------------------------------------+
-                  |  _ScannerWorker._run loop                |
-                  |                                          |
-                  |    sleep on _wake with timeout =         |
-                  |      _next_event_at(now) - now           |
-                  |    await _tick()                         |
-                  |                                          |
-                  |  _tick (sync collect, one await):        |
-                  |    1. _collect_due_buckets               |
-                  |       skip addresses whose owner         |
-                  |       (last_service_info.source) is      |
-                  |       not this scanner                   |
-                  |    2. sweep_due = sweep cadence elapsed  |
-                  |    3. if owner has connect in progress:  |
-                  |          dispatch per-address to a       |
-                  |          fallback scanner; return        |
-                  |    4. duration = max(due durations,      |
-                  |       SWEEP_DURATION if sweep_due)       |
-                  |    5. _advance_due (pre-await) so the    |
-                  |       new owner of any of these          |
-                  |       addresses can't double-fire;       |
-                  |       _sweep_last_completed = now (any   |
-                  |       active scan satisfies the floor)   |
-                  |    6. ONE await:                         |
-                  |       scanner.async_request_active_window|
-                  +------------------------------------------+
+                  add_request(req)           on_advertisement(adv)
+                       |                            |
+                       | _ownership.seed(...)       | _ownership.seed(...) per req;
+                       | _ownership.assign(addr,    | _ownership.assign(addr,
+                       |   history.source)          |   adv.source) wakes owner
+                       v                            v
+              +----------------------------------------------+
+              |  AutoScanScheduler                           |
+              |    _requests_by_address                      |
+              |       addr -> set of ActiveScanRequest       |
+              |    _workers                                  |
+              |       source -> _ScannerWorker               |
+              |    _ownership: _OwnershipIndex               |
+              |       _due_at                                |
+              |          addr -> {request: next_due_time}    |
+              |       _owner_by_address                      |
+              |          addr -> source                      |
+              +----------------------------------------------+
+                                |
+                                | aliased per-worker view:
+                                | worker._owned_due_at[addr]
+                                |   is _due_at[addr] for entries
+                                |   this worker owns
+                                v
+              +----------------------------------------------+
+              |  _ScannerWorker._run loop                    |
+              |                                              |
+              |    sleep on _wake with timeout =             |
+              |      _next_event_at(now) - now               |
+              |    await _tick()                             |
+              |                                              |
+              |  _tick (sync collect, one await):            |
+              |    1. _collect_due_buckets iterates          |
+              |       _owned_due_at (owned subset only);     |
+              |       per-address history call is just for   |
+              |       orphan/drift resync, not the owner     |
+              |       check (ownership is the view itself)   |
+              |    2. sweep_due = sweep cadence elapsed      |
+              |    3. if owner has connect in progress:      |
+              |          dispatch per-address to a           |
+              |          fallback scanner; return            |
+              |    4. duration = max(due durations,          |
+              |       SWEEP_DURATION if sweep_due)           |
+              |    5. _advance_due (pre-await) so the        |
+              |       new owner of any of these              |
+              |       addresses can't double-fire;           |
+              |       _sweep_last_completed = now (any       |
+              |       active scan satisfies the floor)       |
+              |    6. ONE await:                             |
+              |       scanner.async_request_active_window    |
+              +----------------------------------------------+
 
 
 Migration
@@ -80,15 +87,18 @@ up the new owner without any address-level rescheduling:
    and then calls ``auto_scheduler.on_advertisement(service_info)``
    *before* the same-payload short-circuit, so the flip is visible to
    the scheduler even for static-payload beacons.
-2. ``on_advertisement`` always calls ``_ownership.assign(adv.address,
-   adv.source)`` when the address has registered requests, which wakes
-   B's worker as part of the assignment.
-3. On B's next ``_tick``, ``_collect_due_buckets`` reads
-   ``last_service_info(addr).source`` and sees B; the entry is
-   collected and dispatched. A's worker on its own next tick sees
-   ``last_service_info(addr).source != A`` and skips.
-4. The pre-await ``_advance_due`` in step 5 of ``_tick`` prevents A
-   from double-firing if the flip lands mid-window.
+2. ``on_advertisement`` calls ``_ownership.assign(adv.address,
+   adv.source)``. The index detaches the entry from A's
+   ``_owned_due_at``, attaches it to B's ``_owned_due_at`` (same dict
+   object, just a different worker holds the alias), and wakes B's
+   worker. A's worker no longer sees the address at all; B's does.
+3. On B's next ``_tick``, ``_collect_due_buckets`` iterates its
+   ``_owned_due_at``, finds the entry, and dispatches it.
+4. If the flip lands mid-window on A, the pre-await ``_advance_due``
+   in step 5 of ``_tick`` already advanced the entry's due time, so
+   B can't double-fire. The rare orphan/drift branches in
+   ``_collect_due_buckets`` handle the edge case where the manager's
+   history disagrees with the cached owner view.
 
 
 Connecting fallback

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -377,10 +377,6 @@ class _ScannerWorker:
         resyncs on owner drift.
         """
         source = self._scanner.source
-        scheduler = self._scheduler
-        ownership = scheduler._ownership
-        needs = scheduler._needs
-        owned = self._owned_needs
         last_service_info = self._manager.async_last_service_info
         threshold = now + _AUTO_COALESCE_LOOKAHEAD
         due_buckets: list[
@@ -388,18 +384,18 @@ class _ScannerWorker:
         ] = []
         all_due: list[ActiveScanRequest] = []
         any_immediate = False
-        for address in list(owned):
-            entries = owned.get(address)
+        for address in list(self._owned_needs):
+            entries = self._owned_needs.get(address)
             if not entries:
                 continue
             history = last_service_info(address, False)
             if history is None:
-                ownership.unown(address)
-                needs.pop(address, None)
+                self._scheduler._ownership.unown(address)
+                self._scheduler._needs.pop(address, None)
                 continue
             if history.source != source:
-                ownership.assign(address, history.source)
-                scheduler._wake_worker(history.source)
+                self._scheduler._ownership.assign(address, history.source)
+                self._scheduler._wake_worker(history.source)
                 continue
             due: list[ActiveScanRequest] = []
             for r, t in entries.items():
@@ -664,12 +660,10 @@ class _OwnershipIndex:
 
     def clear_source(self, source: str) -> None:
         """Drop owner mappings and ``_needs`` entries owned by ``source``."""
-        owner_by_address = self._owner_by_address
-        needs = self._needs
-        for address in list(owner_by_address):
-            if owner_by_address[address] == source:
-                del owner_by_address[address]
-                needs.pop(address, None)
+        for address in list(self._owner_by_address):
+            if self._owner_by_address[address] == source:
+                del self._owner_by_address[address]
+                self._needs.pop(address, None)
         worker = self._workers.get(source)
         if worker is not None:
             worker._clear_owned()
@@ -679,10 +673,9 @@ class _OwnershipIndex:
         worker = self._workers.get(source)
         if worker is None:
             return
-        needs = self._needs
         for address, owner in self._owner_by_address.items():
             if owner == source:
-                entries = needs.get(address)
+                entries = self._needs.get(address)
                 if entries is not None:
                     worker._attach_owned(address, entries)
 

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -142,7 +142,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from bleak_retry_connector import NO_RSSI_VALUE
 
@@ -383,14 +383,20 @@ class _ScannerWorker:
                 continue
             history = last_service_info(address, False)
             if history is None:
-                # Orphan: history aged out.
+                # Orphan: history aged out. Drop from this worker's
+                # view explicitly: assign(None) may early-return if
+                # _owner_by_address disagrees, leaving a stale entry.
                 ownership.assign(address, None)
+                owned.pop(address, None)
                 needs.pop(address, None)
                 continue
             if history.source != source:
                 # Owner drifted; reassign and wake the new owner so it
-                # can re-evaluate its next event time promptly.
+                # can re-evaluate its next event time promptly. Drop
+                # from this worker's view explicitly for the same
+                # early-return reason as the orphan branch.
                 ownership.assign(address, history.source)
+                owned.pop(address, None)
                 scheduler._wake_worker(history.source)
                 continue
             due: list[ActiveScanRequest] = []
@@ -619,8 +625,11 @@ class _OwnershipIndex:
 
     Single source of truth for which scanner owns each address and
     for the aliased subset of ``_needs`` each owner's worker sees on
-    its hot path. Invariant: an address has an owner iff
-    ``_needs[address]`` is non-empty.
+    its hot path. Owner mappings track the manager's history-reported
+    source for each address; the aliased per-worker entry only exists
+    when ``_needs[address]`` is non-empty (assign() records the owner
+    either way, but skips attaching an entry when ``_needs`` is empty
+    so the worker view stays consistent with what ``_needs`` holds).
     """
 
     __slots__ = ("_needs", "_owner_by_address", "_workers")
@@ -635,7 +644,15 @@ class _OwnershipIndex:
         self._workers = workers
         self._owner_by_address: dict[str, str] = {}
 
-    def assign(self, address: str, new_source: str | None) -> None:
+    # `Optional[str]` (not `str | None`) for the .pxd `cpdef` cross-check:
+    # under `from __future__ import annotations` Cython 3 treats the PEP 604
+    # form as a non-nullable `str`, which conflicts with the `object` param
+    # in the matching .pxd signature.
+    def assign(
+        self,
+        address: str,
+        new_source: Optional[str],  # noqa: UP045
+    ) -> None:
         """Move ownership of ``address`` to ``new_source`` (None clears)."""
         old_source = self._owner_by_address.get(address)
         if old_source == new_source:

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -319,8 +319,8 @@ class _ScannerWorker:
           our bump. The optimization is then skipped: this worker
           ticks normally during the delegated window. Correctness is
           preserved (scanner-level ``_active_window_handle`` extends
-          the radio window idempotently; ``_due_at`` is advanced
-          per-address by each worker on its own tick), only the
+          the radio window idempotently; each worker advances its
+          ``_owned_due_at`` entries on its own tick), only the
           intended "skip your own ticks during my window" hint is
           lost. ``_sweep_last_completed`` lives outside the
           ``finally`` and survives.
@@ -438,8 +438,8 @@ class _ScannerWorker:
         window duration is the max of every due per-device duration
         and (if sweep is due) the sweep duration. ``scan_interval``
         runs from window start (now), not window end. Failure of the
-        scanner call still advances ``_due_at`` so a stuck scanner
-        can't busy-loop the worker.
+        scanner call still advances the due times (``_advance_due``
+        ran pre-await) so a stuck scanner can't busy-loop the worker.
 
         If the owner is mid-connect at tick time, dispatch is routed
         to alternate scanners via ``_dispatch_to_fallback``.
@@ -696,7 +696,7 @@ class _ScanSchedule:
                 worker._attach_owned(address, self._due_at[address])
 
     def clear(self) -> None:
-        """Reset the index, every worker's owned view, and ``_due_at``."""
+        """Reset all schedule state and every worker's owned view."""
         for worker in self._workers.values():
             worker._clear_owned()
         self._owner_by_address.clear()

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -142,7 +142,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from bleak_retry_connector import NO_RSSI_VALUE
 
@@ -246,8 +246,9 @@ class _ScannerWorker:
         self._sweep_last_completed: float = 0.0
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
-        # Owned subset of _needs; inner dicts aliased so in-place
-        # advances stay visible. Maintained by _OwnershipIndex.
+        # Subset of _needs owned by this worker; inner dicts aliased so
+        # in-place advances stay visible. Mutated only via _attach_owned
+        # / _detach_owned / _clear_owned, driven by _OwnershipIndex.
         self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
 
     def start(
@@ -275,6 +276,20 @@ class _ScannerWorker:
     def wake(self) -> None:
         """Interrupt the worker's sleep so it re-evaluates pending work."""
         self._wake.set()
+
+    def _attach_owned(
+        self, address: str, entries: dict[ActiveScanRequest, float]
+    ) -> None:
+        """Attach an owned ``_needs`` bucket; called only by _OwnershipIndex."""
+        self._owned_needs[address] = entries
+
+    def _detach_owned(self, address: str) -> None:
+        """Detach an owned bucket; called only by _OwnershipIndex."""
+        self._owned_needs.pop(address, None)
+
+    def _clear_owned(self) -> None:
+        """Drop all owned buckets; called only by _OwnershipIndex."""
+        self._owned_needs.clear()
 
     def note_window_dispatched(self, window_end: float, now: float) -> None:
         """
@@ -379,16 +394,11 @@ class _ScannerWorker:
                 continue
             history = last_service_info(address, False)
             if history is None:
-                # Orphan: history aged out. Drop from owned explicitly;
-                # assign(None) may early-return on owner mismatch.
-                ownership.assign(address, None)
-                owned.pop(address, None)
+                ownership.unown(address)
                 needs.pop(address, None)
                 continue
             if history.source != source:
-                # Owner drifted; reassign, drop locally, wake new owner.
                 ownership.assign(address, history.source)
-                owned.pop(address, None)
                 scheduler._wake_worker(history.source)
                 continue
             due: list[ActiveScanRequest] = []
@@ -626,32 +636,31 @@ class _OwnershipIndex:
         self._workers = workers
         self._owner_by_address: dict[str, str] = {}
 
-    # ``Optional[str]`` (not ``str | None``): PEP 604 under future
-    # annotations parses as non-nullable ``str`` and clashes with the
-    # ``object`` param in the .pxd ``cpdef`` signature.
-    def assign(
-        self,
-        address: str,
-        new_source: Optional[str],  # noqa: UP045
-    ) -> None:
-        """Move ownership of ``address`` to ``new_source`` (None clears)."""
+    def assign(self, address: str, new_source: str) -> None:
+        """Move ownership of ``address`` to ``new_source``."""
         old_source = self._owner_by_address.get(address)
         if old_source == new_source:
             return
         if old_source is not None:
             old_worker = self._workers.get(old_source)
             if old_worker is not None:
-                old_worker._owned_needs.pop(address, None)
-        if new_source is None:
-            self._owner_by_address.pop(address, None)
-            return
+                old_worker._detach_owned(address)
         self._owner_by_address[address] = new_source
         entries = self._needs.get(address)
         if entries is None:
             return
         new_worker = self._workers.get(new_source)
         if new_worker is not None:
-            new_worker._owned_needs[address] = entries
+            new_worker._attach_owned(address, entries)
+
+    def unown(self, address: str) -> None:
+        """Drop the owner mapping for ``address``."""
+        old_source = self._owner_by_address.pop(address, None)
+        if old_source is None:
+            return
+        old_worker = self._workers.get(old_source)
+        if old_worker is not None:
+            old_worker._detach_owned(address)
 
     def clear_source(self, source: str) -> None:
         """Drop owner mappings and ``_needs`` entries owned by ``source``."""
@@ -663,25 +672,24 @@ class _OwnershipIndex:
                 needs.pop(address, None)
         worker = self._workers.get(source)
         if worker is not None:
-            worker._owned_needs.clear()
+            worker._clear_owned()
 
     def hook_worker(self, source: str) -> None:
         """Attach pre-assigned entries to a newly-registered worker."""
         worker = self._workers.get(source)
         if worker is None:
             return
-        owned_needs = worker._owned_needs
         needs = self._needs
         for address, owner in self._owner_by_address.items():
             if owner == source:
                 entries = needs.get(address)
                 if entries is not None:
-                    owned_needs[address] = entries
+                    worker._attach_owned(address, entries)
 
     def clear(self) -> None:
         """Reset the index and every worker's owned view."""
         for worker in self._workers.values():
-            worker._owned_needs.clear()
+            worker._clear_owned()
         self._owner_by_address.clear()
 
 
@@ -863,7 +871,7 @@ class AutoScanScheduler:
             entries.pop(request, None)
             if not entries:
                 del self._needs[request.address]
-                self._ownership.assign(request.address, None)
+                self._ownership.unown(request.address)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
         """

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -339,8 +339,6 @@ class _ScannerWorker:
             return self._window_end
         next_at = self._sweep_last_completed + _AUTO_REDISCOVERY_INTERVAL
         for entries in self._owned_due_at.values():
-            if not entries:
-                continue
             earliest = min(entries.values())
             if earliest < next_at:
                 next_at = earliest
@@ -386,9 +384,7 @@ class _ScannerWorker:
         all_due: list[ActiveScanRequest] = []
         any_immediate = False
         for address in list(self._owned_due_at):
-            entries = self._owned_due_at.get(address)
-            if not entries:
-                continue
+            entries = self._owned_due_at[address]
             history = last_service_info(address, False)
             if history is None:
                 self._scheduler._ownership.unown(address)
@@ -632,10 +628,8 @@ class _OwnershipIndex:
         self._owner_by_address: dict[str, str] = {}
 
     def _attach(self, worker: _ScannerWorker, address: str) -> None:
-        """Attach the ``_due_at`` bucket for ``address`` to ``worker``, if any."""
-        entries = self._due_at.get(address)
-        if entries is not None:
-            worker._attach_owned(address, entries)
+        """Attach the ``_due_at`` bucket for ``address`` to ``worker``."""
+        worker._attach_owned(address, self._due_at[address])
 
     def _detach(self, address: str, source: str) -> None:
         """Detach ``address`` from the worker for ``source``, if it exists."""
@@ -658,10 +652,8 @@ class _OwnershipIndex:
 
     def unown(self, address: str) -> None:
         """Forget ``address`` entirely; drops due_at, owner, and worker view."""
-        self._due_at.pop(address, None)
-        old_source = self._owner_by_address.pop(address, None)
-        if old_source is not None:
-            self._detach(address, old_source)
+        del self._due_at[address]
+        self._detach(address, self._owner_by_address.pop(address))
 
     def clear_source(self, source: str) -> None:
         """Drop owner mappings and ``_due_at`` entries owned by ``source``."""
@@ -675,9 +667,7 @@ class _OwnershipIndex:
 
     def hook_worker(self, source: str) -> None:
         """Attach pre-assigned entries to a newly-registered worker."""
-        worker = self._workers.get(source)
-        if worker is None:
-            return
+        worker = self._workers[source]
         for address, owner in self._owner_by_address.items():
             if owner == source:
                 self._attach(worker, address)

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -726,7 +726,7 @@ class BaseHaScanner:
         flipped the radio, ``False`` that the request was ignored.
 
         The auto scheduler branches on the return value: per-device
-        ``_needs`` entries still advance by ``scan_interval``
+        ``_due_at`` entries still advance by ``scan_interval``
         regardless (to avoid busy-looping a stuck scanner), but a
         ``True`` is what advances ``_sweep_last_completed`` (satisfies
         the 12 h rediscovery floor) and counts toward the on-demand

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1108,7 +1108,7 @@ class BluetoothManager:
             scan_duration = DEFAULT_ACTIVE_SCAN_DURATION
         # Reject non-finite values explicitly: NaN compared to anything
         # returns False, so a NaN would slip past the lower-bound
-        # checks below and end up in _needs and call_later as a NaN
+        # checks below and end up in _due_at and call_later as a NaN
         # due-time / duration, busy-looping the worker.
         if not math.isfinite(scan_interval) or scan_interval < MIN_ACTIVE_SCAN_INTERVAL:
             msg = (

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -5972,3 +5972,67 @@ async def test_detach_from_worker_tolerates_missing_worker() -> None:
     sched = manager._auto_scheduler
     # No scanner registered for this source — helper must not raise.
     sched._detach_from_worker("ZZ:99:99:99:99:99", "AA:00:00:00:00:99")
+
+
+@pytest.mark.asyncio
+async def test_next_event_at_skips_empty_owned_entries() -> None:
+    """An owned entry with an empty dict is skipped (defensive)."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        worker._owned_needs["AA:00:00:00:00:99"] = {}
+        next_at = worker._next_event_at(loop.time())
+        assert next_at == worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_collect_due_buckets_skips_empty_owned_entries() -> None:
+    """An owned entry with an empty dict is skipped (defensive)."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        worker._owned_needs["AA:00:00:00:00:99"] = {}
+        due_buckets, all_due, any_immediate = worker._collect_due_buckets(loop.time())
+        assert due_buckets == []
+        assert all_due == []
+        assert any_immediate is False
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
+    """_spawn_worker only attaches entries owned by the new scanner's source."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address_a = "11:22:33:44:55:66"
+    address_b = "77:88:99:AA:BB:CC"
+    cancel_a = manager.async_register_active_scan(address_a, scan_interval=60.0)
+    cancel_b = manager.async_register_active_scan(address_b, scan_interval=60.0)
+    foreign_source = "AA:BB:CC:DD:EE:FF"
+    request_b = next(iter(sched._requests_by_address[address_b]))
+    sched._needs[address_b] = {request_b: loop.time()}
+    sched._owner_by_address[address_b] = foreign_source
+    try:
+        scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+        register_cancel = manager.async_register_scanner(scanner)
+        try:
+            worker = sched._workers[scanner.source]
+            # Foreign-owned address must not appear in this worker's view.
+            assert address_b not in worker._owned_needs
+        finally:
+            register_cancel()
+    finally:
+        cancel_a()
+        cancel_b()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -104,6 +104,51 @@ async def _run_worker_tick(scheduler: object, source: str) -> None:
     await worker._tick()
 
 
+def _assert_schedule_invariant(sched: object) -> None:
+    """
+    Assert the schedule's three indices are in lock step.
+
+    1. ``_due_at`` and ``_owner_by_address`` have the same keyset.
+    2. Every ``_due_at`` value is a non-empty dict.
+    3. For each AUTO worker, its ``_owned_due_at`` exactly equals the
+       addresses the schedule says it owns, and each entry's dict object
+       is the *same* dict aliased from ``_due_at`` (not a copy).
+    4. Addresses owned by a non-AUTO source do not appear in any
+       worker's ``_owned_due_at``.
+    """
+    schedule = sched._schedule  # type: ignore[attr-defined]
+    workers = sched._workers  # type: ignore[attr-defined]
+    assert set(schedule._due_at) == set(schedule._owner_by_address), (
+        f"_due_at keys {set(schedule._due_at)} != "
+        f"_owner_by_address keys {set(schedule._owner_by_address)}"
+    )
+    for address, entries in schedule._due_at.items():
+        assert entries, f"_due_at[{address}] is empty"
+    for source, worker in workers.items():
+        index_owned = {
+            addr
+            for addr, owner in schedule._owner_by_address.items()
+            if owner == source
+        }
+        worker_owned = set(worker._owned_due_at)
+        assert worker_owned == index_owned, (
+            f"worker {source}: _owned_due_at={worker_owned} "
+            f"!= index-owned={index_owned}"
+        )
+        for addr in worker_owned:
+            assert worker._owned_due_at[addr] is schedule._due_at[addr], (
+                f"worker {source}: _owned_due_at[{addr}] is not the "
+                f"same dict object as _due_at[{addr}]"
+            )
+    for address, source in schedule._owner_by_address.items():
+        if source not in workers:
+            for worker in workers.values():
+                assert address not in worker._owned_due_at, (
+                    f"non-AUTO owner {source} leaked into worker "
+                    f"{worker._scanner.source}'s _owned_due_at"
+                )
+
+
 @pytest.mark.asyncio
 async def test_advertisement_starts_tracking() -> None:
     """A matching address advertisement creates a per-(address, request) entry."""
@@ -6006,3 +6051,231 @@ async def test_ownership_flip_from_non_auto_to_auto_owner() -> None:
         cancel()
         c_passive()
         c_auto()
+
+
+@pytest.mark.asyncio
+async def test_invariant_through_full_lifecycle() -> None:
+    """Schedule invariant holds at every step of a typical request lifecycle."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    _assert_schedule_invariant(sched)
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    _assert_schedule_invariant(sched)
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    _assert_schedule_invariant(sched)
+    _inject(scanner, address)
+    _assert_schedule_invariant(sched)
+    assert address in sched._schedule._due_at
+    assert sched._schedule._owner_by_address[address] == scanner.source
+    cancel()
+    _assert_schedule_invariant(sched)
+    assert address not in sched._schedule._due_at
+    assert address not in sched._schedule._owner_by_address
+    register_cancel()
+    _assert_schedule_invariant(sched)
+
+
+@pytest.mark.asyncio
+async def test_invariant_through_ownership_flips() -> None:
+    """Schedule invariant holds through a sequence of RSSI-driven flips."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    s_a = _RecordingAutoScanner("AA:00:00:00:00:01", BluetoothScanningMode.AUTO)
+    s_b = _RecordingAutoScanner("AA:00:00:00:00:02", BluetoothScanningMode.AUTO)
+    s_c = _RecordingAutoScanner("AA:00:00:00:00:03", BluetoothScanningMode.AUTO)
+    c_a = manager.async_register_scanner(s_a)
+    c_b = manager.async_register_scanner(s_b)
+    c_c = manager.async_register_scanner(s_c)
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    try:
+        _assert_schedule_invariant(sched)
+        # Each step is a >= 40 dB jump (monotonically stronger) so the
+        # manager flips ownership on every inject.
+        for scanner, rssi in (
+            (s_a, -100),
+            (s_b, -60),
+            (s_c, -20),
+        ):
+            _inject_with_rssi(scanner, address, rssi=rssi)
+            _assert_schedule_invariant(sched)
+            assert sched._schedule._owner_by_address[address] == scanner.source
+        # Same scanner re-advertises: same owner; invariant holds.
+        _inject_with_rssi(s_c, address, rssi=-15)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == s_c.source
+    finally:
+        cancel()
+        c_a()
+        c_b()
+        c_c()
+    _assert_schedule_invariant(sched)
+
+
+@pytest.mark.asyncio
+async def test_invariant_through_mixed_mode_flips() -> None:
+    """
+    Schedule invariant holds when ownership flips across all scanner modes.
+
+    Mix of ACTIVE, PASSIVE, and AUTO scanners; ownership migrates among
+    them as RSSI climbs. Only the AUTO scanner has a worker, so the
+    invariant exercises both the "owner has worker" and "owner has no
+    worker" branches in the same scenario.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    active = _RecordingAutoScanner("AA:00:00:00:00:0A", BluetoothScanningMode.ACTIVE)
+    passive = _RecordingAutoScanner("AA:00:00:00:00:0B", BluetoothScanningMode.PASSIVE)
+    auto = _RecordingAutoScanner("AA:00:00:00:00:0C", BluetoothScanningMode.AUTO)
+    c_active = manager.async_register_scanner(active)
+    c_passive = manager.async_register_scanner(passive)
+    c_auto = manager.async_register_scanner(auto)
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    try:
+        _assert_schedule_invariant(sched)
+        # Workers exist only for AUTO scanners.
+        assert active.source not in sched._workers
+        assert passive.source not in sched._workers
+        assert auto.source in sched._workers
+        auto_worker = sched._workers[auto.source]
+        # ACTIVE first (no worker for the owner; address is in
+        # _owner_by_address but not in any worker's _owned_due_at).
+        _inject_with_rssi(active, address, rssi=-100)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == active.source
+        assert address not in auto_worker._owned_due_at
+        # PASSIVE with stronger RSSI: another non-AUTO owner.
+        _inject_with_rssi(passive, address, rssi=-60)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == passive.source
+        assert address not in auto_worker._owned_due_at
+        # AUTO with stronger RSSI: ownership flips to the worker-having
+        # source; the address now appears in the worker's owned view.
+        _inject_with_rssi(auto, address, rssi=-20)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == auto.source
+        assert address in auto_worker._owned_due_at
+        # Flip BACK to PASSIVE by unregistering the AUTO scanner: its
+        # owned-view entry is pruned via clear_source. The address goes
+        # away from the schedule entirely (no other scanner advertised
+        # since the AUTO claim).
+        c_auto()
+        _assert_schedule_invariant(sched)
+        assert address not in sched._schedule._owner_by_address
+        # A subsequent PASSIVE advertisement re-bootstraps ownership;
+        # back to non-AUTO-owned state without a worker view.
+        _inject_with_rssi(passive, address, rssi=-50)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == passive.source
+    finally:
+        cancel()
+        c_active()
+        c_passive()
+    _assert_schedule_invariant(sched)
+
+
+@pytest.mark.asyncio
+async def test_invariant_through_orphan_prune() -> None:
+    """Schedule invariant holds after a tick prunes an aged-out address."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "AA:BB:CC:DD:EE:FF"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        _assert_schedule_invariant(sched)
+        # Force the entry due so the tick actually inspects history.
+        request = next(iter(sched._schedule._due_at[address]))
+        sched._schedule._due_at[address][request] = loop.time() - 1.0
+        # History ages out under the worker's feet; the tick's orphan
+        # branch should clean every index in lock step.
+        manager._all_history.pop(address, None)
+        manager._connectable_history.pop(address, None)
+        await _run_worker_tick(sched, scanner.source)
+        _assert_schedule_invariant(sched)
+        assert address not in sched._schedule._due_at
+        assert address not in sched._schedule._owner_by_address
+    finally:
+        cancel()
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_invariant_through_many_addresses_and_scanners() -> None:
+    """Schedule invariant holds when many scanners and addresses interleave."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanners = [
+        _RecordingAutoScanner(f"AA:00:00:00:00:{i:02X}", BluetoothScanningMode.AUTO)
+        for i in range(4)
+    ]
+    register_cancels = [manager.async_register_scanner(s) for s in scanners]
+    cancels = [
+        manager.async_register_active_scan(
+            f"BB:00:00:00:00:{i:02X}", scan_interval=60.0
+        )
+        for i in range(16)
+    ]
+    addresses = [f"BB:00:00:00:00:{i:02X}" for i in range(16)]
+    try:
+        _assert_schedule_invariant(sched)
+        # Round-robin each address to a scanner, ramping RSSI by 30 dB
+        # per round so every later inject flips ownership.
+        for round_ix, scanner in enumerate(scanners):
+            rssi = -100 + 30 * round_ix
+            for address in addresses:
+                _inject_with_rssi(scanner, address, rssi=rssi)
+            _assert_schedule_invariant(sched)
+        # All addresses now owned by the last scanner (strongest RSSI).
+        last = scanners[-1]
+        for address in addresses:
+            assert sched._schedule._owner_by_address[address] == last.source
+        # Removing the owner scanner prunes the addresses it owned;
+        # the schedule cleans them out without surfacing them anywhere.
+        register_cancels[-1]()
+        _assert_schedule_invariant(sched)
+        for address in addresses:
+            assert address not in sched._schedule._due_at
+    finally:
+        for c in cancels:
+            c()
+        for rc in register_cancels[:-1]:
+            rc()
+    _assert_schedule_invariant(sched)
+
+
+@pytest.mark.asyncio
+async def test_invariant_through_stop_and_restart() -> None:
+    """Schedule invariant holds across stop + start replay."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    try:
+        _inject(scanner, address)
+        _assert_schedule_invariant(sched)
+        sched.stop()
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._due_at == {}
+        assert sched._schedule._owner_by_address == {}
+        # Give the previously running worker task a chance to fully exit
+        # so the post-restart spawn doesn't share its source slot.
+        await asyncio.sleep(0)
+        loop = asyncio.get_running_loop()
+        sched.start(loop)
+        _assert_schedule_invariant(sched)
+        # start() replayed the request and re-assigned via history.
+        assert address in sched._schedule._due_at
+        assert sched._schedule._owner_by_address[address] == scanner.source
+    finally:
+        cancel()
+        register_cancel()
+    _assert_schedule_invariant(sched)

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -18,7 +18,7 @@ from habluetooth import (
     BluetoothServiceInfoBleak,
     get_manager,
 )
-from habluetooth.auto_scheduler import ActiveScanRequest, _OwnershipIndex
+from habluetooth.auto_scheduler import ActiveScanRequest, _ScanSchedule
 from habluetooth.const import (
     AUTO_INITIAL_SWEEP_DELAY,
     AUTO_REDISCOVERY_INTERVAL,
@@ -117,11 +117,11 @@ async def test_advertisement_starts_tracking() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        assert "11:22:33:44:55:66" in sched._ownership._due_at
+        assert "11:22:33:44:55:66" in sched._schedule._due_at
     finally:
         cancel()
         register_cancel()
-    assert sched._ownership._due_at == {}
+    assert sched._schedule._due_at == {}
 
 
 @pytest.mark.asyncio
@@ -138,7 +138,7 @@ async def test_advertisement_for_unrelated_address_is_ignored() -> None:
         # The registered address has tracking from add_request; the
         # unrelated advertisement must not create its own entry.
         _inject(scanner, "AA:AA:AA:AA:AA:AA")
-        assert "AA:AA:AA:AA:AA:AA" not in sched._ownership._due_at
+        assert "AA:AA:AA:AA:AA:AA" not in sched._schedule._due_at
     finally:
         cancel()
         register_cancel()
@@ -157,7 +157,7 @@ async def test_worker_tick_fires_active_window() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        entries = sched._ownership._due_at["11:22:33:44:55:66"]
+        entries = sched._schedule._due_at["11:22:33:44:55:66"]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         await _run_worker_tick(sched, scanner.source)
@@ -190,7 +190,7 @@ async def test_worker_tick_advances_by_scan_interval_from_window_start() -> None
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         before_tick = loop.time()
@@ -227,8 +227,8 @@ async def test_worker_tick_coalesces_near_future_due_entries() -> None:
         # A is due now; B is due 10s from now (within the lookahead).
         # One tick should serve both.
         now = loop.time()
-        entries_a = sched._ownership._due_at[addr_a]
-        entries_b = sched._ownership._due_at[addr_b]
+        entries_a = sched._schedule._due_at[addr_a]
+        entries_b = sched._schedule._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -264,7 +264,7 @@ async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> No
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         # Set next_due 5s in the future — within the lookahead but
         # not immediately due.
         for req in entries:
@@ -296,8 +296,8 @@ async def test_worker_tick_coalesces_near_max_window_boundary() -> None:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
         now = loop.time()
-        entries_a = sched._ownership._due_at[addr_a]
-        entries_b = sched._ownership._due_at[addr_b]
+        entries_a = sched._schedule._due_at[addr_a]
+        entries_b = sched._schedule._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -336,8 +336,8 @@ async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
         fallback.add_discovered(addr_b, rssi=-70)
         owner._add_connecting(addr_a)
         now = loop.time()
-        entries_a = sched._ownership._due_at[addr_a]
-        entries_b = sched._ownership._due_at[addr_b]
+        entries_a = sched._schedule._due_at[addr_a]
+        entries_b = sched._schedule._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -380,7 +380,7 @@ async def test_worker_tick_sweep_alone_pulls_in_soon_due_entries() -> None:
         # Make the sweep due; per-device entry is soon-due but not
         # immediate.
         worker._sweep_last_completed = loop.time() - AUTO_REDISCOVERY_INTERVAL - 1.0
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         soon_due_at = loop.time() + 5.0
         for req in entries:
             entries[req] = soon_due_at
@@ -414,7 +414,7 @@ async def test_worker_tick_coalesces_overlapping_requests() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await _run_worker_tick(sched, scanner.source)
@@ -442,7 +442,7 @@ async def test_multiple_requests_same_address_track_independent_intervals() -> N
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         assert len(entries) == 2
         fast, slow = sorted(entries, key=lambda r: r.scan_interval)
         entries[fast] = loop.time() - 1.0
@@ -596,7 +596,7 @@ async def test_active_scan_registered_before_auto_scanner_wakes_on_register() ->
             _inject(scanner, address)
             assert worker._wake.is_set()
             # The address now has a tracked entry on this scanner.
-            assert address in sched._ownership._due_at
+            assert address in sched._schedule._due_at
         finally:
             register_cancel()
     finally:
@@ -614,9 +614,9 @@ async def test_remove_request_clears_tracking() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._ownership._due_at
+        assert address in sched._schedule._due_at
         cancel()
-        assert address not in sched._ownership._due_at
+        assert address not in sched._schedule._due_at
         assert sched._requests_by_address == {}
     finally:
         register_cancel()
@@ -675,16 +675,16 @@ async def test_dispatch_drops_tracking_for_unseen_address() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        request = next(iter(sched._ownership._due_at[address]))
-        sched._ownership._due_at[address][request] = loop.time() - 1.0
+        request = next(iter(sched._schedule._due_at[address]))
+        sched._schedule._due_at[address][request] = loop.time() - 1.0
         # Simulate the manager's history aging out under the worker's
         # feet — the orphan-prune branch should clean both _due_at and
         # _owner_by_address.
         manager._all_history.pop(address, None)
         manager._connectable_history.pop(address, None)
         await _run_worker_tick(sched, scanner.source)
-        assert address not in sched._ownership._due_at
-        assert address not in sched._ownership._owner_by_address
+        assert address not in sched._schedule._due_at
+        assert address not in sched._schedule._owner_by_address
         assert address not in sched._workers[scanner.source]._owned_due_at
     finally:
         cancel()
@@ -794,14 +794,14 @@ async def test_remove_scanner_prunes_owned_due_at_entries() -> None:
     try:
         _inject(s_a, address_owned)
         _inject(s_b, address_foreign)
-        assert address_owned in sched._ownership._due_at
-        assert address_foreign in sched._ownership._due_at
+        assert address_owned in sched._schedule._due_at
+        assert address_foreign in sched._schedule._due_at
         # Remove s_a. The owned entry must be pruned; the foreign one
         # (owned by s_b) must remain.
         c_a()
         await asyncio.sleep(0)
-        assert address_owned not in sched._ownership._due_at
-        assert address_foreign in sched._ownership._due_at
+        assert address_owned not in sched._schedule._due_at
+        assert address_foreign in sched._schedule._due_at
     finally:
         cancel_owned()
         cancel_foreign()
@@ -863,10 +863,10 @@ async def test_stop_clears_loop_so_post_stop_add_request_is_record_only() -> Non
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             assert address in sched._requests_by_address
-            assert address not in sched._ownership._due_at
+            assert address not in sched._schedule._due_at
             # on_advertisement after stop is a no-op on _due_at too.
             _inject(scanner, address)
-            assert address not in sched._ownership._due_at
+            assert address not in sched._schedule._due_at
         finally:
             cancel()
     finally:
@@ -904,7 +904,7 @@ async def test_on_advertisement_early_returns_with_no_requests() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        assert sched._ownership._due_at == {}
+        assert sched._schedule._due_at == {}
         assert sched._requests_by_address == {}
     finally:
         register_cancel()
@@ -924,10 +924,10 @@ async def test_on_advertisement_re_bootstraps_pruned_tracking() -> None:
         # No advertisement has been seen yet, so add_request skipped
         # the _due_at seed (the prune-on-no-history path). Simulate the
         # "pruned" state by ensuring it's not there.
-        sched._ownership._due_at.pop(address, None)
+        sched._schedule._due_at.pop(address, None)
         worker._wake.clear()
         _inject(scanner, address)
-        assert address in sched._ownership._due_at
+        assert address in sched._schedule._due_at
         assert worker._wake.is_set()
     finally:
         cancel()
@@ -1046,7 +1046,7 @@ async def test_add_request_without_history_skips_seed() -> None:
         # Sanity: history doesn't exist for this address yet.
         assert manager.async_last_service_info(address, False) is None
         # _due_at was not seeded -> no entry to prune later.
-        assert address not in sched._ownership._due_at
+        assert address not in sched._schedule._due_at
         # But the request IS recorded for on_advertisement to pick up.
         assert address in sched._requests_by_address
         # First advertisement bootstraps tracking and wakes the
@@ -1054,7 +1054,7 @@ async def test_add_request_without_history_skips_seed() -> None:
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         _inject(scanner, address)
-        assert address in sched._ownership._due_at
+        assert address in sched._schedule._due_at
         assert worker._wake.is_set()
     finally:
         cancel()
@@ -1199,12 +1199,12 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
     auto_cancel = manager.async_register_scanner(auto_scanner)
     try:
         _inject(auto_scanner, address)
-        assert address in sched._ownership._due_at
+        assert address in sched._schedule._due_at
         assert auto_scanner.source in sched._workers
         # Mode switch in UI -> unregister AUTO scanner.
         auto_cancel()
         assert auto_scanner.source not in sched._workers
-        assert address not in sched._ownership._due_at
+        assert address not in sched._schedule._due_at
         # User's registration is preserved across the switch.
         assert address in sched._requests_by_address
         # Re-register with the SAME source but PASSIVE mode.
@@ -1216,7 +1216,7 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
             # PASSIVE doesn't get a worker.
             assert passive_scanner.source not in sched._workers
             # Still no _due_at entry (no AUTO scanner owns it).
-            assert address not in sched._ownership._due_at
+            assert address not in sched._schedule._due_at
             passive_cancel()
             # Now switch BACK to AUTO with the same source.
             new_auto = _RecordingAutoScanner(
@@ -1228,7 +1228,7 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
                 # First advertisement on the new AUTO scanner bootstraps
                 # tracking again from the still-registered request.
                 _inject(new_auto, address)
-                assert address in sched._ownership._due_at
+                assert address in sched._schedule._due_at
             finally:
                 new_auto_cancel()
         except BaseException:
@@ -1275,7 +1275,7 @@ async def test_start_replays_pre_start_requests_into_due_at() -> None:
                 address_no_history, scan_interval=60.0, scan_duration=5.0
             )
             try:
-                assert address_with_history not in sched._ownership._due_at
+                assert address_with_history not in sched._schedule._due_at
                 requests = list(sched._requests_by_address[address_with_history])
                 pre_existing, to_be_inserted = requests
                 # Pre-populate _due_at with one request only. The
@@ -1285,12 +1285,10 @@ async def test_start_replays_pre_start_requests_into_due_at() -> None:
                 # about the absolute value, only that start() leaves
                 # it alone.
                 sentinel = saved_loop.time() + 1.0e9
-                sched._ownership._due_at[address_with_history] = {
-                    pre_existing: sentinel
-                }
+                sched._schedule._due_at[address_with_history] = {pre_existing: sentinel}
                 before_start = saved_loop.time()
                 sched.start(saved_loop)
-                seeded = sched._ownership._due_at[address_with_history]
+                seeded = sched._schedule._due_at[address_with_history]
                 # The pre-existing entry was left alone (covers the
                 # `request not in existing` False branch).
                 assert seeded[pre_existing] == sentinel
@@ -1302,7 +1300,7 @@ async def test_start_replays_pre_start_requests_into_due_at() -> None:
                 )
                 # No-history address: skipped by the
                 # `last_service_info(...) is None` branch.
-                assert address_no_history not in sched._ownership._due_at
+                assert address_no_history not in sched._schedule._due_at
             finally:
                 cancel_with_a()
                 cancel_with_b()
@@ -1357,14 +1355,14 @@ async def test_dispatch_does_not_resurrect_cancelled_request() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
         await gate.wait()
         # remove_request emptied the bucket; the tick must not have
         # re-added the cancelled request.
-        assert address not in sched._ownership._due_at
+        assert address not in sched._schedule._due_at
     finally:
         register_cancel()
 
@@ -1383,7 +1381,7 @@ async def test_dispatch_skips_address_owned_by_other_scanner() -> None:
     c2 = manager.async_register_scanner(other)
     try:
         _inject(owner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         # The "other" scanner runs its tick. The address is owned by
@@ -1427,7 +1425,7 @@ async def test_next_event_at_returns_earliest_per_device_need() -> None:
         worker = sched._workers[scanner.source]
         # Sweep is far in the future (initial delay window). The earliest
         # event for the worker is the per-device next-due.
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         request = next(iter(entries))
         per_device_at = loop.time() + 5.0
         entries[request] = per_device_at
@@ -1450,7 +1448,7 @@ async def test_dispatch_per_device_skips_not_yet_due() -> None:
     try:
         _inject(scanner, address)
         # Push the due time far in the future.
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for request in list(entries):
             entries[request] = loop.time() + 1000.0
         await sched._workers[scanner.source]._tick()
@@ -1600,7 +1598,7 @@ async def test_remove_request_handles_missing_bucket() -> None:
     # Bucket was never added; remove_request must be a no-op.
     sched.remove_request(request)
     assert "AA:BB:CC:DD:EE:99" not in sched._requests_by_address
-    assert "AA:BB:CC:DD:EE:99" not in sched._ownership._due_at
+    assert "AA:BB:CC:DD:EE:99" not in sched._schedule._due_at
 
 
 @pytest.mark.asyncio
@@ -1615,7 +1613,7 @@ async def test_on_advertisement_no_match_no_wake() -> None:
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         _inject(scanner, "AA:AA:AA:AA:AA:AA")
-        assert "AA:AA:AA:AA:AA:AA" not in sched._ownership._due_at
+        assert "AA:AA:AA:AA:AA:AA" not in sched._schedule._due_at
         assert not worker._wake.is_set()
     finally:
         cancel()
@@ -1665,7 +1663,7 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
     req_a = ActiveScanRequest(address, 60.0, 10.0)
     req_b = ActiveScanRequest(address, 120.0, 10.0)
     sched._requests_by_address[address] = {req_a, req_b}
-    sched._ownership._due_at[address] = {req_a: 0.0, req_b: 0.0}
+    sched._schedule._due_at[address] = {req_a: 0.0, req_b: 0.0}
     try:
         si = BluetoothServiceInfoBleak(
             name="x",
@@ -1689,10 +1687,10 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
         # triggers when every request was already in _due_at.
         assert worker._wake.is_set()
         # Sanity: the entries we put in are untouched.
-        assert sched._ownership._due_at[address] == {req_a: 0.0, req_b: 0.0}
+        assert sched._schedule._due_at[address] == {req_a: 0.0, req_b: 0.0}
     finally:
         sched._requests_by_address.pop(address, None)
-        sched._ownership._due_at.pop(address, None)
+        sched._schedule._due_at.pop(address, None)
         register_cancel()
 
 
@@ -1735,8 +1733,8 @@ async def test_next_event_at_skips_per_device_later_than_sweep() -> None:
         sweep_at = worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
         # Push per-device need past the sweep cadence so the earliest <
         # next_at branch is False inside _next_event_at.
-        for req in list(sched._ownership._due_at[address]):
-            sched._ownership._due_at[address][req] = sweep_at + 100.0
+        for req in list(sched._schedule._due_at[address]):
+            sched._schedule._due_at[address][req] = sweep_at + 100.0
         assert worker._next_event_at(loop.time()) == sweep_at
     finally:
         cancel()
@@ -1792,7 +1790,7 @@ async def test_coalesce_three_due_uses_max_clamped() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1818,7 +1816,7 @@ async def test_coalesce_clamps_oversize_request() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1845,7 +1843,7 @@ async def test_coalesce_only_due_requests_count() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         short_req = next(r for r in entries if r.scan_duration == 5.0)
         long_req = next(r for r in entries if r.scan_duration == 20.0)
         # Only the short request is due; the long one is well in the
@@ -1880,7 +1878,7 @@ async def test_coalesce_distinct_addresses_share_one_window() -> None:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
         for address in (addr_a, addr_b):
-            entries = sched._ownership._due_at[address]
+            entries = sched._schedule._due_at[address]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1907,7 +1905,7 @@ async def test_tick_combines_due_sweep_and_per_device_into_one_window() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         worker = sched._workers[scanner.source]
@@ -1948,7 +1946,7 @@ async def test_three_inkbirds_share_one_scan() -> None:
     try:
         for addr in addresses:
             _inject(scanner, addr)
-            entries = sched._ownership._due_at[addr]
+            entries = sched._schedule._due_at[addr]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1956,7 +1954,7 @@ async def test_three_inkbirds_share_one_scan() -> None:
         assert scanner.active_window_calls == [15.0]
         # Next-due moved forward by scan_interval for every request.
         for addr in addresses:
-            for due in sched._ownership._due_at[addr].values():
+            for due in sched._schedule._due_at[addr].values():
                 assert due > loop.time() + 250.0
     finally:
         for cancel in cancels:
@@ -1983,7 +1981,7 @@ async def test_dispatch_coalesces_different_durations_to_max() -> None:
     try:
         for addr in (addr_short, addr_long):
             _inject(scanner, addr)
-            entries = sched._ownership._due_at[addr]
+            entries = sched._schedule._due_at[addr]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -2019,7 +2017,7 @@ async def test_three_inkbirds_same_address_coalesce_to_one_scan() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         assert len(entries) == 3
         for req in list(entries):
             entries[req] = loop.time() - 1.0
@@ -2059,13 +2057,13 @@ async def test_three_inkbirds_window_unchanged_after_removal() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         assert len(entries) == 3
         # Cancel one of the three; two should remain in both the registry
         # and the _due_at tracker.
         cancels.pop()()
         assert len(sched._requests_by_address[address]) == 2
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         assert len(entries) == 2
         for req in list(entries):
             entries[req] = loop.time() - 1.0
@@ -2104,7 +2102,7 @@ async def test_only_owning_scanner_fires_among_four() -> None:
     try:
         owner = scanners[2]
         _inject(owner, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         for scanner in scanners:
@@ -2128,7 +2126,7 @@ async def test_add_request_before_start_does_not_seed_due_at() -> None:
     try:
         sched.add_request(ActiveScanRequest(address, 60.0, 10.0))
         assert address in sched._requests_by_address
-        assert address not in sched._ownership._due_at
+        assert address not in sched._schedule._due_at
     finally:
         sched._loop = original_loop
         sched._requests_by_address.pop(address, None)
@@ -2153,11 +2151,11 @@ async def test_add_request_idempotent_keeps_existing_due() -> None:
         sched.add_request(request)
         # Inject so add_request can see history on the second call.
         _inject(scanner, address)
-        sched._ownership._due_at[address][request] = 1234.5
+        sched._schedule._due_at[address][request] = 1234.5
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         sched.add_request(request)
-        assert sched._ownership._due_at[address][request] == 1234.5
+        assert sched._schedule._due_at[address][request] == 1234.5
         # No new entry → no wake.
         assert not worker._wake.is_set()
         sched.remove_request(request)
@@ -2217,7 +2215,7 @@ async def test_owner_flip_during_window_does_not_double_fire() -> None:
     c_b = manager.async_register_scanner(s_b)
     try:
         _inject(s_a, address)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
 
@@ -2295,7 +2293,7 @@ async def test_device_migration_between_scanners_fires_on_new_owner() -> None:
 
         # Make the existing tracking entry due and fire the first
         # window on A.
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[s_a.source]._tick()
@@ -2380,12 +2378,12 @@ async def test_stop_clears_due_at_so_restart_does_not_reuse_stale_due_times() ->
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._ownership._due_at
+        assert address in sched._schedule._due_at
         original_loop = sched._loop
         sched.stop()
         # _due_at cleared so stale timestamps from the now-defunct loop
         # can't survive into a re-start.
-        assert sched._ownership._due_at == {}
+        assert sched._schedule._due_at == {}
         assert sched._loop is None
         assert sched._workers == {}
         # _requests_by_address is loop-independent and must persist so
@@ -2395,8 +2393,8 @@ async def test_stop_clears_due_at_so_restart_does_not_reuse_stale_due_times() ->
         # a fresh due time from the new loop.time() base.
         assert original_loop is not None
         sched.start(original_loop)
-        assert address in sched._ownership._due_at
-        entries = sched._ownership._due_at[address]
+        assert address in sched._schedule._due_at
+        entries = sched._schedule._due_at[address]
         expected_due = original_loop.time() + 60.0
         assert all(abs(due - expected_due) < 0.5 for due in entries.values())
     finally:
@@ -2432,7 +2430,7 @@ class _DiscoverableAutoScanner(_RecordingAutoScanner):
 
 def _make_due(sched: object, address: str) -> None:
     """Make every tracked request for ``address`` due immediately."""
-    entries = sched._ownership._due_at[address]  # type: ignore[attr-defined]
+    entries = sched._schedule._due_at[address]  # type: ignore[attr-defined]
     loop = asyncio.get_running_loop()
     for req in list(entries):
         entries[req] = loop.time() - 1.0
@@ -3159,7 +3157,7 @@ async def test_worker_tick_advance_pre_dispatch_blocks_double_fire() -> None:
         _make_due(sched, address)
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for due in entries.values():
             # Advanced to roughly before + 90s, NOT before - 1.0.
             assert due == pytest.approx(before + 90.0, abs=0.5)
@@ -3686,7 +3684,7 @@ async def test_worker_tick_ownership_flip_during_dispatch_no_double_fire() -> No
         await asyncio.sleep(0)
         # Confirm fallback call is in flight and entries advanced.
         assert fb.active_window_calls == [6.0]
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for due in entries.values():
             assert due == pytest.approx(before + 90.0, abs=0.5)
         # Ownership flips to fb mid-dispatch (much stronger RSSI).
@@ -4008,7 +4006,7 @@ async def test_worker_tick_three_addresses_no_fallback_advance_by_defer() -> Non
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
         for addr in (addr_a, addr_b, addr_c):
-            entries = sched._ownership._due_at[addr]
+            entries = sched._schedule._due_at[addr]
             for due in entries.values():
                 assert due == pytest.approx(before + 30.0, abs=0.5)
                 assert due < before + 60.0
@@ -4141,11 +4139,11 @@ async def test_worker_tick_three_addresses_mixed_outcomes_advance_correctly() ->
         owner._add_connecting(addr_covered)
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
-        for due in sched._ownership._due_at[addr_covered].values():
+        for due in sched._schedule._due_at[addr_covered].values():
             assert due == pytest.approx(before + 120.0, abs=0.5)
-        for due in sched._ownership._due_at[addr_flipped].values():
+        for due in sched._schedule._due_at[addr_flipped].values():
             assert due == pytest.approx(before + 240.0, abs=0.5)
-        for due in sched._ownership._due_at[addr_orphan].values():
+        for due in sched._schedule._due_at[addr_orphan].values():
             assert due == pytest.approx(before + 30.0, abs=0.5)
         assert fb.active_window_calls == [9.0]
         assert active.active_window_calls == []
@@ -4278,7 +4276,7 @@ async def test_worker_tick_failed_fallback_advances_entries_by_full_interval() -
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
         # Entries advanced by full scan_interval, NOT retry_at.
-        for due in sched._ownership._due_at[address].values():
+        for due in sched._schedule._due_at[address].values():
             assert due == pytest.approx(before + 120.0, abs=0.5)
             assert due > before + 60.0  # well past the 30s retry_at
         # fb_worker bumps from note_window_dispatched are preserved.
@@ -5518,9 +5516,9 @@ async def test_owned_due_at_populated_for_owner_on_add_request_with_history() ->
         # history-gating finds it.
         _inject(scanner, address)
         # Drop the entry add_request seeded so we can re-add through
-        # add_request and observe its _ownership.assign side-effect.
-        sched._ownership._due_at.pop(address, None)
-        sched._ownership._owner_by_address.pop(address, None)
+        # add_request and observe its _schedule.assign side-effect.
+        sched._schedule._due_at.pop(address, None)
+        sched._schedule._owner_by_address.pop(address, None)
         sched._workers[scanner.source]._owned_due_at.pop(address, None)
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
@@ -5529,8 +5527,8 @@ async def test_owned_due_at_populated_for_owner_on_add_request_with_history() ->
             # Inner dict must be the SAME object aliased between
             # _due_at and _owned_due_at so _advance_due mutations apply
             # to both views.
-            assert owned[address] is sched._ownership._due_at[address]
-            assert sched._ownership._owner_by_address[address] == scanner.source
+            assert owned[address] is sched._schedule._due_at[address]
+            assert sched._schedule._owner_by_address[address] == scanner.source
         finally:
             cancel()
     finally:
@@ -5548,8 +5546,8 @@ async def test_add_request_without_history_leaves_owned_due_at_empty() -> None:
     try:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
-            assert address not in sched._ownership._due_at
-            assert address not in sched._ownership._owner_by_address
+            assert address not in sched._schedule._due_at
+            assert address not in sched._schedule._owner_by_address
             assert address not in sched._workers[scanner.source]._owned_due_at
         finally:
             cancel()
@@ -5571,8 +5569,8 @@ async def test_on_advertisement_bootstraps_owned_due_at() -> None:
             _inject(scanner, address)
             owned = sched._workers[scanner.source]._owned_due_at
             assert address in owned
-            assert owned[address] is sched._ownership._due_at[address]
-            assert sched._ownership._owner_by_address[address] == scanner.source
+            assert owned[address] is sched._schedule._due_at[address]
+            assert sched._schedule._owner_by_address[address] == scanner.source
         finally:
             cancel()
     finally:
@@ -5596,15 +5594,15 @@ async def test_ownership_flip_moves_entry_between_owned_due_at() -> None:
         worker_b = sched._workers[s_b.source]
         assert address in worker_a._owned_due_at
         assert address not in worker_b._owned_due_at
-        assert sched._ownership._owner_by_address[address] == s_a.source
+        assert sched._schedule._owner_by_address[address] == s_a.source
 
         # B with much stronger RSSI triggers ownership flip in the
         # manager; scheduler's on_advertisement reassigns owner.
         _inject_with_rssi(s_b, address, rssi=-30)
         assert address not in worker_a._owned_due_at
         assert address in worker_b._owned_due_at
-        assert worker_b._owned_due_at[address] is sched._ownership._due_at[address]
-        assert sched._ownership._owner_by_address[address] == s_b.source
+        assert worker_b._owned_due_at[address] is sched._schedule._due_at[address]
+        assert sched._schedule._owner_by_address[address] == s_b.source
     finally:
         c_a()
         c_b()
@@ -5625,8 +5623,8 @@ async def test_remove_request_clears_owner_when_bucket_empties() -> None:
         worker = sched._workers[scanner.source]
         assert address in worker._owned_due_at
         cancel()
-        assert address not in sched._ownership._due_at
-        assert address not in sched._ownership._owner_by_address
+        assert address not in sched._schedule._due_at
+        assert address not in sched._schedule._owner_by_address
         assert address not in worker._owned_due_at
     finally:
         register_cancel()
@@ -5645,14 +5643,14 @@ async def test_remove_request_preserves_owner_when_other_requests_remain() -> No
         cancel2 = manager.async_register_active_scan(address, scan_interval=120.0)
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        assert len(sched._ownership._due_at[address]) == 2
+        assert len(sched._schedule._due_at[address]) == 2
         cancel1()
-        assert address in sched._ownership._due_at
-        assert sched._ownership._owner_by_address[address] == scanner.source
+        assert address in sched._schedule._due_at
+        assert sched._schedule._owner_by_address[address] == scanner.source
         assert address in worker._owned_due_at
         cancel2()
-        assert address not in sched._ownership._due_at
-        assert address not in sched._ownership._owner_by_address
+        assert address not in sched._schedule._due_at
+        assert address not in sched._schedule._owner_by_address
         assert address not in worker._owned_due_at
     finally:
         register_cancel()
@@ -5669,11 +5667,11 @@ async def test_remove_scanner_clears_owner_and_due_at() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._ownership._due_at
-        assert sched._ownership._owner_by_address[address] == scanner.source
+        assert address in sched._schedule._due_at
+        assert sched._schedule._owner_by_address[address] == scanner.source
         register_cancel()
-        assert address not in sched._ownership._due_at
-        assert address not in sched._ownership._owner_by_address
+        assert address not in sched._schedule._due_at
+        assert address not in sched._schedule._owner_by_address
         assert scanner.source not in sched._workers
     finally:
         cancel()
@@ -5693,8 +5691,8 @@ async def test_stop_clears_all_owned_due_at_state() -> None:
         worker = sched._workers[scanner.source]
         assert address in worker._owned_due_at
         sched.stop()
-        assert sched._ownership._due_at == {}
-        assert sched._ownership._owner_by_address == {}
+        assert sched._schedule._due_at == {}
+        assert sched._schedule._owner_by_address == {}
         # Worker dropped from registry; the cleared dict is on the
         # detached instance still held by the local. Confirm both.
         assert sched._workers == {}
@@ -5728,19 +5726,17 @@ async def test_start_replay_populates_owned_due_at() -> None:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             # Pre-start: only _requests_by_address is populated.
-            assert address not in sched._ownership._due_at
-            assert address not in sched._ownership._owner_by_address
+            assert address not in sched._schedule._due_at
+            assert address not in sched._schedule._owner_by_address
             sched.start(loop)
             try:
                 # After start, the replay seeded _due_at and assigned
                 # the owner.
                 worker = sched._workers[scanner.source]
-                assert address in sched._ownership._due_at
-                assert sched._ownership._owner_by_address[address] == scanner.source
+                assert address in sched._schedule._due_at
+                assert sched._schedule._owner_by_address[address] == scanner.source
                 assert address in worker._owned_due_at
-                assert (
-                    worker._owned_due_at[address] is sched._ownership._due_at[address]
-                )
+                assert worker._owned_due_at[address] is sched._schedule._due_at[address]
             finally:
                 # Stop the spawned worker tasks so they do not leak.
                 for w in list(sched._workers.values()):
@@ -5766,15 +5762,15 @@ async def test_spawn_worker_picks_up_preassigned_owner() -> None:
     # registers as AUTO. We bypass the manager here because plumbing a
     # synthetic history entry is more wiring than the invariant needs.
     request = next(iter(sched._requests_by_address[address]))
-    sched._ownership._due_at[address] = {request: loop.time()}
-    sched._ownership._owner_by_address[address] = source
+    sched._schedule._due_at[address] = {request: loop.time()}
+    sched._schedule._owner_by_address[address] = source
     try:
         scanner = _RecordingAutoScanner(source, BluetoothScanningMode.AUTO)
         register_cancel = manager.async_register_scanner(scanner)
         try:
             worker = sched._workers[source]
             assert address in worker._owned_due_at
-            assert worker._owned_due_at[address] is sched._ownership._due_at[address]
+            assert worker._owned_due_at[address] is sched._schedule._due_at[address]
         finally:
             register_cancel()
     finally:
@@ -5797,7 +5793,7 @@ async def test_next_event_at_skips_other_workers_entries() -> None:
         _inject(s_a, address)
         # Drive the entry's due time well below A's sweep so any leak
         # of foreign entries would change B's next_at.
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() + 1.0
         worker_b = sched._workers[s_b.source]
@@ -5856,7 +5852,7 @@ async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
         info = manager.async_last_service_info(address, False)
         assert info is not None
         info.source = s_b.source
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await worker_a._tick()
@@ -5864,7 +5860,7 @@ async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
         assert s_a.active_window_calls == []
         assert address not in worker_a._owned_due_at
         assert address in worker_b._owned_due_at
-        assert sched._ownership._owner_by_address[address] == s_b.source
+        assert sched._schedule._owner_by_address[address] == s_b.source
     finally:
         c_a()
         c_b()
@@ -5883,14 +5879,14 @@ async def test_assign_owner_noop_when_source_unchanged() -> None:
     try:
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        entries = sched._ownership._due_at[address]
+        entries = sched._schedule._due_at[address]
         owned_before = worker._owned_due_at[address]
         # Second injection from the same scanner: owner unchanged,
         # owned-view aliasing preserved (same dict object).
         _inject(scanner, address)
-        assert sched._ownership._owner_by_address[address] == scanner.source
+        assert sched._schedule._owner_by_address[address] == scanner.source
         assert worker._owned_due_at[address] is owned_before
-        assert sched._ownership._due_at[address] is entries
+        assert sched._schedule._due_at[address] is entries
     finally:
         cancel()
         register_cancel()
@@ -5908,8 +5904,8 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
     cancel_b = manager.async_register_active_scan(address_b, scan_interval=60.0)
     foreign_source = "AA:BB:CC:DD:EE:FF"
     request_b = next(iter(sched._requests_by_address[address_b]))
-    sched._ownership._due_at[address_b] = {request_b: loop.time()}
-    sched._ownership._owner_by_address[address_b] = foreign_source
+    sched._schedule._due_at[address_b] = {request_b: loop.time()}
+    sched._schedule._owner_by_address[address_b] = foreign_source
     try:
         scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
         register_cancel = manager.async_register_scanner(scanner)
@@ -5933,8 +5929,8 @@ async def test_ownership_index_clear_source_no_match() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        sched._ownership.clear_source(scanner.source)
-        assert sched._ownership._owner_by_address == {}
+        sched._schedule.clear_source(scanner.source)
+        assert sched._schedule._owner_by_address == {}
         assert worker._owned_due_at == {}
     finally:
         register_cancel()
@@ -5943,7 +5939,7 @@ async def test_ownership_index_clear_source_no_match() -> None:
 def test_ownership_index_clear_no_workers() -> None:
     """clear() over an index with no workers leaves state empty."""
     workers: dict[str, Any] = {}
-    idx = _OwnershipIndex(workers)
+    idx = _ScanSchedule(workers)
     idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
     idx.clear()
     assert idx._owner_by_address == {}
@@ -5962,7 +5958,7 @@ async def test_ownership_assign_records_non_auto_owner() -> None:
     register_cancel = manager.async_register_scanner(passive)
     try:
         _inject(passive, address)
-        assert sched._ownership._owner_by_address[address] == passive.source
+        assert sched._schedule._owner_by_address[address] == passive.source
         assert passive.source not in sched._workers
     finally:
         cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -5954,14 +5954,14 @@ async def test_ownership_assign_tolerates_missing_needs_or_worker() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        # No _needs entry for this address — attach path early-returns.
+        # No _needs entry for this address; attach path early-returns.
         sched._ownership.assign("AA:00:00:00:00:99", scanner.source)
         assert "AA:00:00:00:00:99" not in worker._owned_needs
         assert sched._ownership._owner_by_address["AA:00:00:00:00:99"] == (
             scanner.source
         )
-        # Worker not registered for this source — also a no-op on the
-        # attach side, but the owner mapping is still recorded.
+        # Worker not registered for this source; the owner mapping is
+        # still recorded even though no worker can attach.
         sched._needs["BB:00:00:00:00:99"] = {}
         sched._ownership.assign("BB:00:00:00:00:99", "ZZ:99:99:99:99:99")
         assert sched._ownership._owner_by_address["BB:00:00:00:00:99"] == (
@@ -5970,21 +5970,51 @@ async def test_ownership_assign_tolerates_missing_needs_or_worker() -> None:
         sched._needs.pop("BB:00:00:00:00:99", None)
         # Clean up the synthetic owner mappings so other tests do not
         # see foreign state.
-        sched._ownership.assign("AA:00:00:00:00:99", None)
-        sched._ownership.assign("BB:00:00:00:00:99", None)
+        sched._ownership.unown("AA:00:00:00:00:99")
+        sched._ownership.unown("BB:00:00:00:00:99")
     finally:
         register_cancel()
 
 
 @pytest.mark.asyncio
 async def test_ownership_assign_tolerates_missing_old_worker() -> None:
-    """Reassigning away from a source whose worker is gone must not raise."""
+    """assign() reassigning from an unregistered old source must not raise."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        address = "AA:00:00:00:00:99"
+        sched._needs[address] = {}
+        # Pre-seed an owner mapping pointing at an unregistered source
+        # so the detach branch hits the missing-worker path.
+        sched._ownership._owner_by_address[address] = "ZZ:99:99:99:99:99"
+        sched._ownership.assign(address, scanner.source)
+        assert sched._ownership._owner_by_address[address] == scanner.source
+        sched._needs.pop(address, None)
+        sched._ownership.unown(address)
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_ownership_unown_tolerates_missing_old_worker() -> None:
+    """unown() against a source whose worker is gone must not raise."""
     manager = get_manager()
     sched = manager._auto_scheduler
     # Forge an owner mapping for an unregistered source so the detach
     # branch hits a missing-worker path.
     sched._ownership._owner_by_address["AA:00:00:00:00:99"] = "ZZ:99:99:99:99:99"
-    sched._ownership.assign("AA:00:00:00:00:99", None)
+    sched._ownership.unown("AA:00:00:00:00:99")
+    assert "AA:00:00:00:00:99" not in sched._ownership._owner_by_address
+
+
+@pytest.mark.asyncio
+async def test_ownership_unown_unknown_address_noop() -> None:
+    """unown() on an address with no owner mapping is a no-op."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    sched._ownership.unown("AA:00:00:00:00:99")
     assert "AA:00:00:00:00:99" not in sched._ownership._owner_by_address
 
 
@@ -6068,7 +6098,12 @@ def test_ownership_index_hook_worker_skips_address_without_needs() -> None:
 
     class _StubWorker:
         def __init__(self) -> None:
-            self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
+            self.attached: list[tuple[str, dict[ActiveScanRequest, float]]] = []
+
+        def _attach_owned(
+            self, address: str, entries: dict[ActiveScanRequest, float]
+        ) -> None:
+            self.attached.append((address, entries))
 
     needs: dict[str, dict[ActiveScanRequest, float]] = {}
     worker = _StubWorker()
@@ -6077,7 +6112,7 @@ def test_ownership_index_hook_worker_skips_address_without_needs() -> None:
     # Owner mapping exists but the address has no needs entry yet.
     idx._owner_by_address["AA:00:00:00:00:99"] = "src"
     idx.hook_worker("src")
-    assert worker._owned_needs == {}
+    assert worker.attached == []
 
 
 def test_ownership_index_clear_source_no_match() -> None:
@@ -6085,7 +6120,10 @@ def test_ownership_index_clear_source_no_match() -> None:
 
     class _StubWorker:
         def __init__(self) -> None:
-            self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
+            self.cleared = 0
+
+        def _clear_owned(self) -> None:
+            self.cleared += 1
 
     needs: dict[str, dict[ActiveScanRequest, float]] = {}
     worker = _StubWorker()
@@ -6093,7 +6131,9 @@ def test_ownership_index_clear_source_no_match() -> None:
     idx = _OwnershipIndex(needs, workers)
     idx.clear_source("src")
     assert idx._owner_by_address == {}
-    assert worker._owned_needs == {}
+    # No addresses owned by ``src``, but the worker view is still
+    # cleared defensively in case prior drift left a stale entry.
+    assert worker.cleared == 1
 
 
 def test_ownership_index_clear_no_workers() -> None:

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6262,6 +6262,51 @@ async def test_invariant_through_many_addresses_and_scanners() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unown_fails_fast_on_missing_due_at() -> None:
+    """Pin the fail-fast contract: KeyError if ``_due_at`` lacks the address."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    sched._schedule._owner_by_address["AA:00:00:00:00:99"] = "ghost"
+    try:
+        with pytest.raises(KeyError):
+            sched._schedule.unown("AA:00:00:00:00:99")
+    finally:
+        sched._schedule._owner_by_address.pop("AA:00:00:00:00:99", None)
+
+
+@pytest.mark.asyncio
+async def test_unown_fails_fast_on_missing_owner() -> None:
+    """Pin the fail-fast contract: KeyError if ``_owner_by_address`` lacks address."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    sched._schedule._due_at["AA:00:00:00:00:99"] = {}
+    try:
+        with pytest.raises(KeyError):
+            sched._schedule.unown("AA:00:00:00:00:99")
+    finally:
+        sched._schedule._due_at.pop("AA:00:00:00:00:99", None)
+
+
+@pytest.mark.asyncio
+async def test_next_event_at_fails_fast_on_empty_owned_bucket() -> None:
+    """Pin the fail-fast contract: ValueError on an empty owned bucket."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        worker._owned_due_at["AA:00:00:00:00:99"] = {}
+        try:
+            with pytest.raises(ValueError, match="min"):
+                worker._next_event_at(asyncio.get_running_loop().time())
+        finally:
+            worker._owned_due_at.pop("AA:00:00:00:00:99", None)
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
 async def test_invariant_through_stop_and_restart() -> None:
     """Schedule invariant holds across stop + start replay."""
     manager = get_manager()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -117,11 +117,11 @@ async def test_advertisement_starts_tracking() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        assert "11:22:33:44:55:66" in sched._needs
+        assert "11:22:33:44:55:66" in sched._due_at
     finally:
         cancel()
         register_cancel()
-    assert sched._needs == {}
+    assert sched._due_at == {}
 
 
 @pytest.mark.asyncio
@@ -138,7 +138,7 @@ async def test_advertisement_for_unrelated_address_is_ignored() -> None:
         # The registered address has tracking from add_request; the
         # unrelated advertisement must not create its own entry.
         _inject(scanner, "AA:AA:AA:AA:AA:AA")
-        assert "AA:AA:AA:AA:AA:AA" not in sched._needs
+        assert "AA:AA:AA:AA:AA:AA" not in sched._due_at
     finally:
         cancel()
         register_cancel()
@@ -157,7 +157,7 @@ async def test_worker_tick_fires_active_window() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        entries = sched._needs["11:22:33:44:55:66"]
+        entries = sched._due_at["11:22:33:44:55:66"]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         await _run_worker_tick(sched, scanner.source)
@@ -190,7 +190,7 @@ async def test_worker_tick_advances_by_scan_interval_from_window_start() -> None
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         before_tick = loop.time()
@@ -227,8 +227,8 @@ async def test_worker_tick_coalesces_near_future_due_entries() -> None:
         # A is due now; B is due 10s from now (within the lookahead).
         # One tick should serve both.
         now = loop.time()
-        entries_a = sched._needs[addr_a]
-        entries_b = sched._needs[addr_b]
+        entries_a = sched._due_at[addr_a]
+        entries_b = sched._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -264,7 +264,7 @@ async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> No
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         # Set next_due 5s in the future — within the lookahead but
         # not immediately due.
         for req in entries:
@@ -296,8 +296,8 @@ async def test_worker_tick_coalesces_near_max_window_boundary() -> None:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
         now = loop.time()
-        entries_a = sched._needs[addr_a]
-        entries_b = sched._needs[addr_b]
+        entries_a = sched._due_at[addr_a]
+        entries_b = sched._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -336,8 +336,8 @@ async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
         fallback.add_discovered(addr_b, rssi=-70)
         owner._add_connecting(addr_a)
         now = loop.time()
-        entries_a = sched._needs[addr_a]
-        entries_b = sched._needs[addr_b]
+        entries_a = sched._due_at[addr_a]
+        entries_b = sched._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -380,7 +380,7 @@ async def test_worker_tick_sweep_alone_pulls_in_soon_due_entries() -> None:
         # Make the sweep due; per-device entry is soon-due but not
         # immediate.
         worker._sweep_last_completed = loop.time() - AUTO_REDISCOVERY_INTERVAL - 1.0
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         soon_due_at = loop.time() + 5.0
         for req in entries:
             entries[req] = soon_due_at
@@ -414,7 +414,7 @@ async def test_worker_tick_coalesces_overlapping_requests() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await _run_worker_tick(sched, scanner.source)
@@ -442,7 +442,7 @@ async def test_multiple_requests_same_address_track_independent_intervals() -> N
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         assert len(entries) == 2
         fast, slow = sorted(entries, key=lambda r: r.scan_interval)
         entries[fast] = loop.time() - 1.0
@@ -579,7 +579,7 @@ async def test_active_scan_registered_before_auto_scanner_wakes_on_register() ->
     _requests_by_address; no worker exists yet for the device).
     Later, an AUTO scanner is registered and starts seeing the device.
     The first advertisement on that scanner must wake its worker so
-    the entry in _needs is acted upon.
+    the entry in _due_at is acted upon.
     """
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -596,7 +596,7 @@ async def test_active_scan_registered_before_auto_scanner_wakes_on_register() ->
             _inject(scanner, address)
             assert worker._wake.is_set()
             # The address now has a tracked entry on this scanner.
-            assert address in sched._needs
+            assert address in sched._due_at
         finally:
             register_cancel()
     finally:
@@ -614,9 +614,9 @@ async def test_remove_request_clears_tracking() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._needs
+        assert address in sched._due_at
         cancel()
-        assert address not in sched._needs
+        assert address not in sched._due_at
         assert sched._requests_by_address == {}
     finally:
         register_cancel()
@@ -675,17 +675,17 @@ async def test_dispatch_drops_tracking_for_unseen_address() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        request = next(iter(sched._needs[address]))
-        sched._needs[address][request] = loop.time() - 1.0
+        request = next(iter(sched._due_at[address]))
+        sched._due_at[address][request] = loop.time() - 1.0
         # Simulate the manager's history aging out under the worker's
-        # feet — the orphan-prune branch should clean both _needs and
+        # feet — the orphan-prune branch should clean both _due_at and
         # _owner_by_address.
         manager._all_history.pop(address, None)
         manager._connectable_history.pop(address, None)
         await _run_worker_tick(sched, scanner.source)
-        assert address not in sched._needs
+        assert address not in sched._due_at
         assert address not in sched._ownership._owner_by_address
-        assert address not in sched._workers[scanner.source]._owned_needs
+        assert address not in sched._workers[scanner.source]._owned_due_at
     finally:
         cancel()
         register_cancel()
@@ -769,9 +769,9 @@ async def test_remove_scanner_stops_its_worker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_scanner_prunes_owned_needs_entries() -> None:
+async def test_remove_scanner_prunes_owned_due_at_entries() -> None:
     """
-    _needs entries owned by the leaving scanner are pruned at remove.
+    _due_at entries owned by the leaving scanner are pruned at remove.
 
     Without the prune, those entries would sit pinned until the
     device either turns up on another scanner (history flips) or
@@ -794,14 +794,14 @@ async def test_remove_scanner_prunes_owned_needs_entries() -> None:
     try:
         _inject(s_a, address_owned)
         _inject(s_b, address_foreign)
-        assert address_owned in sched._needs
-        assert address_foreign in sched._needs
+        assert address_owned in sched._due_at
+        assert address_foreign in sched._due_at
         # Remove s_a. The owned entry must be pruned; the foreign one
         # (owned by s_b) must remain.
         c_a()
         await asyncio.sleep(0)
-        assert address_owned not in sched._needs
-        assert address_foreign in sched._needs
+        assert address_owned not in sched._due_at
+        assert address_foreign in sched._due_at
     finally:
         cancel_owned()
         cancel_foreign()
@@ -842,9 +842,9 @@ async def test_stop_is_safe_when_already_idle() -> None:
 @pytest.mark.asyncio
 async def test_stop_clears_loop_so_post_stop_add_request_is_record_only() -> None:
     """
-    After stop(), add_request and on_advertisement skip _needs.
+    After stop(), add_request and on_advertisement skip _due_at.
 
-    Without nulling _loop, post-stop add_request would seed _needs
+    Without nulling _loop, post-stop add_request would seed _due_at
     with timestamps from the cancelled loop and try to wake a worker
     that no longer exists. on_advertisement is similar. Both must
     fall back to the record-only / no-op path once stop() runs.
@@ -859,14 +859,14 @@ async def test_stop_clears_loop_so_post_stop_add_request_is_record_only() -> Non
         sched.stop()
         assert sched._loop is None
         # add_request after stop: still tracked in _requests_by_address
-        # but no _needs seed (loop is None).
+        # but no _due_at seed (loop is None).
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             assert address in sched._requests_by_address
-            assert address not in sched._needs
-            # on_advertisement after stop is a no-op on _needs too.
+            assert address not in sched._due_at
+            # on_advertisement after stop is a no-op on _due_at too.
             _inject(scanner, address)
-            assert address not in sched._needs
+            assert address not in sched._due_at
         finally:
             cancel()
     finally:
@@ -904,7 +904,7 @@ async def test_on_advertisement_early_returns_with_no_requests() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        assert sched._needs == {}
+        assert sched._due_at == {}
         assert sched._requests_by_address == {}
     finally:
         register_cancel()
@@ -922,12 +922,12 @@ async def test_on_advertisement_re_bootstraps_pruned_tracking() -> None:
     try:
         worker = sched._workers[scanner.source]
         # No advertisement has been seen yet, so add_request skipped
-        # the _needs seed (the prune-on-no-history path). Simulate the
+        # the _due_at seed (the prune-on-no-history path). Simulate the
         # "pruned" state by ensuring it's not there.
-        sched._needs.pop(address, None)
+        sched._due_at.pop(address, None)
         worker._wake.clear()
         _inject(scanner, address)
-        assert address in sched._needs
+        assert address in sched._due_at
         assert worker._wake.is_set()
     finally:
         cancel()
@@ -1030,7 +1030,7 @@ async def test_register_active_scan_normalizes_address_case() -> None:
 @pytest.mark.asyncio
 async def test_add_request_without_history_skips_seed() -> None:
     """
-    add_request skips _needs when no last_service_info exists yet.
+    add_request skips _due_at when no last_service_info exists yet.
 
     on_advertisement bootstraps tracking instead. The previous
     behavior seeded unconditionally and let the next worker tick
@@ -1045,8 +1045,8 @@ async def test_add_request_without_history_skips_seed() -> None:
     try:
         # Sanity: history doesn't exist for this address yet.
         assert manager.async_last_service_info(address, False) is None
-        # _needs was not seeded -> no entry to prune later.
-        assert address not in sched._needs
+        # _due_at was not seeded -> no entry to prune later.
+        assert address not in sched._due_at
         # But the request IS recorded for on_advertisement to pick up.
         assert address in sched._requests_by_address
         # First advertisement bootstraps tracking and wakes the
@@ -1054,7 +1054,7 @@ async def test_add_request_without_history_skips_seed() -> None:
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         _inject(scanner, address)
-        assert address in sched._needs
+        assert address in sched._due_at
         assert worker._wake.is_set()
     finally:
         cancel()
@@ -1179,10 +1179,10 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
     HA's UI mode-switch path reloads the config entry: the old
     scanner is unregistered, a new one with the same source is
     registered with the new mode. The scheduler must (1) prune
-    _needs entries the leaving scanner owned via remove_scanner,
+    _due_at entries the leaving scanner owned via remove_scanner,
     (2) keep user-registered ActiveScanRequests in
     _requests_by_address, (3) spawn a fresh worker for a new AUTO
-    scanner via add_scanner, and (4) bootstrap _needs on the first
+    scanner via add_scanner, and (4) bootstrap _due_at on the first
     advertisement from the new scanner.
     """
     manager = get_manager()
@@ -1199,12 +1199,12 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
     auto_cancel = manager.async_register_scanner(auto_scanner)
     try:
         _inject(auto_scanner, address)
-        assert address in sched._needs
+        assert address in sched._due_at
         assert auto_scanner.source in sched._workers
         # Mode switch in UI -> unregister AUTO scanner.
         auto_cancel()
         assert auto_scanner.source not in sched._workers
-        assert address not in sched._needs
+        assert address not in sched._due_at
         # User's registration is preserved across the switch.
         assert address in sched._requests_by_address
         # Re-register with the SAME source but PASSIVE mode.
@@ -1215,8 +1215,8 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
         try:
             # PASSIVE doesn't get a worker.
             assert passive_scanner.source not in sched._workers
-            # Still no _needs entry (no AUTO scanner owns it).
-            assert address not in sched._needs
+            # Still no _due_at entry (no AUTO scanner owns it).
+            assert address not in sched._due_at
             passive_cancel()
             # Now switch BACK to AUTO with the same source.
             new_auto = _RecordingAutoScanner(
@@ -1228,7 +1228,7 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
                 # First advertisement on the new AUTO scanner bootstraps
                 # tracking again from the still-registered request.
                 _inject(new_auto, address)
-                assert address in sched._needs
+                assert address in sched._due_at
             finally:
                 new_auto_cancel()
         except BaseException:
@@ -1239,9 +1239,9 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
 
 
 @pytest.mark.asyncio
-async def test_start_replays_pre_start_requests_into_needs() -> None:
+async def test_start_replays_pre_start_requests_into_due_at() -> None:
     """
-    add_request before start() seeds _needs at start() if history exists.
+    add_request before start() seeds _due_at at start() if history exists.
 
     Also covers the no-history skip path and the
     already-in-existing-entries no-op so the replay loop's branches
@@ -1262,7 +1262,7 @@ async def test_start_replays_pre_start_requests_into_needs() -> None:
         sched._running = False
         try:
             # Register TWO requests on the with-history address so
-            # we can pre-populate _needs with one of them and prove
+            # we can pre-populate _due_at with one of them and prove
             # start() (a) leaves the pre-existing entry alone and
             # (b) inserts a fresh entry for the other.
             cancel_with_a = manager.async_register_active_scan(
@@ -1275,20 +1275,20 @@ async def test_start_replays_pre_start_requests_into_needs() -> None:
                 address_no_history, scan_interval=60.0, scan_duration=5.0
             )
             try:
-                assert address_with_history not in sched._needs
+                assert address_with_history not in sched._due_at
                 requests = list(sched._requests_by_address[address_with_history])
                 pre_existing, to_be_inserted = requests
-                # Pre-populate _needs with one request only. The
+                # Pre-populate _due_at with one request only. The
                 # sentinel is well above loop.time() + scan_interval
                 # so the test is robust against the loop being
                 # freshly-started (CI) or long-lived; we don't care
                 # about the absolute value, only that start() leaves
                 # it alone.
                 sentinel = saved_loop.time() + 1.0e9
-                sched._needs[address_with_history] = {pre_existing: sentinel}
+                sched._due_at[address_with_history] = {pre_existing: sentinel}
                 before_start = saved_loop.time()
                 sched.start(saved_loop)
-                seeded = sched._needs[address_with_history]
+                seeded = sched._due_at[address_with_history]
                 # The pre-existing entry was left alone (covers the
                 # `request not in existing` False branch).
                 assert seeded[pre_existing] == sentinel
@@ -1300,7 +1300,7 @@ async def test_start_replays_pre_start_requests_into_needs() -> None:
                 )
                 # No-history address: skipped by the
                 # `last_service_info(...) is None` branch.
-                assert address_no_history not in sched._needs
+                assert address_no_history not in sched._due_at
             finally:
                 cancel_with_a()
                 cancel_with_b()
@@ -1355,14 +1355,14 @@ async def test_dispatch_does_not_resurrect_cancelled_request() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
         await gate.wait()
         # remove_request emptied the bucket; the tick must not have
         # re-added the cancelled request.
-        assert address not in sched._needs
+        assert address not in sched._due_at
     finally:
         register_cancel()
 
@@ -1381,7 +1381,7 @@ async def test_dispatch_skips_address_owned_by_other_scanner() -> None:
     c2 = manager.async_register_scanner(other)
     try:
         _inject(owner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         # The "other" scanner runs its tick. The address is owned by
@@ -1425,7 +1425,7 @@ async def test_next_event_at_returns_earliest_per_device_need() -> None:
         worker = sched._workers[scanner.source]
         # Sweep is far in the future (initial delay window). The earliest
         # event for the worker is the per-device next-due.
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         request = next(iter(entries))
         per_device_at = loop.time() + 5.0
         entries[request] = per_device_at
@@ -1446,19 +1446,19 @@ async def test_next_event_at_ignores_empty_or_foreign_entries() -> None:
     try:
         worker = sched._workers[scanner.source]
         # Empty entries: hits the "if not entries: continue" branch.
-        sched._needs["AA:BB:CC:DD:EE:01"] = {}
+        sched._due_at["AA:BB:CC:DD:EE:01"] = {}
         # No history at all: hits "if history is None or history.source != source".
         cancel = manager.async_register_active_scan(
             "AA:BB:CC:DD:EE:02", scan_interval=60.0
         )
         request = next(iter(sched._requests_by_address["AA:BB:CC:DD:EE:02"]))
-        sched._needs["AA:BB:CC:DD:EE:02"] = {request: loop.time() - 1.0}
+        sched._due_at["AA:BB:CC:DD:EE:02"] = {request: loop.time() - 1.0}
         next_at = worker._next_event_at(loop.time())
         # With no contributing per-device entries the next event reverts
         # to the sweep cadence (well into the future via initial delay).
         assert next_at == worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
         cancel()
-        del sched._needs["AA:BB:CC:DD:EE:01"]
+        del sched._due_at["AA:BB:CC:DD:EE:01"]
     finally:
         register_cancel()
 
@@ -1471,10 +1471,10 @@ async def test_dispatch_per_device_skips_empty_entries() -> None:
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
-        sched._needs["AA:BB:CC:DD:EE:FF"] = {}
+        sched._due_at["AA:BB:CC:DD:EE:FF"] = {}
         await sched._workers[scanner.source]._tick()
         assert scanner.active_window_calls == []
-        del sched._needs["AA:BB:CC:DD:EE:FF"]
+        del sched._due_at["AA:BB:CC:DD:EE:FF"]
     finally:
         register_cancel()
 
@@ -1492,7 +1492,7 @@ async def test_dispatch_per_device_skips_not_yet_due() -> None:
     try:
         _inject(scanner, address)
         # Push the due time far in the future.
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for request in list(entries):
             entries[request] = loop.time() + 1000.0
         await sched._workers[scanner.source]._tick()
@@ -1642,7 +1642,7 @@ async def test_remove_request_handles_missing_bucket() -> None:
     # Bucket was never added; remove_request must be a no-op.
     sched.remove_request(request)
     assert "AA:BB:CC:DD:EE:99" not in sched._requests_by_address
-    assert "AA:BB:CC:DD:EE:99" not in sched._needs
+    assert "AA:BB:CC:DD:EE:99" not in sched._due_at
 
 
 @pytest.mark.asyncio
@@ -1657,7 +1657,7 @@ async def test_on_advertisement_no_match_no_wake() -> None:
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         _inject(scanner, "AA:AA:AA:AA:AA:AA")
-        assert "AA:AA:AA:AA:AA:AA" not in sched._needs
+        assert "AA:AA:AA:AA:AA:AA" not in sched._due_at
         assert not worker._wake.is_set()
     finally:
         cancel()
@@ -1698,7 +1698,7 @@ async def test_on_advertisement_wakes_on_every_ad_for_tracked_address() -> None:
 
 @pytest.mark.asyncio
 async def test_on_advertisement_with_all_requests_already_tracked() -> None:
-    """on_advertisement still wakes when every request is already in _needs."""
+    """on_advertisement still wakes when every request is already in _due_at."""
     manager = get_manager()
     sched = manager._auto_scheduler
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
@@ -1707,7 +1707,7 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
     req_a = ActiveScanRequest(address, 60.0, 10.0)
     req_b = ActiveScanRequest(address, 120.0, 10.0)
     sched._requests_by_address[address] = {req_a, req_b}
-    sched._needs[address] = {req_a: 0.0, req_b: 0.0}
+    sched._due_at[address] = {req_a: 0.0, req_b: 0.0}
     try:
         si = BluetoothServiceInfoBleak(
             name="x",
@@ -1728,13 +1728,13 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
         worker._wake.clear()
         sched.on_advertisement(si)
         # Wake fires unconditionally so ownership-flip detection still
-        # triggers when every request was already in _needs.
+        # triggers when every request was already in _due_at.
         assert worker._wake.is_set()
         # Sanity: the entries we put in are untouched.
-        assert sched._needs[address] == {req_a: 0.0, req_b: 0.0}
+        assert sched._due_at[address] == {req_a: 0.0, req_b: 0.0}
     finally:
         sched._requests_by_address.pop(address, None)
-        sched._needs.pop(address, None)
+        sched._due_at.pop(address, None)
         register_cancel()
 
 
@@ -1777,8 +1777,8 @@ async def test_next_event_at_skips_per_device_later_than_sweep() -> None:
         sweep_at = worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
         # Push per-device need past the sweep cadence so the earliest <
         # next_at branch is False inside _next_event_at.
-        for req in list(sched._needs[address]):
-            sched._needs[address][req] = sweep_at + 100.0
+        for req in list(sched._due_at[address]):
+            sched._due_at[address][req] = sweep_at + 100.0
         assert worker._next_event_at(loop.time()) == sweep_at
     finally:
         cancel()
@@ -1834,7 +1834,7 @@ async def test_coalesce_three_due_uses_max_clamped() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1860,7 +1860,7 @@ async def test_coalesce_clamps_oversize_request() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1887,7 +1887,7 @@ async def test_coalesce_only_due_requests_count() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         short_req = next(r for r in entries if r.scan_duration == 5.0)
         long_req = next(r for r in entries if r.scan_duration == 20.0)
         # Only the short request is due; the long one is well in the
@@ -1922,7 +1922,7 @@ async def test_coalesce_distinct_addresses_share_one_window() -> None:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
         for address in (addr_a, addr_b):
-            entries = sched._needs[address]
+            entries = sched._due_at[address]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1949,7 +1949,7 @@ async def test_tick_combines_due_sweep_and_per_device_into_one_window() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         worker = sched._workers[scanner.source]
@@ -1990,7 +1990,7 @@ async def test_three_inkbirds_share_one_scan() -> None:
     try:
         for addr in addresses:
             _inject(scanner, addr)
-            entries = sched._needs[addr]
+            entries = sched._due_at[addr]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1998,7 +1998,7 @@ async def test_three_inkbirds_share_one_scan() -> None:
         assert scanner.active_window_calls == [15.0]
         # Next-due moved forward by scan_interval for every request.
         for addr in addresses:
-            for due in sched._needs[addr].values():
+            for due in sched._due_at[addr].values():
                 assert due > loop.time() + 250.0
     finally:
         for cancel in cancels:
@@ -2025,7 +2025,7 @@ async def test_dispatch_coalesces_different_durations_to_max() -> None:
     try:
         for addr in (addr_short, addr_long):
             _inject(scanner, addr)
-            entries = sched._needs[addr]
+            entries = sched._due_at[addr]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -2061,7 +2061,7 @@ async def test_three_inkbirds_same_address_coalesce_to_one_scan() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         assert len(entries) == 3
         for req in list(entries):
             entries[req] = loop.time() - 1.0
@@ -2101,13 +2101,13 @@ async def test_three_inkbirds_window_unchanged_after_removal() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         assert len(entries) == 3
         # Cancel one of the three; two should remain in both the registry
-        # and the _needs tracker.
+        # and the _due_at tracker.
         cancels.pop()()
         assert len(sched._requests_by_address[address]) == 2
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         assert len(entries) == 2
         for req in list(entries):
             entries[req] = loop.time() - 1.0
@@ -2146,7 +2146,7 @@ async def test_only_owning_scanner_fires_among_four() -> None:
     try:
         owner = scanners[2]
         _inject(owner, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         for scanner in scanners:
@@ -2160,7 +2160,7 @@ async def test_only_owning_scanner_fires_among_four() -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_request_before_start_does_not_seed_needs() -> None:
+async def test_add_request_before_start_does_not_seed_due_at() -> None:
     """If add_request runs before start() the entry is deferred to advertisement."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -2170,7 +2170,7 @@ async def test_add_request_before_start_does_not_seed_needs() -> None:
     try:
         sched.add_request(ActiveScanRequest(address, 60.0, 10.0))
         assert address in sched._requests_by_address
-        assert address not in sched._needs
+        assert address not in sched._due_at
     finally:
         sched._loop = original_loop
         sched._requests_by_address.pop(address, None)
@@ -2195,11 +2195,11 @@ async def test_add_request_idempotent_keeps_existing_due() -> None:
         sched.add_request(request)
         # Inject so add_request can see history on the second call.
         _inject(scanner, address)
-        sched._needs[address][request] = 1234.5
+        sched._due_at[address][request] = 1234.5
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         sched.add_request(request)
-        assert sched._needs[address][request] == 1234.5
+        assert sched._due_at[address][request] == 1234.5
         # No new entry → no wake.
         assert not worker._wake.is_set()
         sched.remove_request(request)
@@ -2259,7 +2259,7 @@ async def test_owner_flip_during_window_does_not_double_fire() -> None:
     c_b = manager.async_register_scanner(s_b)
     try:
         _inject(s_a, address)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
 
@@ -2337,7 +2337,7 @@ async def test_device_migration_between_scanners_fires_on_new_owner() -> None:
 
         # Make the existing tracking entry due and fire the first
         # window on A.
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[s_a.source]._tick()
@@ -2376,7 +2376,7 @@ async def test_device_migration_wakes_new_owner_worker() -> None:
     sit until its previously-computed _next_event_at (sweep cadence)
     even though there's a tracked address whose due time is much
     sooner. The wake is on_advertisement's job and must fire even when
-    the _needs entry already exists (i.e. the ad doesn't add a new
+    the _due_at entry already exists (i.e. the ad doesn't add a new
     request, it just notifies us this scanner now sees the device).
     """
     manager = get_manager()
@@ -2404,9 +2404,9 @@ async def test_device_migration_wakes_new_owner_worker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stop_clears_needs_so_restart_does_not_reuse_stale_due_times() -> None:
+async def test_stop_clears_due_at_so_restart_does_not_reuse_stale_due_times() -> None:
     """
-    stop() drops _needs so a later start(new_loop) seeds fresh due-times.
+    stop() drops _due_at so a later start(new_loop) seeds fresh due-times.
 
     Without this, a restart against a different event loop (whose
     ``time()`` origin differs) would reuse timestamps from the
@@ -2422,12 +2422,12 @@ async def test_stop_clears_needs_so_restart_does_not_reuse_stale_due_times() -> 
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._needs
+        assert address in sched._due_at
         original_loop = sched._loop
         sched.stop()
-        # _needs cleared so stale timestamps from the now-defunct loop
+        # _due_at cleared so stale timestamps from the now-defunct loop
         # can't survive into a re-start.
-        assert sched._needs == {}
+        assert sched._due_at == {}
         assert sched._loop is None
         assert sched._workers == {}
         # _requests_by_address is loop-independent and must persist so
@@ -2437,8 +2437,8 @@ async def test_stop_clears_needs_so_restart_does_not_reuse_stale_due_times() -> 
         # a fresh due time from the new loop.time() base.
         assert original_loop is not None
         sched.start(original_loop)
-        assert address in sched._needs
-        entries = sched._needs[address]
+        assert address in sched._due_at
+        entries = sched._due_at[address]
         expected_due = original_loop.time() + 60.0
         assert all(abs(due - expected_due) < 0.5 for due in entries.values())
     finally:
@@ -2474,7 +2474,7 @@ class _DiscoverableAutoScanner(_RecordingAutoScanner):
 
 def _make_due(sched: object, address: str) -> None:
     """Make every tracked request for ``address`` due immediately."""
-    entries = sched._needs[address]  # type: ignore[attr-defined]
+    entries = sched._due_at[address]  # type: ignore[attr-defined]
     loop = asyncio.get_running_loop()
     for req in list(entries):
         entries[req] = loop.time() - 1.0
@@ -3177,7 +3177,7 @@ async def test_worker_tick_two_different_fallbacks_both_dispatched() -> None:
 @pytest.mark.asyncio
 async def test_worker_tick_advance_pre_dispatch_blocks_double_fire() -> None:
     """
-    Per-address ``_needs`` entries are advanced before the dispatch.
+    Per-address ``_due_at`` entries are advanced before the dispatch.
 
     The pre-dispatch advance protects against an in-flight ownership
     flip causing a duplicate window on a different worker (same
@@ -3201,7 +3201,7 @@ async def test_worker_tick_advance_pre_dispatch_blocks_double_fire() -> None:
         _make_due(sched, address)
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for due in entries.values():
             # Advanced to roughly before + 90s, NOT before - 1.0.
             assert due == pytest.approx(before + 90.0, abs=0.5)
@@ -3599,7 +3599,7 @@ async def test_worker_tick_connect_finish_during_dispatch_keeps_dispatch() -> No
     Race: owner finishes connecting WHILE the fallback dispatch is awaiting.
 
     The connecting state was True at tick start, so we entered the
-    fallback branch and already advanced ``_needs``. The connect
+    fallback branch and already advanced ``_due_at``. The connect
     completing mid-await must not cancel the in-flight fallback call
     nor cause a duplicate window on the owner.
     """
@@ -3700,7 +3700,7 @@ async def test_worker_tick_ownership_flip_during_dispatch_no_double_fire() -> No
     Race: ownership flips from owner to fallback during the dispatch.
 
     Same protection as the non-connecting migration test: the
-    pre-await ``_advance_due`` updates ``_needs`` to ``now +
+    pre-await ``_advance_due`` updates ``_due_at`` to ``now +
     scan_interval`` before the fallback await, so if RSSI causes
     ownership to shift to the fallback mid-dispatch, the fallback's
     own next tick sees a future due time and skips — no duplicate
@@ -3728,7 +3728,7 @@ async def test_worker_tick_ownership_flip_during_dispatch_no_double_fire() -> No
         await asyncio.sleep(0)
         # Confirm fallback call is in flight and entries advanced.
         assert fb.active_window_calls == [6.0]
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for due in entries.values():
             assert due == pytest.approx(before + 90.0, abs=0.5)
         # Ownership flips to fb mid-dispatch (much stronger RSSI).
@@ -4050,7 +4050,7 @@ async def test_worker_tick_three_addresses_no_fallback_advance_by_defer() -> Non
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
         for addr in (addr_a, addr_b, addr_c):
-            entries = sched._needs[addr]
+            entries = sched._due_at[addr]
             for due in entries.values():
                 assert due == pytest.approx(before + 30.0, abs=0.5)
                 assert due < before + 60.0
@@ -4183,11 +4183,11 @@ async def test_worker_tick_three_addresses_mixed_outcomes_advance_correctly() ->
         owner._add_connecting(addr_covered)
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
-        for due in sched._needs[addr_covered].values():
+        for due in sched._due_at[addr_covered].values():
             assert due == pytest.approx(before + 120.0, abs=0.5)
-        for due in sched._needs[addr_flipped].values():
+        for due in sched._due_at[addr_flipped].values():
             assert due == pytest.approx(before + 240.0, abs=0.5)
-        for due in sched._needs[addr_orphan].values():
+        for due in sched._due_at[addr_orphan].values():
             assert due == pytest.approx(before + 30.0, abs=0.5)
         assert fb.active_window_calls == [9.0]
         assert active.active_window_calls == []
@@ -4320,7 +4320,7 @@ async def test_worker_tick_failed_fallback_advances_entries_by_full_interval() -
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
         # Entries advanced by full scan_interval, NOT retry_at.
-        for due in sched._needs[address].values():
+        for due in sched._due_at[address].values():
             assert due == pytest.approx(before + 120.0, abs=0.5)
             assert due > before + 60.0  # well past the 30s retry_at
         # fb_worker bumps from note_window_dispatched are preserved.
@@ -5548,8 +5548,8 @@ async def test_orphan_leader_does_not_clobber_fresh_sweep_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_owned_needs_populated_for_owner_on_add_request_with_history() -> None:
-    """add_request hooks the entry into the owner's _owned_needs view."""
+async def test_owned_due_at_populated_for_owner_on_add_request_with_history() -> None:
+    """add_request hooks the entry into the owner's _owned_due_at view."""
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:55:66"
@@ -5561,17 +5561,17 @@ async def test_owned_needs_populated_for_owner_on_add_request_with_history() -> 
         _inject(scanner, address)
         # Drop the entry add_request seeded so we can re-add through
         # add_request and observe its _ownership.assign side-effect.
-        sched._needs.pop(address, None)
+        sched._due_at.pop(address, None)
         sched._ownership._owner_by_address.pop(address, None)
-        sched._workers[scanner.source]._owned_needs.pop(address, None)
+        sched._workers[scanner.source]._owned_due_at.pop(address, None)
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
-            owned = sched._workers[scanner.source]._owned_needs
+            owned = sched._workers[scanner.source]._owned_due_at
             assert address in owned
             # Inner dict must be the SAME object aliased between
-            # _needs and _owned_needs so _advance_due mutations apply
+            # _due_at and _owned_due_at so _advance_due mutations apply
             # to both views.
-            assert owned[address] is sched._needs[address]
+            assert owned[address] is sched._due_at[address]
             assert sched._ownership._owner_by_address[address] == scanner.source
         finally:
             cancel()
@@ -5580,7 +5580,7 @@ async def test_owned_needs_populated_for_owner_on_add_request_with_history() -> 
 
 
 @pytest.mark.asyncio
-async def test_add_request_without_history_leaves_owned_needs_empty() -> None:
+async def test_add_request_without_history_leaves_owned_due_at_empty() -> None:
     """add_request without history defers seeding to on_advertisement."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -5590,9 +5590,9 @@ async def test_add_request_without_history_leaves_owned_needs_empty() -> None:
     try:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
-            assert address not in sched._needs
+            assert address not in sched._due_at
             assert address not in sched._ownership._owner_by_address
-            assert address not in sched._workers[scanner.source]._owned_needs
+            assert address not in sched._workers[scanner.source]._owned_due_at
         finally:
             cancel()
     finally:
@@ -5600,7 +5600,7 @@ async def test_add_request_without_history_leaves_owned_needs_empty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_advertisement_bootstraps_owned_needs() -> None:
+async def test_on_advertisement_bootstraps_owned_due_at() -> None:
     """First advertisement for a tracked address populates owner's view."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -5611,9 +5611,9 @@ async def test_on_advertisement_bootstraps_owned_needs() -> None:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             _inject(scanner, address)
-            owned = sched._workers[scanner.source]._owned_needs
+            owned = sched._workers[scanner.source]._owned_due_at
             assert address in owned
-            assert owned[address] is sched._needs[address]
+            assert owned[address] is sched._due_at[address]
             assert sched._ownership._owner_by_address[address] == scanner.source
         finally:
             cancel()
@@ -5622,7 +5622,7 @@ async def test_on_advertisement_bootstraps_owned_needs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ownership_flip_moves_entry_between_owned_needs() -> None:
+async def test_ownership_flip_moves_entry_between_owned_due_at() -> None:
     """On migration, the entry moves from old owner's view to new owner's view."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -5636,16 +5636,16 @@ async def test_ownership_flip_moves_entry_between_owned_needs() -> None:
         _inject_with_rssi(s_a, address, rssi=-80)
         worker_a = sched._workers[s_a.source]
         worker_b = sched._workers[s_b.source]
-        assert address in worker_a._owned_needs
-        assert address not in worker_b._owned_needs
+        assert address in worker_a._owned_due_at
+        assert address not in worker_b._owned_due_at
         assert sched._ownership._owner_by_address[address] == s_a.source
 
         # B with much stronger RSSI triggers ownership flip in the
         # manager; scheduler's on_advertisement reassigns owner.
         _inject_with_rssi(s_b, address, rssi=-30)
-        assert address not in worker_a._owned_needs
-        assert address in worker_b._owned_needs
-        assert worker_b._owned_needs[address] is sched._needs[address]
+        assert address not in worker_a._owned_due_at
+        assert address in worker_b._owned_due_at
+        assert worker_b._owned_due_at[address] is sched._due_at[address]
         assert sched._ownership._owner_by_address[address] == s_b.source
     finally:
         c_a()
@@ -5655,7 +5655,7 @@ async def test_ownership_flip_moves_entry_between_owned_needs() -> None:
 
 @pytest.mark.asyncio
 async def test_remove_request_clears_owner_when_bucket_empties() -> None:
-    """The last remove_request for an address clears owner and _owned_needs."""
+    """The last remove_request for an address clears owner and _owned_due_at."""
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:55:66"
@@ -5665,11 +5665,11 @@ async def test_remove_request_clears_owner_when_bucket_empties() -> None:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        assert address in worker._owned_needs
+        assert address in worker._owned_due_at
         cancel()
-        assert address not in sched._needs
+        assert address not in sched._due_at
         assert address not in sched._ownership._owner_by_address
-        assert address not in worker._owned_needs
+        assert address not in worker._owned_due_at
     finally:
         register_cancel()
 
@@ -5687,22 +5687,22 @@ async def test_remove_request_preserves_owner_when_other_requests_remain() -> No
         cancel2 = manager.async_register_active_scan(address, scan_interval=120.0)
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        assert len(sched._needs[address]) == 2
+        assert len(sched._due_at[address]) == 2
         cancel1()
-        assert address in sched._needs
+        assert address in sched._due_at
         assert sched._ownership._owner_by_address[address] == scanner.source
-        assert address in worker._owned_needs
+        assert address in worker._owned_due_at
         cancel2()
-        assert address not in sched._needs
+        assert address not in sched._due_at
         assert address not in sched._ownership._owner_by_address
-        assert address not in worker._owned_needs
+        assert address not in worker._owned_due_at
     finally:
         register_cancel()
 
 
 @pytest.mark.asyncio
-async def test_remove_scanner_clears_owner_and_needs() -> None:
-    """Removing the owning scanner drops the entry from _needs and the owner index."""
+async def test_remove_scanner_clears_owner_and_due_at() -> None:
+    """Removing the owning scanner drops the entry from _due_at and the owner index."""
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:55:66"
@@ -5711,10 +5711,10 @@ async def test_remove_scanner_clears_owner_and_needs() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._needs
+        assert address in sched._due_at
         assert sched._ownership._owner_by_address[address] == scanner.source
         register_cancel()
-        assert address not in sched._needs
+        assert address not in sched._due_at
         assert address not in sched._ownership._owner_by_address
         assert scanner.source not in sched._workers
     finally:
@@ -5722,8 +5722,8 @@ async def test_remove_scanner_clears_owner_and_needs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stop_clears_all_owned_needs_state() -> None:
-    """stop() drains _needs, _owner_by_address, and per-worker _owned_needs."""
+async def test_stop_clears_all_owned_due_at_state() -> None:
+    """stop() drains _due_at, _owner_by_address, and per-worker _owned_due_at."""
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:55:66"
@@ -5733,14 +5733,14 @@ async def test_stop_clears_all_owned_needs_state() -> None:
     try:
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        assert address in worker._owned_needs
+        assert address in worker._owned_due_at
         sched.stop()
-        assert sched._needs == {}
+        assert sched._due_at == {}
         assert sched._ownership._owner_by_address == {}
         # Worker dropped from registry; the cleared dict is on the
         # detached instance still held by the local. Confirm both.
         assert sched._workers == {}
-        assert worker._owned_needs == {}
+        assert worker._owned_due_at == {}
     finally:
         cancel()
         # register_cancel() may double-call but is idempotent on the
@@ -5750,7 +5750,7 @@ async def test_stop_clears_all_owned_needs_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_replay_populates_owned_needs() -> None:
+async def test_start_replay_populates_owned_due_at() -> None:
     """A request registered before start() is hooked into the worker's view on start."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -5770,17 +5770,17 @@ async def test_start_replay_populates_owned_needs() -> None:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             # Pre-start: only _requests_by_address is populated.
-            assert address not in sched._needs
+            assert address not in sched._due_at
             assert address not in sched._ownership._owner_by_address
             sched.start(loop)
             try:
-                # After start, the replay seeded _needs and assigned
+                # After start, the replay seeded _due_at and assigned
                 # the owner.
                 worker = sched._workers[scanner.source]
-                assert address in sched._needs
+                assert address in sched._due_at
                 assert sched._ownership._owner_by_address[address] == scanner.source
-                assert address in worker._owned_needs
-                assert worker._owned_needs[address] is sched._needs[address]
+                assert address in worker._owned_due_at
+                assert worker._owned_due_at[address] is sched._due_at[address]
             finally:
                 # Stop the spawned worker tasks so they do not leak.
                 for w in list(sched._workers.values()):
@@ -5806,15 +5806,15 @@ async def test_spawn_worker_picks_up_preassigned_owner() -> None:
     # registers as AUTO. We bypass the manager here because plumbing a
     # synthetic history entry is more wiring than the invariant needs.
     request = next(iter(sched._requests_by_address[address]))
-    sched._needs[address] = {request: loop.time()}
+    sched._due_at[address] = {request: loop.time()}
     sched._ownership._owner_by_address[address] = source
     try:
         scanner = _RecordingAutoScanner(source, BluetoothScanningMode.AUTO)
         register_cancel = manager.async_register_scanner(scanner)
         try:
             worker = sched._workers[source]
-            assert address in worker._owned_needs
-            assert worker._owned_needs[address] is sched._needs[address]
+            assert address in worker._owned_due_at
+            assert worker._owned_due_at[address] is sched._due_at[address]
         finally:
             register_cancel()
     finally:
@@ -5837,7 +5837,7 @@ async def test_next_event_at_skips_other_workers_entries() -> None:
         _inject(s_a, address)
         # Drive the entry's due time well below A's sweep so any leak
         # of foreign entries would change B's next_at.
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() + 1.0
         worker_b = sched._workers[s_b.source]
@@ -5896,14 +5896,14 @@ async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
         info = manager.async_last_service_info(address, False)
         assert info is not None
         info.source = s_b.source
-        entries = sched._needs[address]
+        entries = sched._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await worker_a._tick()
         # A skipped (foreign), reassigned ownership to B.
         assert s_a.active_window_calls == []
-        assert address not in worker_a._owned_needs
-        assert address in worker_b._owned_needs
+        assert address not in worker_a._owned_due_at
+        assert address in worker_b._owned_due_at
         assert sched._ownership._owner_by_address[address] == s_b.source
     finally:
         c_a()
@@ -5923,21 +5923,21 @@ async def test_assign_owner_noop_when_source_unchanged() -> None:
     try:
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        entries = sched._needs[address]
-        owned_before = worker._owned_needs[address]
+        entries = sched._due_at[address]
+        owned_before = worker._owned_due_at[address]
         # Second injection from the same scanner: owner unchanged,
         # owned-view aliasing preserved (same dict object).
         _inject(scanner, address)
         assert sched._ownership._owner_by_address[address] == scanner.source
-        assert worker._owned_needs[address] is owned_before
-        assert sched._needs[address] is entries
+        assert worker._owned_due_at[address] is owned_before
+        assert sched._due_at[address] is entries
     finally:
         cancel()
         register_cancel()
 
 
 @pytest.mark.asyncio
-async def test_ownership_assign_tolerates_missing_needs_or_worker() -> None:
+async def test_ownership_assign_tolerates_missing_due_at_or_worker() -> None:
     """assign() records the owner even when needs entry or worker is absent."""
     manager = get_manager()
     sched = manager._auto_scheduler
@@ -5945,20 +5945,20 @@ async def test_ownership_assign_tolerates_missing_needs_or_worker() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        # No _needs entry for this address; attach path early-returns.
+        # No _due_at entry for this address; attach path early-returns.
         sched._ownership.assign("AA:00:00:00:00:99", scanner.source)
-        assert "AA:00:00:00:00:99" not in worker._owned_needs
+        assert "AA:00:00:00:00:99" not in worker._owned_due_at
         assert sched._ownership._owner_by_address["AA:00:00:00:00:99"] == (
             scanner.source
         )
         # Worker not registered for this source; the owner mapping is
         # still recorded even though no worker can attach.
-        sched._needs["BB:00:00:00:00:99"] = {}
+        sched._due_at["BB:00:00:00:00:99"] = {}
         sched._ownership.assign("BB:00:00:00:00:99", "ZZ:99:99:99:99:99")
         assert sched._ownership._owner_by_address["BB:00:00:00:00:99"] == (
             "ZZ:99:99:99:99:99"
         )
-        sched._needs.pop("BB:00:00:00:00:99", None)
+        sched._due_at.pop("BB:00:00:00:00:99", None)
         # Clean up the synthetic owner mappings so other tests do not
         # see foreign state.
         sched._ownership.unown("AA:00:00:00:00:99")
@@ -5976,13 +5976,13 @@ async def test_ownership_assign_tolerates_missing_old_worker() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         address = "AA:00:00:00:00:99"
-        sched._needs[address] = {}
+        sched._due_at[address] = {}
         # Pre-seed an owner mapping pointing at an unregistered source
         # so the detach branch hits the missing-worker path.
         sched._ownership._owner_by_address[address] = "ZZ:99:99:99:99:99"
         sched._ownership.assign(address, scanner.source)
         assert sched._ownership._owner_by_address[address] == scanner.source
-        sched._needs.pop(address, None)
+        sched._due_at.pop(address, None)
         sched._ownership.unown(address)
     finally:
         register_cancel()
@@ -6019,7 +6019,7 @@ async def test_next_event_at_skips_empty_owned_entries() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        worker._owned_needs["AA:00:00:00:00:99"] = {}
+        worker._owned_due_at["AA:00:00:00:00:99"] = {}
         next_at = worker._next_event_at(loop.time())
         assert next_at == worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
     finally:
@@ -6036,7 +6036,7 @@ async def test_collect_due_buckets_skips_empty_owned_entries() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        worker._owned_needs["AA:00:00:00:00:99"] = {}
+        worker._owned_due_at["AA:00:00:00:00:99"] = {}
         due_buckets, all_due, any_immediate = worker._collect_due_buckets(loop.time())
         assert due_buckets == []
         assert all_due == []
@@ -6057,7 +6057,7 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
     cancel_b = manager.async_register_active_scan(address_b, scan_interval=60.0)
     foreign_source = "AA:BB:CC:DD:EE:FF"
     request_b = next(iter(sched._requests_by_address[address_b]))
-    sched._needs[address_b] = {request_b: loop.time()}
+    sched._due_at[address_b] = {request_b: loop.time()}
     sched._ownership._owner_by_address[address_b] = foreign_source
     try:
         scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
@@ -6065,7 +6065,7 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
         try:
             worker = sched._workers[scanner.source]
             # Foreign-owned address must not appear in this worker's view.
-            assert address_b not in worker._owned_needs
+            assert address_b not in worker._owned_due_at
         finally:
             register_cancel()
     finally:
@@ -6075,9 +6075,9 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
 
 def test_ownership_index_hook_worker_missing_worker() -> None:
     """hook_worker returns cleanly when the source has no registered worker."""
-    needs: dict[str, dict[ActiveScanRequest, float]] = {}
+    due_at: dict[str, dict[ActiveScanRequest, float]] = {}
     workers: dict[str, Any] = {}
-    idx = _OwnershipIndex(needs, workers)
+    idx = _OwnershipIndex(due_at, workers)
     idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
     # No worker registered for "ghost" — defensive guard returns early.
     idx.hook_worker("ghost")
@@ -6085,19 +6085,19 @@ def test_ownership_index_hook_worker_missing_worker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ownership_index_hook_worker_skips_address_without_needs() -> None:
-    """hook_worker skips an owned address that has no _needs entry."""
+async def test_ownership_index_hook_worker_skips_address_without_due_at() -> None:
+    """hook_worker skips an owned address that has no _due_at entry."""
     manager = get_manager()
     sched = manager._auto_scheduler
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        # Owner mapping exists but the address has no _needs entry; the
+        # Owner mapping exists but the address has no _due_at entry; the
         # attach helper must early-return without touching the worker.
         sched._ownership._owner_by_address["AA:00:00:00:00:99"] = scanner.source
         sched._ownership.hook_worker(scanner.source)
-        assert "AA:00:00:00:00:99" not in worker._owned_needs
+        assert "AA:00:00:00:00:99" not in worker._owned_due_at
         sched._ownership._owner_by_address.pop("AA:00:00:00:00:99", None)
     finally:
         register_cancel()
@@ -6114,16 +6114,16 @@ async def test_ownership_index_clear_source_no_match() -> None:
         worker = sched._workers[scanner.source]
         sched._ownership.clear_source(scanner.source)
         assert sched._ownership._owner_by_address == {}
-        assert worker._owned_needs == {}
+        assert worker._owned_due_at == {}
     finally:
         register_cancel()
 
 
 def test_ownership_index_clear_no_workers() -> None:
     """clear() over an index with no workers leaves state empty."""
-    needs: dict[str, dict[ActiveScanRequest, float]] = {}
+    due_at: dict[str, dict[ActiveScanRequest, float]] = {}
     workers: dict[str, Any] = {}
-    idx = _OwnershipIndex(needs, workers)
+    idx = _OwnershipIndex(due_at, workers)
     idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
     idx.clear()
     assert idx._owner_by_address == {}

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6084,47 +6084,39 @@ def test_ownership_index_hook_worker_missing_worker() -> None:
     assert idx._owner_by_address["AA:00:00:00:00:99"] == "ghost"
 
 
-def test_ownership_index_hook_worker_skips_address_without_needs() -> None:
+@pytest.mark.asyncio
+async def test_ownership_index_hook_worker_skips_address_without_needs() -> None:
     """hook_worker skips an owned address that has no _needs entry."""
-
-    class _StubWorker:
-        def __init__(self) -> None:
-            self.attached: list[tuple[str, dict[ActiveScanRequest, float]]] = []
-
-        def _attach_owned(
-            self, address: str, entries: dict[ActiveScanRequest, float]
-        ) -> None:
-            self.attached.append((address, entries))
-
-    needs: dict[str, dict[ActiveScanRequest, float]] = {}
-    worker = _StubWorker()
-    workers: dict[str, Any] = {"src": worker}
-    idx = _OwnershipIndex(needs, workers)
-    # Owner mapping exists but the address has no needs entry yet.
-    idx._owner_by_address["AA:00:00:00:00:99"] = "src"
-    idx.hook_worker("src")
-    assert worker.attached == []
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        # Owner mapping exists but the address has no _needs entry; the
+        # attach helper must early-return without touching the worker.
+        sched._ownership._owner_by_address["AA:00:00:00:00:99"] = scanner.source
+        sched._ownership.hook_worker(scanner.source)
+        assert "AA:00:00:00:00:99" not in worker._owned_needs
+        sched._ownership._owner_by_address.pop("AA:00:00:00:00:99", None)
+    finally:
+        register_cancel()
 
 
-def test_ownership_index_clear_source_no_match() -> None:
+@pytest.mark.asyncio
+async def test_ownership_index_clear_source_no_match() -> None:
     """clear_source over an index with no addresses for the source is a no-op."""
-
-    class _StubWorker:
-        def __init__(self) -> None:
-            self.cleared = 0
-
-        def _clear_owned(self) -> None:
-            self.cleared += 1
-
-    needs: dict[str, dict[ActiveScanRequest, float]] = {}
-    worker = _StubWorker()
-    workers: dict[str, Any] = {"src": worker}
-    idx = _OwnershipIndex(needs, workers)
-    idx.clear_source("src")
-    assert idx._owner_by_address == {}
-    # No addresses owned by ``src``, but the worker view is still
-    # cleared defensively in case prior drift left a stale entry.
-    assert worker.cleared == 1
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        sched._ownership.clear_source(scanner.source)
+        assert sched._ownership._owner_by_address == {}
+        assert worker._owned_needs == {}
+    finally:
+        register_cancel()
 
 
 def test_ownership_index_clear_no_workers() -> None:

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6322,6 +6322,69 @@ async def test_next_event_at_fails_fast_on_empty_owned_bucket() -> None:
 
 
 @pytest.mark.asyncio
+async def test_invariant_through_mode_switches() -> None:
+    """
+    Schedule invariant holds across in-place scanner mode switches.
+
+    HA's UI mode switch is implemented as unregister-old + register-new
+    with the same source. The scheduler has to (a) drop the worker when
+    AUTO leaves, (b) spawn a fresh worker when AUTO arrives, and (c)
+    keep ``_requests_by_address`` intact across the gap so the new
+    worker can be re-bootstrapped. Walk through every transition with
+    invariant checks at each step.
+    """
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    source = "AA:BB:CC:DD:EE:32"
+    address = "11:22:33:44:55:99"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    _assert_schedule_invariant(sched)
+    try:
+        # 1. PASSIVE first (entering as non-AUTO).
+        passive = _RecordingAutoScanner(source, BluetoothScanningMode.PASSIVE)
+        c_passive = manager.async_register_scanner(passive)
+        _assert_schedule_invariant(sched)
+        assert source not in sched._workers
+        _inject(passive, address)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == source
+        # 2. Switch INTO AUTO: unregister PASSIVE, register AUTO at same source.
+        c_passive()
+        _assert_schedule_invariant(sched)
+        # PASSIVE's clear_source removed the owner mapping.
+        assert address not in sched._schedule._owner_by_address
+        # User's registration survived.
+        assert address in sched._requests_by_address
+        auto = _RecordingAutoScanner(source, BluetoothScanningMode.AUTO)
+        c_auto = manager.async_register_scanner(auto)
+        _assert_schedule_invariant(sched)
+        assert source in sched._workers
+        # 3. AUTO sees the device, becomes owner with a worker attached.
+        _inject(auto, address)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == source
+        assert address in sched._workers[source]._owned_due_at
+        # 4. Switch OUT of AUTO: unregister AUTO, register ACTIVE same source.
+        c_auto()
+        _assert_schedule_invariant(sched)
+        assert source not in sched._workers
+        assert address not in sched._schedule._owner_by_address
+        active = _RecordingAutoScanner(source, BluetoothScanningMode.ACTIVE)
+        c_active = manager.async_register_scanner(active)
+        _assert_schedule_invariant(sched)
+        assert source not in sched._workers
+        # 5. ACTIVE sees the device; back to a non-AUTO-owned state.
+        _inject(active, address)
+        _assert_schedule_invariant(sched)
+        assert sched._schedule._owner_by_address[address] == source
+        c_active()
+        _assert_schedule_invariant(sched)
+    finally:
+        cancel()
+    _assert_schedule_invariant(sched)
+
+
+@pytest.mark.asyncio
 async def test_invariant_through_stop_and_restart() -> None:
     """Schedule invariant holds across stop + start replay."""
     manager = get_manager()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -18,7 +18,7 @@ from habluetooth import (
     BluetoothServiceInfoBleak,
     get_manager,
 )
-from habluetooth.auto_scheduler import ActiveScanRequest
+from habluetooth.auto_scheduler import ActiveScanRequest, _OwnershipIndex
 from habluetooth.const import (
     AUTO_INITIAL_SWEEP_DELAY,
     AUTO_REDISCOVERY_INTERVAL,
@@ -6050,3 +6050,57 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
     finally:
         cancel_a()
         cancel_b()
+
+
+def test_ownership_index_hook_worker_missing_worker() -> None:
+    """hook_worker returns cleanly when the source has no registered worker."""
+    needs: dict[str, dict[ActiveScanRequest, float]] = {}
+    workers: dict[str, Any] = {}
+    idx = _OwnershipIndex(needs, workers)
+    idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
+    # No worker registered for "ghost" — defensive guard returns early.
+    idx.hook_worker("ghost")
+    assert idx._owner_by_address["AA:00:00:00:00:99"] == "ghost"
+
+
+def test_ownership_index_hook_worker_skips_address_without_needs() -> None:
+    """hook_worker skips an owned address that has no _needs entry."""
+
+    class _StubWorker:
+        def __init__(self) -> None:
+            self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
+
+    needs: dict[str, dict[ActiveScanRequest, float]] = {}
+    worker = _StubWorker()
+    workers: dict[str, Any] = {"src": worker}
+    idx = _OwnershipIndex(needs, workers)
+    # Owner mapping exists but the address has no needs entry yet.
+    idx._owner_by_address["AA:00:00:00:00:99"] = "src"
+    idx.hook_worker("src")
+    assert worker._owned_needs == {}
+
+
+def test_ownership_index_clear_source_no_match() -> None:
+    """clear_source over an index with no addresses for the source is a no-op."""
+
+    class _StubWorker:
+        def __init__(self) -> None:
+            self._owned_needs: dict[str, dict[ActiveScanRequest, float]] = {}
+
+    needs: dict[str, dict[ActiveScanRequest, float]] = {}
+    worker = _StubWorker()
+    workers: dict[str, Any] = {"src": worker}
+    idx = _OwnershipIndex(needs, workers)
+    idx.clear_source("src")
+    assert idx._owner_by_address == {}
+    assert worker._owned_needs == {}
+
+
+def test_ownership_index_clear_no_workers() -> None:
+    """clear() over an index with no workers leaves state empty."""
+    needs: dict[str, dict[ActiveScanRequest, float]] = {}
+    workers: dict[str, Any] = {}
+    idx = _OwnershipIndex(needs, workers)
+    idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
+    idx.clear()
+    assert idx._owner_by_address == {}

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -117,11 +117,11 @@ async def test_advertisement_starts_tracking() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        assert "11:22:33:44:55:66" in sched._due_at
+        assert "11:22:33:44:55:66" in sched._ownership._due_at
     finally:
         cancel()
         register_cancel()
-    assert sched._due_at == {}
+    assert sched._ownership._due_at == {}
 
 
 @pytest.mark.asyncio
@@ -138,7 +138,7 @@ async def test_advertisement_for_unrelated_address_is_ignored() -> None:
         # The registered address has tracking from add_request; the
         # unrelated advertisement must not create its own entry.
         _inject(scanner, "AA:AA:AA:AA:AA:AA")
-        assert "AA:AA:AA:AA:AA:AA" not in sched._due_at
+        assert "AA:AA:AA:AA:AA:AA" not in sched._ownership._due_at
     finally:
         cancel()
         register_cancel()
@@ -157,7 +157,7 @@ async def test_worker_tick_fires_active_window() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        entries = sched._due_at["11:22:33:44:55:66"]
+        entries = sched._ownership._due_at["11:22:33:44:55:66"]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         await _run_worker_tick(sched, scanner.source)
@@ -190,7 +190,7 @@ async def test_worker_tick_advances_by_scan_interval_from_window_start() -> None
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         before_tick = loop.time()
@@ -227,8 +227,8 @@ async def test_worker_tick_coalesces_near_future_due_entries() -> None:
         # A is due now; B is due 10s from now (within the lookahead).
         # One tick should serve both.
         now = loop.time()
-        entries_a = sched._due_at[addr_a]
-        entries_b = sched._due_at[addr_b]
+        entries_a = sched._ownership._due_at[addr_a]
+        entries_b = sched._ownership._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -264,7 +264,7 @@ async def test_worker_tick_does_not_fire_when_only_soon_due_no_immediate() -> No
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         # Set next_due 5s in the future — within the lookahead but
         # not immediately due.
         for req in entries:
@@ -296,8 +296,8 @@ async def test_worker_tick_coalesces_near_max_window_boundary() -> None:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
         now = loop.time()
-        entries_a = sched._due_at[addr_a]
-        entries_b = sched._due_at[addr_b]
+        entries_a = sched._ownership._due_at[addr_a]
+        entries_b = sched._ownership._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -336,8 +336,8 @@ async def test_worker_tick_fallback_dispatch_rides_soon_due_entries() -> None:
         fallback.add_discovered(addr_b, rssi=-70)
         owner._add_connecting(addr_a)
         now = loop.time()
-        entries_a = sched._due_at[addr_a]
-        entries_b = sched._due_at[addr_b]
+        entries_a = sched._ownership._due_at[addr_a]
+        entries_b = sched._ownership._due_at[addr_b]
         for req in entries_a:
             entries_a[req] = now - 1.0
         for req in entries_b:
@@ -380,7 +380,7 @@ async def test_worker_tick_sweep_alone_pulls_in_soon_due_entries() -> None:
         # Make the sweep due; per-device entry is soon-due but not
         # immediate.
         worker._sweep_last_completed = loop.time() - AUTO_REDISCOVERY_INTERVAL - 1.0
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         soon_due_at = loop.time() + 5.0
         for req in entries:
             entries[req] = soon_due_at
@@ -414,7 +414,7 @@ async def test_worker_tick_coalesces_overlapping_requests() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await _run_worker_tick(sched, scanner.source)
@@ -442,7 +442,7 @@ async def test_multiple_requests_same_address_track_independent_intervals() -> N
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         assert len(entries) == 2
         fast, slow = sorted(entries, key=lambda r: r.scan_interval)
         entries[fast] = loop.time() - 1.0
@@ -596,7 +596,7 @@ async def test_active_scan_registered_before_auto_scanner_wakes_on_register() ->
             _inject(scanner, address)
             assert worker._wake.is_set()
             # The address now has a tracked entry on this scanner.
-            assert address in sched._due_at
+            assert address in sched._ownership._due_at
         finally:
             register_cancel()
     finally:
@@ -614,9 +614,9 @@ async def test_remove_request_clears_tracking() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         cancel()
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         assert sched._requests_by_address == {}
     finally:
         register_cancel()
@@ -675,15 +675,15 @@ async def test_dispatch_drops_tracking_for_unseen_address() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        request = next(iter(sched._due_at[address]))
-        sched._due_at[address][request] = loop.time() - 1.0
+        request = next(iter(sched._ownership._due_at[address]))
+        sched._ownership._due_at[address][request] = loop.time() - 1.0
         # Simulate the manager's history aging out under the worker's
         # feet — the orphan-prune branch should clean both _due_at and
         # _owner_by_address.
         manager._all_history.pop(address, None)
         manager._connectable_history.pop(address, None)
         await _run_worker_tick(sched, scanner.source)
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         assert address not in sched._ownership._owner_by_address
         assert address not in sched._workers[scanner.source]._owned_due_at
     finally:
@@ -794,14 +794,14 @@ async def test_remove_scanner_prunes_owned_due_at_entries() -> None:
     try:
         _inject(s_a, address_owned)
         _inject(s_b, address_foreign)
-        assert address_owned in sched._due_at
-        assert address_foreign in sched._due_at
+        assert address_owned in sched._ownership._due_at
+        assert address_foreign in sched._ownership._due_at
         # Remove s_a. The owned entry must be pruned; the foreign one
         # (owned by s_b) must remain.
         c_a()
         await asyncio.sleep(0)
-        assert address_owned not in sched._due_at
-        assert address_foreign in sched._due_at
+        assert address_owned not in sched._ownership._due_at
+        assert address_foreign in sched._ownership._due_at
     finally:
         cancel_owned()
         cancel_foreign()
@@ -863,10 +863,10 @@ async def test_stop_clears_loop_so_post_stop_add_request_is_record_only() -> Non
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             assert address in sched._requests_by_address
-            assert address not in sched._due_at
+            assert address not in sched._ownership._due_at
             # on_advertisement after stop is a no-op on _due_at too.
             _inject(scanner, address)
-            assert address not in sched._due_at
+            assert address not in sched._ownership._due_at
         finally:
             cancel()
     finally:
@@ -904,7 +904,7 @@ async def test_on_advertisement_early_returns_with_no_requests() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, "11:22:33:44:55:66")
-        assert sched._due_at == {}
+        assert sched._ownership._due_at == {}
         assert sched._requests_by_address == {}
     finally:
         register_cancel()
@@ -924,10 +924,10 @@ async def test_on_advertisement_re_bootstraps_pruned_tracking() -> None:
         # No advertisement has been seen yet, so add_request skipped
         # the _due_at seed (the prune-on-no-history path). Simulate the
         # "pruned" state by ensuring it's not there.
-        sched._due_at.pop(address, None)
+        sched._ownership._due_at.pop(address, None)
         worker._wake.clear()
         _inject(scanner, address)
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         assert worker._wake.is_set()
     finally:
         cancel()
@@ -1046,7 +1046,7 @@ async def test_add_request_without_history_skips_seed() -> None:
         # Sanity: history doesn't exist for this address yet.
         assert manager.async_last_service_info(address, False) is None
         # _due_at was not seeded -> no entry to prune later.
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         # But the request IS recorded for on_advertisement to pick up.
         assert address in sched._requests_by_address
         # First advertisement bootstraps tracking and wakes the
@@ -1054,7 +1054,7 @@ async def test_add_request_without_history_skips_seed() -> None:
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         _inject(scanner, address)
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         assert worker._wake.is_set()
     finally:
         cancel()
@@ -1199,12 +1199,12 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
     auto_cancel = manager.async_register_scanner(auto_scanner)
     try:
         _inject(auto_scanner, address)
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         assert auto_scanner.source in sched._workers
         # Mode switch in UI -> unregister AUTO scanner.
         auto_cancel()
         assert auto_scanner.source not in sched._workers
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         # User's registration is preserved across the switch.
         assert address in sched._requests_by_address
         # Re-register with the SAME source but PASSIVE mode.
@@ -1216,7 +1216,7 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
             # PASSIVE doesn't get a worker.
             assert passive_scanner.source not in sched._workers
             # Still no _due_at entry (no AUTO scanner owns it).
-            assert address not in sched._due_at
+            assert address not in sched._ownership._due_at
             passive_cancel()
             # Now switch BACK to AUTO with the same source.
             new_auto = _RecordingAutoScanner(
@@ -1228,7 +1228,7 @@ async def test_mode_switch_unregister_then_register_picks_up_existing_request() 
                 # First advertisement on the new AUTO scanner bootstraps
                 # tracking again from the still-registered request.
                 _inject(new_auto, address)
-                assert address in sched._due_at
+                assert address in sched._ownership._due_at
             finally:
                 new_auto_cancel()
         except BaseException:
@@ -1275,7 +1275,7 @@ async def test_start_replays_pre_start_requests_into_due_at() -> None:
                 address_no_history, scan_interval=60.0, scan_duration=5.0
             )
             try:
-                assert address_with_history not in sched._due_at
+                assert address_with_history not in sched._ownership._due_at
                 requests = list(sched._requests_by_address[address_with_history])
                 pre_existing, to_be_inserted = requests
                 # Pre-populate _due_at with one request only. The
@@ -1285,10 +1285,12 @@ async def test_start_replays_pre_start_requests_into_due_at() -> None:
                 # about the absolute value, only that start() leaves
                 # it alone.
                 sentinel = saved_loop.time() + 1.0e9
-                sched._due_at[address_with_history] = {pre_existing: sentinel}
+                sched._ownership._due_at[address_with_history] = {
+                    pre_existing: sentinel
+                }
                 before_start = saved_loop.time()
                 sched.start(saved_loop)
-                seeded = sched._due_at[address_with_history]
+                seeded = sched._ownership._due_at[address_with_history]
                 # The pre-existing entry was left alone (covers the
                 # `request not in existing` False branch).
                 assert seeded[pre_existing] == sentinel
@@ -1300,7 +1302,7 @@ async def test_start_replays_pre_start_requests_into_due_at() -> None:
                 )
                 # No-history address: skipped by the
                 # `last_service_info(...) is None` branch.
-                assert address_no_history not in sched._due_at
+                assert address_no_history not in sched._ownership._due_at
             finally:
                 cancel_with_a()
                 cancel_with_b()
@@ -1355,14 +1357,14 @@ async def test_dispatch_does_not_resurrect_cancelled_request() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         request = next(iter(entries))
         entries[request] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
         await gate.wait()
         # remove_request emptied the bucket; the tick must not have
         # re-added the cancelled request.
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
     finally:
         register_cancel()
 
@@ -1381,7 +1383,7 @@ async def test_dispatch_skips_address_owned_by_other_scanner() -> None:
     c2 = manager.async_register_scanner(other)
     try:
         _inject(owner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         # The "other" scanner runs its tick. The address is owned by
@@ -1425,7 +1427,7 @@ async def test_next_event_at_returns_earliest_per_device_need() -> None:
         worker = sched._workers[scanner.source]
         # Sweep is far in the future (initial delay window). The earliest
         # event for the worker is the per-device next-due.
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         request = next(iter(entries))
         per_device_at = loop.time() + 5.0
         entries[request] = per_device_at
@@ -1448,7 +1450,7 @@ async def test_dispatch_per_device_skips_not_yet_due() -> None:
     try:
         _inject(scanner, address)
         # Push the due time far in the future.
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for request in list(entries):
             entries[request] = loop.time() + 1000.0
         await sched._workers[scanner.source]._tick()
@@ -1598,7 +1600,7 @@ async def test_remove_request_handles_missing_bucket() -> None:
     # Bucket was never added; remove_request must be a no-op.
     sched.remove_request(request)
     assert "AA:BB:CC:DD:EE:99" not in sched._requests_by_address
-    assert "AA:BB:CC:DD:EE:99" not in sched._due_at
+    assert "AA:BB:CC:DD:EE:99" not in sched._ownership._due_at
 
 
 @pytest.mark.asyncio
@@ -1613,7 +1615,7 @@ async def test_on_advertisement_no_match_no_wake() -> None:
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         _inject(scanner, "AA:AA:AA:AA:AA:AA")
-        assert "AA:AA:AA:AA:AA:AA" not in sched._due_at
+        assert "AA:AA:AA:AA:AA:AA" not in sched._ownership._due_at
         assert not worker._wake.is_set()
     finally:
         cancel()
@@ -1663,7 +1665,7 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
     req_a = ActiveScanRequest(address, 60.0, 10.0)
     req_b = ActiveScanRequest(address, 120.0, 10.0)
     sched._requests_by_address[address] = {req_a, req_b}
-    sched._due_at[address] = {req_a: 0.0, req_b: 0.0}
+    sched._ownership._due_at[address] = {req_a: 0.0, req_b: 0.0}
     try:
         si = BluetoothServiceInfoBleak(
             name="x",
@@ -1687,10 +1689,10 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
         # triggers when every request was already in _due_at.
         assert worker._wake.is_set()
         # Sanity: the entries we put in are untouched.
-        assert sched._due_at[address] == {req_a: 0.0, req_b: 0.0}
+        assert sched._ownership._due_at[address] == {req_a: 0.0, req_b: 0.0}
     finally:
         sched._requests_by_address.pop(address, None)
-        sched._due_at.pop(address, None)
+        sched._ownership._due_at.pop(address, None)
         register_cancel()
 
 
@@ -1733,8 +1735,8 @@ async def test_next_event_at_skips_per_device_later_than_sweep() -> None:
         sweep_at = worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
         # Push per-device need past the sweep cadence so the earliest <
         # next_at branch is False inside _next_event_at.
-        for req in list(sched._due_at[address]):
-            sched._due_at[address][req] = sweep_at + 100.0
+        for req in list(sched._ownership._due_at[address]):
+            sched._ownership._due_at[address][req] = sweep_at + 100.0
         assert worker._next_event_at(loop.time()) == sweep_at
     finally:
         cancel()
@@ -1790,7 +1792,7 @@ async def test_coalesce_three_due_uses_max_clamped() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1816,7 +1818,7 @@ async def test_coalesce_clamps_oversize_request() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1843,7 +1845,7 @@ async def test_coalesce_only_due_requests_count() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         short_req = next(r for r in entries if r.scan_duration == 5.0)
         long_req = next(r for r in entries if r.scan_duration == 20.0)
         # Only the short request is due; the long one is well in the
@@ -1878,7 +1880,7 @@ async def test_coalesce_distinct_addresses_share_one_window() -> None:
         _inject(scanner, addr_a)
         _inject(scanner, addr_b)
         for address in (addr_a, addr_b):
-            entries = sched._due_at[address]
+            entries = sched._ownership._due_at[address]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1905,7 +1907,7 @@ async def test_tick_combines_due_sweep_and_per_device_into_one_window() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         worker = sched._workers[scanner.source]
@@ -1946,7 +1948,7 @@ async def test_three_inkbirds_share_one_scan() -> None:
     try:
         for addr in addresses:
             _inject(scanner, addr)
-            entries = sched._due_at[addr]
+            entries = sched._ownership._due_at[addr]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -1954,7 +1956,7 @@ async def test_three_inkbirds_share_one_scan() -> None:
         assert scanner.active_window_calls == [15.0]
         # Next-due moved forward by scan_interval for every request.
         for addr in addresses:
-            for due in sched._due_at[addr].values():
+            for due in sched._ownership._due_at[addr].values():
                 assert due > loop.time() + 250.0
     finally:
         for cancel in cancels:
@@ -1981,7 +1983,7 @@ async def test_dispatch_coalesces_different_durations_to_max() -> None:
     try:
         for addr in (addr_short, addr_long):
             _inject(scanner, addr)
-            entries = sched._due_at[addr]
+            entries = sched._ownership._due_at[addr]
             for req in list(entries):
                 entries[req] = loop.time() - 1.0
         await sched._workers[scanner.source]._tick()
@@ -2017,7 +2019,7 @@ async def test_three_inkbirds_same_address_coalesce_to_one_scan() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         assert len(entries) == 3
         for req in list(entries):
             entries[req] = loop.time() - 1.0
@@ -2057,13 +2059,13 @@ async def test_three_inkbirds_window_unchanged_after_removal() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         assert len(entries) == 3
         # Cancel one of the three; two should remain in both the registry
         # and the _due_at tracker.
         cancels.pop()()
         assert len(sched._requests_by_address[address]) == 2
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         assert len(entries) == 2
         for req in list(entries):
             entries[req] = loop.time() - 1.0
@@ -2102,7 +2104,7 @@ async def test_only_owning_scanner_fires_among_four() -> None:
     try:
         owner = scanners[2]
         _inject(owner, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         for scanner in scanners:
@@ -2126,7 +2128,7 @@ async def test_add_request_before_start_does_not_seed_due_at() -> None:
     try:
         sched.add_request(ActiveScanRequest(address, 60.0, 10.0))
         assert address in sched._requests_by_address
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
     finally:
         sched._loop = original_loop
         sched._requests_by_address.pop(address, None)
@@ -2151,11 +2153,11 @@ async def test_add_request_idempotent_keeps_existing_due() -> None:
         sched.add_request(request)
         # Inject so add_request can see history on the second call.
         _inject(scanner, address)
-        sched._due_at[address][request] = 1234.5
+        sched._ownership._due_at[address][request] = 1234.5
         worker = sched._workers[scanner.source]
         worker._wake.clear()
         sched.add_request(request)
-        assert sched._due_at[address][request] == 1234.5
+        assert sched._ownership._due_at[address][request] == 1234.5
         # No new entry → no wake.
         assert not worker._wake.is_set()
         sched.remove_request(request)
@@ -2215,7 +2217,7 @@ async def test_owner_flip_during_window_does_not_double_fire() -> None:
     c_b = manager.async_register_scanner(s_b)
     try:
         _inject(s_a, address)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
 
@@ -2293,7 +2295,7 @@ async def test_device_migration_between_scanners_fires_on_new_owner() -> None:
 
         # Make the existing tracking entry due and fire the first
         # window on A.
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await sched._workers[s_a.source]._tick()
@@ -2378,12 +2380,12 @@ async def test_stop_clears_due_at_so_restart_does_not_reuse_stale_due_times() ->
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         original_loop = sched._loop
         sched.stop()
         # _due_at cleared so stale timestamps from the now-defunct loop
         # can't survive into a re-start.
-        assert sched._due_at == {}
+        assert sched._ownership._due_at == {}
         assert sched._loop is None
         assert sched._workers == {}
         # _requests_by_address is loop-independent and must persist so
@@ -2393,8 +2395,8 @@ async def test_stop_clears_due_at_so_restart_does_not_reuse_stale_due_times() ->
         # a fresh due time from the new loop.time() base.
         assert original_loop is not None
         sched.start(original_loop)
-        assert address in sched._due_at
-        entries = sched._due_at[address]
+        assert address in sched._ownership._due_at
+        entries = sched._ownership._due_at[address]
         expected_due = original_loop.time() + 60.0
         assert all(abs(due - expected_due) < 0.5 for due in entries.values())
     finally:
@@ -2430,7 +2432,7 @@ class _DiscoverableAutoScanner(_RecordingAutoScanner):
 
 def _make_due(sched: object, address: str) -> None:
     """Make every tracked request for ``address`` due immediately."""
-    entries = sched._due_at[address]  # type: ignore[attr-defined]
+    entries = sched._ownership._due_at[address]  # type: ignore[attr-defined]
     loop = asyncio.get_running_loop()
     for req in list(entries):
         entries[req] = loop.time() - 1.0
@@ -3157,7 +3159,7 @@ async def test_worker_tick_advance_pre_dispatch_blocks_double_fire() -> None:
         _make_due(sched, address)
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for due in entries.values():
             # Advanced to roughly before + 90s, NOT before - 1.0.
             assert due == pytest.approx(before + 90.0, abs=0.5)
@@ -3684,7 +3686,7 @@ async def test_worker_tick_ownership_flip_during_dispatch_no_double_fire() -> No
         await asyncio.sleep(0)
         # Confirm fallback call is in flight and entries advanced.
         assert fb.active_window_calls == [6.0]
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for due in entries.values():
             assert due == pytest.approx(before + 90.0, abs=0.5)
         # Ownership flips to fb mid-dispatch (much stronger RSSI).
@@ -4006,7 +4008,7 @@ async def test_worker_tick_three_addresses_no_fallback_advance_by_defer() -> Non
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
         for addr in (addr_a, addr_b, addr_c):
-            entries = sched._due_at[addr]
+            entries = sched._ownership._due_at[addr]
             for due in entries.values():
                 assert due == pytest.approx(before + 30.0, abs=0.5)
                 assert due < before + 60.0
@@ -4139,11 +4141,11 @@ async def test_worker_tick_three_addresses_mixed_outcomes_advance_correctly() ->
         owner._add_connecting(addr_covered)
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
-        for due in sched._due_at[addr_covered].values():
+        for due in sched._ownership._due_at[addr_covered].values():
             assert due == pytest.approx(before + 120.0, abs=0.5)
-        for due in sched._due_at[addr_flipped].values():
+        for due in sched._ownership._due_at[addr_flipped].values():
             assert due == pytest.approx(before + 240.0, abs=0.5)
-        for due in sched._due_at[addr_orphan].values():
+        for due in sched._ownership._due_at[addr_orphan].values():
             assert due == pytest.approx(before + 30.0, abs=0.5)
         assert fb.active_window_calls == [9.0]
         assert active.active_window_calls == []
@@ -4276,7 +4278,7 @@ async def test_worker_tick_failed_fallback_advances_entries_by_full_interval() -
         before = loop.time()
         await _run_worker_tick(sched, owner.source)
         # Entries advanced by full scan_interval, NOT retry_at.
-        for due in sched._due_at[address].values():
+        for due in sched._ownership._due_at[address].values():
             assert due == pytest.approx(before + 120.0, abs=0.5)
             assert due > before + 60.0  # well past the 30s retry_at
         # fb_worker bumps from note_window_dispatched are preserved.
@@ -5517,7 +5519,7 @@ async def test_owned_due_at_populated_for_owner_on_add_request_with_history() ->
         _inject(scanner, address)
         # Drop the entry add_request seeded so we can re-add through
         # add_request and observe its _ownership.assign side-effect.
-        sched._due_at.pop(address, None)
+        sched._ownership._due_at.pop(address, None)
         sched._ownership._owner_by_address.pop(address, None)
         sched._workers[scanner.source]._owned_due_at.pop(address, None)
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
@@ -5527,7 +5529,7 @@ async def test_owned_due_at_populated_for_owner_on_add_request_with_history() ->
             # Inner dict must be the SAME object aliased between
             # _due_at and _owned_due_at so _advance_due mutations apply
             # to both views.
-            assert owned[address] is sched._due_at[address]
+            assert owned[address] is sched._ownership._due_at[address]
             assert sched._ownership._owner_by_address[address] == scanner.source
         finally:
             cancel()
@@ -5546,7 +5548,7 @@ async def test_add_request_without_history_leaves_owned_due_at_empty() -> None:
     try:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
-            assert address not in sched._due_at
+            assert address not in sched._ownership._due_at
             assert address not in sched._ownership._owner_by_address
             assert address not in sched._workers[scanner.source]._owned_due_at
         finally:
@@ -5569,7 +5571,7 @@ async def test_on_advertisement_bootstraps_owned_due_at() -> None:
             _inject(scanner, address)
             owned = sched._workers[scanner.source]._owned_due_at
             assert address in owned
-            assert owned[address] is sched._due_at[address]
+            assert owned[address] is sched._ownership._due_at[address]
             assert sched._ownership._owner_by_address[address] == scanner.source
         finally:
             cancel()
@@ -5601,7 +5603,7 @@ async def test_ownership_flip_moves_entry_between_owned_due_at() -> None:
         _inject_with_rssi(s_b, address, rssi=-30)
         assert address not in worker_a._owned_due_at
         assert address in worker_b._owned_due_at
-        assert worker_b._owned_due_at[address] is sched._due_at[address]
+        assert worker_b._owned_due_at[address] is sched._ownership._due_at[address]
         assert sched._ownership._owner_by_address[address] == s_b.source
     finally:
         c_a()
@@ -5623,7 +5625,7 @@ async def test_remove_request_clears_owner_when_bucket_empties() -> None:
         worker = sched._workers[scanner.source]
         assert address in worker._owned_due_at
         cancel()
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         assert address not in sched._ownership._owner_by_address
         assert address not in worker._owned_due_at
     finally:
@@ -5643,13 +5645,13 @@ async def test_remove_request_preserves_owner_when_other_requests_remain() -> No
         cancel2 = manager.async_register_active_scan(address, scan_interval=120.0)
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        assert len(sched._due_at[address]) == 2
+        assert len(sched._ownership._due_at[address]) == 2
         cancel1()
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         assert sched._ownership._owner_by_address[address] == scanner.source
         assert address in worker._owned_due_at
         cancel2()
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         assert address not in sched._ownership._owner_by_address
         assert address not in worker._owned_due_at
     finally:
@@ -5667,10 +5669,10 @@ async def test_remove_scanner_clears_owner_and_due_at() -> None:
     register_cancel = manager.async_register_scanner(scanner)
     try:
         _inject(scanner, address)
-        assert address in sched._due_at
+        assert address in sched._ownership._due_at
         assert sched._ownership._owner_by_address[address] == scanner.source
         register_cancel()
-        assert address not in sched._due_at
+        assert address not in sched._ownership._due_at
         assert address not in sched._ownership._owner_by_address
         assert scanner.source not in sched._workers
     finally:
@@ -5691,7 +5693,7 @@ async def test_stop_clears_all_owned_due_at_state() -> None:
         worker = sched._workers[scanner.source]
         assert address in worker._owned_due_at
         sched.stop()
-        assert sched._due_at == {}
+        assert sched._ownership._due_at == {}
         assert sched._ownership._owner_by_address == {}
         # Worker dropped from registry; the cleared dict is on the
         # detached instance still held by the local. Confirm both.
@@ -5726,17 +5728,19 @@ async def test_start_replay_populates_owned_due_at() -> None:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             # Pre-start: only _requests_by_address is populated.
-            assert address not in sched._due_at
+            assert address not in sched._ownership._due_at
             assert address not in sched._ownership._owner_by_address
             sched.start(loop)
             try:
                 # After start, the replay seeded _due_at and assigned
                 # the owner.
                 worker = sched._workers[scanner.source]
-                assert address in sched._due_at
+                assert address in sched._ownership._due_at
                 assert sched._ownership._owner_by_address[address] == scanner.source
                 assert address in worker._owned_due_at
-                assert worker._owned_due_at[address] is sched._due_at[address]
+                assert (
+                    worker._owned_due_at[address] is sched._ownership._due_at[address]
+                )
             finally:
                 # Stop the spawned worker tasks so they do not leak.
                 for w in list(sched._workers.values()):
@@ -5762,7 +5766,7 @@ async def test_spawn_worker_picks_up_preassigned_owner() -> None:
     # registers as AUTO. We bypass the manager here because plumbing a
     # synthetic history entry is more wiring than the invariant needs.
     request = next(iter(sched._requests_by_address[address]))
-    sched._due_at[address] = {request: loop.time()}
+    sched._ownership._due_at[address] = {request: loop.time()}
     sched._ownership._owner_by_address[address] = source
     try:
         scanner = _RecordingAutoScanner(source, BluetoothScanningMode.AUTO)
@@ -5770,7 +5774,7 @@ async def test_spawn_worker_picks_up_preassigned_owner() -> None:
         try:
             worker = sched._workers[source]
             assert address in worker._owned_due_at
-            assert worker._owned_due_at[address] is sched._due_at[address]
+            assert worker._owned_due_at[address] is sched._ownership._due_at[address]
         finally:
             register_cancel()
     finally:
@@ -5793,7 +5797,7 @@ async def test_next_event_at_skips_other_workers_entries() -> None:
         _inject(s_a, address)
         # Drive the entry's due time well below A's sweep so any leak
         # of foreign entries would change B's next_at.
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() + 1.0
         worker_b = sched._workers[s_b.source]
@@ -5852,7 +5856,7 @@ async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
         info = manager.async_last_service_info(address, False)
         assert info is not None
         info.source = s_b.source
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         for req in list(entries):
             entries[req] = loop.time() - 1.0
         await worker_a._tick()
@@ -5879,14 +5883,14 @@ async def test_assign_owner_noop_when_source_unchanged() -> None:
     try:
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
-        entries = sched._due_at[address]
+        entries = sched._ownership._due_at[address]
         owned_before = worker._owned_due_at[address]
         # Second injection from the same scanner: owner unchanged,
         # owned-view aliasing preserved (same dict object).
         _inject(scanner, address)
         assert sched._ownership._owner_by_address[address] == scanner.source
         assert worker._owned_due_at[address] is owned_before
-        assert sched._due_at[address] is entries
+        assert sched._ownership._due_at[address] is entries
     finally:
         cancel()
         register_cancel()
@@ -5904,7 +5908,7 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
     cancel_b = manager.async_register_active_scan(address_b, scan_interval=60.0)
     foreign_source = "AA:BB:CC:DD:EE:FF"
     request_b = next(iter(sched._requests_by_address[address_b]))
-    sched._due_at[address_b] = {request_b: loop.time()}
+    sched._ownership._due_at[address_b] = {request_b: loop.time()}
     sched._ownership._owner_by_address[address_b] = foreign_source
     try:
         scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
@@ -5938,9 +5942,8 @@ async def test_ownership_index_clear_source_no_match() -> None:
 
 def test_ownership_index_clear_no_workers() -> None:
     """clear() over an index with no workers leaves state empty."""
-    due_at: dict[str, dict[ActiveScanRequest, float]] = {}
     workers: dict[str, Any] = {}
-    idx = _OwnershipIndex(due_at, workers)
+    idx = _OwnershipIndex(workers)
     idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
     idx.clear()
     assert idx._owner_by_address == {}

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -5820,7 +5820,7 @@ async def test_spawn_worker_picks_up_preassigned_owner() -> None:
 
 @pytest.mark.asyncio
 async def test_next_event_at_skips_other_workers_entries() -> None:
-    """An entry owned by scanner B doesn't lower scanner A's next event."""
+    """An entry owned by scanner A doesn't lower scanner B's next event."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -684,7 +684,7 @@ async def test_dispatch_drops_tracking_for_unseen_address() -> None:
         manager._connectable_history.pop(address, None)
         await _run_worker_tick(sched, scanner.source)
         assert address not in sched._needs
-        assert address not in sched._owner_by_address
+        assert address not in sched._ownership._owner_by_address
         assert address not in sched._workers[scanner.source]._owned_needs
     finally:
         cancel()
@@ -5569,9 +5569,9 @@ async def test_owned_needs_populated_for_owner_on_add_request_with_history() -> 
         # history-gating finds it.
         _inject(scanner, address)
         # Drop the entry add_request seeded so we can re-add through
-        # add_request and observe its _assign_owner side-effect.
+        # add_request and observe its _ownership.assign side-effect.
         sched._needs.pop(address, None)
-        sched._owner_by_address.pop(address, None)
+        sched._ownership._owner_by_address.pop(address, None)
         sched._workers[scanner.source]._owned_needs.pop(address, None)
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
@@ -5581,7 +5581,7 @@ async def test_owned_needs_populated_for_owner_on_add_request_with_history() -> 
             # _needs and _owned_needs so _advance_due mutations apply
             # to both views.
             assert owned[address] is sched._needs[address]
-            assert sched._owner_by_address[address] == scanner.source
+            assert sched._ownership._owner_by_address[address] == scanner.source
         finally:
             cancel()
     finally:
@@ -5600,7 +5600,7 @@ async def test_add_request_without_history_leaves_owned_needs_empty() -> None:
         cancel = manager.async_register_active_scan(address, scan_interval=60.0)
         try:
             assert address not in sched._needs
-            assert address not in sched._owner_by_address
+            assert address not in sched._ownership._owner_by_address
             assert address not in sched._workers[scanner.source]._owned_needs
         finally:
             cancel()
@@ -5623,7 +5623,7 @@ async def test_on_advertisement_bootstraps_owned_needs() -> None:
             owned = sched._workers[scanner.source]._owned_needs
             assert address in owned
             assert owned[address] is sched._needs[address]
-            assert sched._owner_by_address[address] == scanner.source
+            assert sched._ownership._owner_by_address[address] == scanner.source
         finally:
             cancel()
     finally:
@@ -5647,7 +5647,7 @@ async def test_ownership_flip_moves_entry_between_owned_needs() -> None:
         worker_b = sched._workers[s_b.source]
         assert address in worker_a._owned_needs
         assert address not in worker_b._owned_needs
-        assert sched._owner_by_address[address] == s_a.source
+        assert sched._ownership._owner_by_address[address] == s_a.source
 
         # B with much stronger RSSI triggers ownership flip in the
         # manager; scheduler's on_advertisement reassigns owner.
@@ -5655,7 +5655,7 @@ async def test_ownership_flip_moves_entry_between_owned_needs() -> None:
         assert address not in worker_a._owned_needs
         assert address in worker_b._owned_needs
         assert worker_b._owned_needs[address] is sched._needs[address]
-        assert sched._owner_by_address[address] == s_b.source
+        assert sched._ownership._owner_by_address[address] == s_b.source
     finally:
         c_a()
         c_b()
@@ -5677,7 +5677,7 @@ async def test_remove_request_clears_owner_when_bucket_empties() -> None:
         assert address in worker._owned_needs
         cancel()
         assert address not in sched._needs
-        assert address not in sched._owner_by_address
+        assert address not in sched._ownership._owner_by_address
         assert address not in worker._owned_needs
     finally:
         register_cancel()
@@ -5699,11 +5699,11 @@ async def test_remove_request_preserves_owner_when_other_requests_remain() -> No
         assert len(sched._needs[address]) == 2
         cancel1()
         assert address in sched._needs
-        assert sched._owner_by_address[address] == scanner.source
+        assert sched._ownership._owner_by_address[address] == scanner.source
         assert address in worker._owned_needs
         cancel2()
         assert address not in sched._needs
-        assert address not in sched._owner_by_address
+        assert address not in sched._ownership._owner_by_address
         assert address not in worker._owned_needs
     finally:
         register_cancel()
@@ -5721,10 +5721,10 @@ async def test_remove_scanner_clears_owner_and_needs() -> None:
     try:
         _inject(scanner, address)
         assert address in sched._needs
-        assert sched._owner_by_address[address] == scanner.source
+        assert sched._ownership._owner_by_address[address] == scanner.source
         register_cancel()
         assert address not in sched._needs
-        assert address not in sched._owner_by_address
+        assert address not in sched._ownership._owner_by_address
         assert scanner.source not in sched._workers
     finally:
         cancel()
@@ -5745,7 +5745,7 @@ async def test_stop_clears_all_owned_needs_state() -> None:
         assert address in worker._owned_needs
         sched.stop()
         assert sched._needs == {}
-        assert sched._owner_by_address == {}
+        assert sched._ownership._owner_by_address == {}
         # Worker dropped from registry; the cleared dict is on the
         # detached instance still held by the local. Confirm both.
         assert sched._workers == {}
@@ -5780,14 +5780,14 @@ async def test_start_replay_populates_owned_needs() -> None:
         try:
             # Pre-start: only _requests_by_address is populated.
             assert address not in sched._needs
-            assert address not in sched._owner_by_address
+            assert address not in sched._ownership._owner_by_address
             sched.start(loop)
             try:
                 # After start, the replay seeded _needs and assigned
                 # the owner.
                 worker = sched._workers[scanner.source]
                 assert address in sched._needs
-                assert sched._owner_by_address[address] == scanner.source
+                assert sched._ownership._owner_by_address[address] == scanner.source
                 assert address in worker._owned_needs
                 assert worker._owned_needs[address] is sched._needs[address]
             finally:
@@ -5816,7 +5816,7 @@ async def test_spawn_worker_picks_up_preassigned_owner() -> None:
     # synthetic history entry is more wiring than the invariant needs.
     request = next(iter(sched._requests_by_address[address]))
     sched._needs[address] = {request: loop.time()}
-    sched._owner_by_address[address] = source
+    sched._ownership._owner_by_address[address] = source
     try:
         scanner = _RecordingAutoScanner(source, BluetoothScanningMode.AUTO)
         register_cancel = manager.async_register_scanner(scanner)
@@ -5913,7 +5913,7 @@ async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
         assert s_a.active_window_calls == []
         assert address not in worker_a._owned_needs
         assert address in worker_b._owned_needs
-        assert sched._owner_by_address[address] == s_b.source
+        assert sched._ownership._owner_by_address[address] == s_b.source
     finally:
         c_a()
         c_b()
@@ -5937,7 +5937,7 @@ async def test_assign_owner_noop_when_source_unchanged() -> None:
         # Second injection from the same scanner: owner unchanged,
         # owned-view aliasing preserved (same dict object).
         _inject(scanner, address)
-        assert sched._owner_by_address[address] == scanner.source
+        assert sched._ownership._owner_by_address[address] == scanner.source
         assert worker._owned_needs[address] is owned_before
         assert sched._needs[address] is entries
     finally:
@@ -5946,32 +5946,46 @@ async def test_assign_owner_noop_when_source_unchanged() -> None:
 
 
 @pytest.mark.asyncio
-async def test_attach_to_worker_tolerates_missing_state() -> None:
-    """_attach_to_worker no-ops when needs entry or worker is absent."""
+async def test_ownership_assign_tolerates_missing_needs_or_worker() -> None:
+    """assign() records the owner even when needs entry or worker is absent."""
     manager = get_manager()
     sched = manager._auto_scheduler
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
         worker = sched._workers[scanner.source]
-        # No _needs entry for this address — defensive early return.
-        sched._attach_to_worker(scanner.source, "AA:00:00:00:00:99")
+        # No _needs entry for this address — attach path early-returns.
+        sched._ownership.assign("AA:00:00:00:00:99", scanner.source)
         assert "AA:00:00:00:00:99" not in worker._owned_needs
-        # Worker not registered for this source — also a no-op.
+        assert sched._ownership._owner_by_address["AA:00:00:00:00:99"] == (
+            scanner.source
+        )
+        # Worker not registered for this source — also a no-op on the
+        # attach side, but the owner mapping is still recorded.
         sched._needs["BB:00:00:00:00:99"] = {}
-        sched._attach_to_worker("ZZ:99:99:99:99:99", "BB:00:00:00:00:99")
+        sched._ownership.assign("BB:00:00:00:00:99", "ZZ:99:99:99:99:99")
+        assert sched._ownership._owner_by_address["BB:00:00:00:00:99"] == (
+            "ZZ:99:99:99:99:99"
+        )
         sched._needs.pop("BB:00:00:00:00:99", None)
+        # Clean up the synthetic owner mappings so other tests do not
+        # see foreign state.
+        sched._ownership.assign("AA:00:00:00:00:99", None)
+        sched._ownership.assign("BB:00:00:00:00:99", None)
     finally:
         register_cancel()
 
 
 @pytest.mark.asyncio
-async def test_detach_from_worker_tolerates_missing_worker() -> None:
-    """_detach_from_worker no-ops when the worker has been removed."""
+async def test_ownership_assign_tolerates_missing_old_worker() -> None:
+    """Reassigning away from a source whose worker is gone must not raise."""
     manager = get_manager()
     sched = manager._auto_scheduler
-    # No scanner registered for this source — helper must not raise.
-    sched._detach_from_worker("ZZ:99:99:99:99:99", "AA:00:00:00:00:99")
+    # Forge an owner mapping for an unregistered source so the detach
+    # branch hits a missing-worker path.
+    sched._ownership._owner_by_address["AA:00:00:00:00:99"] = "ZZ:99:99:99:99:99"
+    sched._ownership.assign("AA:00:00:00:00:99", None)
+    assert "AA:00:00:00:00:99" not in sched._ownership._owner_by_address
 
 
 @pytest.mark.asyncio
@@ -6023,7 +6037,7 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
     foreign_source = "AA:BB:CC:DD:EE:FF"
     request_b = next(iter(sched._requests_by_address[address_b]))
     sched._needs[address_b] = {request_b: loop.time()}
-    sched._owner_by_address[address_b] = foreign_source
+    sched._ownership._owner_by_address[address_b] = foreign_source
     try:
         scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
         register_cancel = manager.async_register_scanner(scanner)

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -665,18 +665,27 @@ async def test_stop_cancels_worker_tasks() -> None:
 
 @pytest.mark.asyncio
 async def test_dispatch_drops_tracking_for_unseen_address() -> None:
-    """An address with no history entry is pruned on the next worker tick."""
+    """An address whose history aged out is pruned on the next worker tick."""
     manager = get_manager()
     sched = manager._auto_scheduler
     loop = asyncio.get_running_loop()
-    cancel = manager.async_register_active_scan("AA:BB:CC:DD:EE:FF", scan_interval=60.0)
+    address = "AA:BB:CC:DD:EE:FF"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     try:
-        request = next(iter(sched._requests_by_address["AA:BB:CC:DD:EE:FF"]))
-        sched._needs["AA:BB:CC:DD:EE:FF"] = {request: loop.time() - 1.0}
+        _inject(scanner, address)
+        request = next(iter(sched._needs[address]))
+        sched._needs[address][request] = loop.time() - 1.0
+        # Simulate the manager's history aging out under the worker's
+        # feet — the orphan-prune branch should clean both _needs and
+        # _owner_by_address.
+        manager._all_history.pop(address, None)
+        manager._connectable_history.pop(address, None)
         await _run_worker_tick(sched, scanner.source)
-        assert "AA:BB:CC:DD:EE:FF" not in sched._needs
+        assert address not in sched._needs
+        assert address not in sched._owner_by_address
+        assert address not in sched._workers[scanner.source]._owned_needs
     finally:
         cancel()
         register_cancel()
@@ -5545,3 +5554,367 @@ async def test_orphan_leader_does_not_clobber_fresh_sweep_state() -> None:
         sched._on_demand_sweep_future = None
         sched._on_demand_sweep_end = 0.0
         register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_owned_needs_populated_for_owner_on_add_request_with_history() -> None:
+    """add_request hooks the entry into the owner's _owned_needs view."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        # First seed history via an advertisement so add_request's
+        # history-gating finds it.
+        _inject(scanner, address)
+        # Drop the entry add_request seeded so we can re-add through
+        # add_request and observe its _assign_owner side-effect.
+        sched._needs.pop(address, None)
+        sched._owner_by_address.pop(address, None)
+        sched._workers[scanner.source]._owned_needs.pop(address, None)
+        cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+        try:
+            owned = sched._workers[scanner.source]._owned_needs
+            assert address in owned
+            # Inner dict must be the SAME object aliased between
+            # _needs and _owned_needs so _advance_due mutations apply
+            # to both views.
+            assert owned[address] is sched._needs[address]
+            assert sched._owner_by_address[address] == scanner.source
+        finally:
+            cancel()
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_add_request_without_history_leaves_owned_needs_empty() -> None:
+    """add_request without history defers seeding to on_advertisement."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+        try:
+            assert address not in sched._needs
+            assert address not in sched._owner_by_address
+            assert address not in sched._workers[scanner.source]._owned_needs
+        finally:
+            cancel()
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_on_advertisement_bootstraps_owned_needs() -> None:
+    """First advertisement for a tracked address populates owner's view."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+        try:
+            _inject(scanner, address)
+            owned = sched._workers[scanner.source]._owned_needs
+            assert address in owned
+            assert owned[address] is sched._needs[address]
+            assert sched._owner_by_address[address] == scanner.source
+        finally:
+            cancel()
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_ownership_flip_moves_entry_between_owned_needs() -> None:
+    """On migration, the entry moves from old owner's view to new owner's view."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:99"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    s_a = _RecordingAutoScanner("AA:00:00:00:00:01", BluetoothScanningMode.AUTO)
+    s_b = _RecordingAutoScanner("AA:00:00:00:00:02", BluetoothScanningMode.AUTO)
+    c_a = manager.async_register_scanner(s_a)
+    c_b = manager.async_register_scanner(s_b)
+    try:
+        _inject_with_rssi(s_a, address, rssi=-80)
+        worker_a = sched._workers[s_a.source]
+        worker_b = sched._workers[s_b.source]
+        assert address in worker_a._owned_needs
+        assert address not in worker_b._owned_needs
+        assert sched._owner_by_address[address] == s_a.source
+
+        # B with much stronger RSSI triggers ownership flip in the
+        # manager; scheduler's on_advertisement reassigns owner.
+        _inject_with_rssi(s_b, address, rssi=-30)
+        assert address not in worker_a._owned_needs
+        assert address in worker_b._owned_needs
+        assert worker_b._owned_needs[address] is sched._needs[address]
+        assert sched._owner_by_address[address] == s_b.source
+    finally:
+        c_a()
+        c_b()
+        cancel()
+
+
+@pytest.mark.asyncio
+async def test_remove_request_clears_owner_when_bucket_empties() -> None:
+    """The last remove_request for an address clears owner and _owned_needs."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+        _inject(scanner, address)
+        worker = sched._workers[scanner.source]
+        assert address in worker._owned_needs
+        cancel()
+        assert address not in sched._needs
+        assert address not in sched._owner_by_address
+        assert address not in worker._owned_needs
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_remove_request_preserves_owner_when_other_requests_remain() -> None:
+    """Removing one of N requests on an address keeps the owner mapping intact."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        cancel1 = manager.async_register_active_scan(address, scan_interval=60.0)
+        cancel2 = manager.async_register_active_scan(address, scan_interval=120.0)
+        _inject(scanner, address)
+        worker = sched._workers[scanner.source]
+        assert len(sched._needs[address]) == 2
+        cancel1()
+        assert address in sched._needs
+        assert sched._owner_by_address[address] == scanner.source
+        assert address in worker._owned_needs
+        cancel2()
+        assert address not in sched._needs
+        assert address not in sched._owner_by_address
+        assert address not in worker._owned_needs
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_remove_scanner_clears_owner_and_needs() -> None:
+    """Removing the owning scanner drops the entry from _needs and the owner index."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        assert address in sched._needs
+        assert sched._owner_by_address[address] == scanner.source
+        register_cancel()
+        assert address not in sched._needs
+        assert address not in sched._owner_by_address
+        assert scanner.source not in sched._workers
+    finally:
+        cancel()
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_all_owned_needs_state() -> None:
+    """stop() drains _needs, _owner_by_address, and per-worker _owned_needs."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        worker = sched._workers[scanner.source]
+        assert address in worker._owned_needs
+        sched.stop()
+        assert sched._needs == {}
+        assert sched._owner_by_address == {}
+        # Worker dropped from registry; the cleared dict is on the
+        # detached instance still held by the local. Confirm both.
+        assert sched._workers == {}
+        assert worker._owned_needs == {}
+    finally:
+        cancel()
+        # register_cancel() may double-call but is idempotent on the
+        # manager side; guard against AttributeError nonetheless.
+        with contextlib.suppress(KeyError, ValueError):
+            register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_start_replay_populates_owned_needs() -> None:
+    """A request registered before start() is hooked into the worker's view on start."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        # Seed history via a real injection so the replay loop's
+        # last_service_info check sees a source.
+        _inject(scanner, address)
+        # Wipe scheduler state and stop the running scheduler so we
+        # can drive start() ourselves with pre-registered requests.
+        sched._workers[scanner.source].stop()
+        await asyncio.sleep(0)
+        sched.stop()
+        cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+        try:
+            # Pre-start: only _requests_by_address is populated.
+            assert address not in sched._needs
+            assert address not in sched._owner_by_address
+            sched.start(loop)
+            try:
+                # After start, the replay seeded _needs and assigned
+                # the owner.
+                worker = sched._workers[scanner.source]
+                assert address in sched._needs
+                assert sched._owner_by_address[address] == scanner.source
+                assert address in worker._owned_needs
+                assert worker._owned_needs[address] is sched._needs[address]
+            finally:
+                # Stop the spawned worker tasks so they do not leak.
+                for w in list(sched._workers.values()):
+                    w.stop()
+                await asyncio.sleep(0)
+        finally:
+            cancel()
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_spawn_worker_picks_up_preassigned_owner() -> None:
+    """A scanner registering after on_advertisement gets the entry hooked up."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    source = "AA:BB:CC:DD:EE:00"
+    # Forge an owner mapping for an unregistered source — the same
+    # state that arises when on_advertisement seeds before its scanner
+    # registers as AUTO. We bypass the manager here because plumbing a
+    # synthetic history entry is more wiring than the invariant needs.
+    request = next(iter(sched._requests_by_address[address]))
+    sched._needs[address] = {request: loop.time()}
+    sched._owner_by_address[address] = source
+    try:
+        scanner = _RecordingAutoScanner(source, BluetoothScanningMode.AUTO)
+        register_cancel = manager.async_register_scanner(scanner)
+        try:
+            worker = sched._workers[source]
+            assert address in worker._owned_needs
+            assert worker._owned_needs[address] is sched._needs[address]
+        finally:
+            register_cancel()
+    finally:
+        cancel()
+
+
+@pytest.mark.asyncio
+async def test_next_event_at_skips_other_workers_entries() -> None:
+    """An entry owned by scanner B doesn't lower scanner A's next event."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    s_a = _RecordingAutoScanner("AA:00:00:00:00:01", BluetoothScanningMode.AUTO)
+    s_b = _RecordingAutoScanner("AA:00:00:00:00:02", BluetoothScanningMode.AUTO)
+    c_a = manager.async_register_scanner(s_a)
+    c_b = manager.async_register_scanner(s_b)
+    try:
+        _inject(s_a, address)
+        # Drive the entry's due time well below A's sweep so any leak
+        # of foreign entries would change B's next_at.
+        entries = sched._needs[address]
+        for req in list(entries):
+            entries[req] = loop.time() + 1.0
+        worker_b = sched._workers[s_b.source]
+        sweep_at_b = worker_b._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
+        assert worker_b._next_event_at(loop.time()) == sweep_at_b
+    finally:
+        c_a()
+        c_b()
+        cancel()
+
+
+@pytest.mark.asyncio
+async def test_next_event_at_makes_no_history_calls() -> None:
+    """The hot path no longer pays a per-entry async_last_service_info lookup."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        worker = sched._workers[scanner.source]
+        with patch.object(
+            manager, "async_last_service_info", side_effect=AssertionError
+        ):
+            # Must not consult the manager's history; iterates owned
+            # entries exclusively.
+            worker._next_event_at(loop.time())
+    finally:
+        cancel()
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
+    """If owned view disagrees with manager history, _collect_due_buckets resyncs."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    s_a = _RecordingAutoScanner("AA:00:00:00:00:01", BluetoothScanningMode.AUTO)
+    s_b = _RecordingAutoScanner("AA:00:00:00:00:02", BluetoothScanningMode.AUTO)
+    c_a = manager.async_register_scanner(s_a)
+    c_b = manager.async_register_scanner(s_b)
+    try:
+        _inject(s_a, address)
+        worker_a = sched._workers[s_a.source]
+        worker_b = sched._workers[s_b.source]
+        # Force a drift: manager's history says B owns the address,
+        # scheduler still has it parked under A's view. (Simulates
+        # any future code path that mutates history without notifying
+        # on_advertisement.)
+        info = manager.async_last_service_info(address, False)
+        assert info is not None
+        info.source = s_b.source
+        entries = sched._needs[address]
+        for req in list(entries):
+            entries[req] = loop.time() - 1.0
+        await worker_a._tick()
+        # A skipped (foreign), reassigned ownership to B.
+        assert s_a.active_window_calls == []
+        assert address not in worker_a._owned_needs
+        assert address in worker_b._owned_needs
+        assert sched._owner_by_address[address] == s_b.source
+    finally:
+        c_a()
+        c_b()
+        cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -1750,7 +1750,7 @@ async def test_add_request_with_history_wakes_owning_worker() -> None:
         # Populate manager._all_history WITHOUT first registering an
         # active scan, so the inject doesn't go through on_advertisement's
         # wake-on-added path. add_request then sees the history entry
-        # and fires _wake_worker itself.
+        # and assign fires the worker wake itself.
         _inject(scanner, address)
         worker = sched._workers[scanner.source]
         worker._wake.clear()
@@ -1812,15 +1812,6 @@ async def test_start_ignores_non_auto_scanner() -> None:
     finally:
         c_auto()
         c_active()
-
-
-@pytest.mark.asyncio
-async def test_wake_worker_without_worker_is_no_op() -> None:
-    """_wake_worker tolerates being called for an unknown source."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    # No scanner registered for this source; should silently no-op.
-    sched._wake_worker("AA:AA:AA:AA:AA:AA")
 
 
 @pytest.mark.asyncio

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -115,6 +115,11 @@ def _assert_schedule_invariant(sched: object) -> None:
        is the *same* dict aliased from ``_due_at`` (not a copy).
     4. Addresses owned by a non-AUTO source do not appear in any
        worker's ``_owned_due_at``.
+    5. Each worker's hot-path ``_next_event_at`` returns without
+       raising. An empty bucket in ``_owned_due_at`` would crash with
+       ``ValueError`` from ``min(())``, so calling it here is the
+       active runtime check for the no-empty-buckets invariant the
+       production code relies on.
     """
     schedule = sched._schedule  # type: ignore[attr-defined]
     workers = sched._workers  # type: ignore[attr-defined]
@@ -147,6 +152,12 @@ def _assert_schedule_invariant(sched: object) -> None:
                     f"non-AUTO owner {source} leaked into worker "
                     f"{worker._scanner.source}'s _owned_due_at"
                 )
+    # Hot-path sanity: would raise ``ValueError`` from ``min(())`` if
+    # any owned bucket were empty. This keeps the guard the source
+    # code removed alive at the test layer.
+    now = asyncio.get_running_loop().time()
+    for worker in workers.values():
+        worker._next_event_at(now)
 
 
 @pytest.mark.asyncio

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6288,6 +6288,21 @@ async def test_unown_fails_fast_on_missing_owner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_detach_owned_fails_fast_on_missing_address() -> None:
+    """Pin the fail-fast contract: KeyError if worker doesn't own the address."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        with pytest.raises(KeyError):
+            worker._detach_owned("AA:00:00:00:00:99")
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
 async def test_next_event_at_fails_fast_on_empty_owned_bucket() -> None:
     """Pin the fail-fast contract: ValueError on an empty owned bucket."""
     manager = get_manager()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -1436,50 +1436,6 @@ async def test_next_event_at_returns_earliest_per_device_need() -> None:
 
 
 @pytest.mark.asyncio
-async def test_next_event_at_ignores_empty_or_foreign_entries() -> None:
-    """Empty entry dicts and entries owned by other scanners don't lower next-event."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    loop = asyncio.get_running_loop()
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        worker = sched._workers[scanner.source]
-        # Empty entries: hits the "if not entries: continue" branch.
-        sched._due_at["AA:BB:CC:DD:EE:01"] = {}
-        # No history at all: hits "if history is None or history.source != source".
-        cancel = manager.async_register_active_scan(
-            "AA:BB:CC:DD:EE:02", scan_interval=60.0
-        )
-        request = next(iter(sched._requests_by_address["AA:BB:CC:DD:EE:02"]))
-        sched._due_at["AA:BB:CC:DD:EE:02"] = {request: loop.time() - 1.0}
-        next_at = worker._next_event_at(loop.time())
-        # With no contributing per-device entries the next event reverts
-        # to the sweep cadence (well into the future via initial delay).
-        assert next_at == worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
-        cancel()
-        del sched._due_at["AA:BB:CC:DD:EE:01"]
-    finally:
-        register_cancel()
-
-
-@pytest.mark.asyncio
-async def test_dispatch_per_device_skips_empty_entries() -> None:
-    """An address whose entries dict is empty is skipped (no del, no fire)."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        sched._due_at["AA:BB:CC:DD:EE:FF"] = {}
-        await sched._workers[scanner.source]._tick()
-        assert scanner.active_window_calls == []
-        del sched._due_at["AA:BB:CC:DD:EE:FF"]
-    finally:
-        register_cancel()
-
-
-@pytest.mark.asyncio
 async def test_dispatch_per_device_skips_not_yet_due() -> None:
     """Entries with future due times don't fire."""
     manager = get_manager()
@@ -5937,115 +5893,6 @@ async def test_assign_owner_noop_when_source_unchanged() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ownership_assign_tolerates_missing_due_at_or_worker() -> None:
-    """assign() records the owner even when needs entry or worker is absent."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        worker = sched._workers[scanner.source]
-        # No _due_at entry for this address; attach path early-returns.
-        sched._ownership.assign("AA:00:00:00:00:99", scanner.source)
-        assert "AA:00:00:00:00:99" not in worker._owned_due_at
-        assert sched._ownership._owner_by_address["AA:00:00:00:00:99"] == (
-            scanner.source
-        )
-        # Worker not registered for this source; the owner mapping is
-        # still recorded even though no worker can attach.
-        sched._due_at["BB:00:00:00:00:99"] = {}
-        sched._ownership.assign("BB:00:00:00:00:99", "ZZ:99:99:99:99:99")
-        assert sched._ownership._owner_by_address["BB:00:00:00:00:99"] == (
-            "ZZ:99:99:99:99:99"
-        )
-        sched._due_at.pop("BB:00:00:00:00:99", None)
-        # Clean up the synthetic owner mappings so other tests do not
-        # see foreign state.
-        sched._ownership.unown("AA:00:00:00:00:99")
-        sched._ownership.unown("BB:00:00:00:00:99")
-    finally:
-        register_cancel()
-
-
-@pytest.mark.asyncio
-async def test_ownership_assign_tolerates_missing_old_worker() -> None:
-    """assign() reassigning from an unregistered old source must not raise."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        address = "AA:00:00:00:00:99"
-        sched._due_at[address] = {}
-        # Pre-seed an owner mapping pointing at an unregistered source
-        # so the detach branch hits the missing-worker path.
-        sched._ownership._owner_by_address[address] = "ZZ:99:99:99:99:99"
-        sched._ownership.assign(address, scanner.source)
-        assert sched._ownership._owner_by_address[address] == scanner.source
-        sched._due_at.pop(address, None)
-        sched._ownership.unown(address)
-    finally:
-        register_cancel()
-
-
-@pytest.mark.asyncio
-async def test_ownership_unown_tolerates_missing_old_worker() -> None:
-    """unown() against a source whose worker is gone must not raise."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    # Forge an owner mapping for an unregistered source so the detach
-    # branch hits a missing-worker path.
-    sched._ownership._owner_by_address["AA:00:00:00:00:99"] = "ZZ:99:99:99:99:99"
-    sched._ownership.unown("AA:00:00:00:00:99")
-    assert "AA:00:00:00:00:99" not in sched._ownership._owner_by_address
-
-
-@pytest.mark.asyncio
-async def test_ownership_unown_unknown_address_noop() -> None:
-    """unown() on an address with no owner mapping is a no-op."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    sched._ownership.unown("AA:00:00:00:00:99")
-    assert "AA:00:00:00:00:99" not in sched._ownership._owner_by_address
-
-
-@pytest.mark.asyncio
-async def test_next_event_at_skips_empty_owned_entries() -> None:
-    """An owned entry with an empty dict is skipped (defensive)."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    loop = asyncio.get_running_loop()
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        worker = sched._workers[scanner.source]
-        worker._owned_due_at["AA:00:00:00:00:99"] = {}
-        next_at = worker._next_event_at(loop.time())
-        assert next_at == worker._sweep_last_completed + AUTO_REDISCOVERY_INTERVAL
-    finally:
-        register_cancel()
-
-
-@pytest.mark.asyncio
-async def test_collect_due_buckets_skips_empty_owned_entries() -> None:
-    """An owned entry with an empty dict is skipped (defensive)."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    loop = asyncio.get_running_loop()
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        worker = sched._workers[scanner.source]
-        worker._owned_due_at["AA:00:00:00:00:99"] = {}
-        due_buckets, all_due, any_immediate = worker._collect_due_buckets(loop.time())
-        assert due_buckets == []
-        assert all_due == []
-        assert any_immediate is False
-    finally:
-        register_cancel()
-
-
-@pytest.mark.asyncio
 async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
     """_spawn_worker only attaches entries owned by the new scanner's source."""
     manager = get_manager()
@@ -6073,36 +5920,6 @@ async def test_spawn_worker_skips_foreign_preassigned_owners() -> None:
         cancel_b()
 
 
-def test_ownership_index_hook_worker_missing_worker() -> None:
-    """hook_worker returns cleanly when the source has no registered worker."""
-    due_at: dict[str, dict[ActiveScanRequest, float]] = {}
-    workers: dict[str, Any] = {}
-    idx = _OwnershipIndex(due_at, workers)
-    idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
-    # No worker registered for "ghost" — defensive guard returns early.
-    idx.hook_worker("ghost")
-    assert idx._owner_by_address["AA:00:00:00:00:99"] == "ghost"
-
-
-@pytest.mark.asyncio
-async def test_ownership_index_hook_worker_skips_address_without_due_at() -> None:
-    """hook_worker skips an owned address that has no _due_at entry."""
-    manager = get_manager()
-    sched = manager._auto_scheduler
-    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
-    register_cancel = manager.async_register_scanner(scanner)
-    try:
-        worker = sched._workers[scanner.source]
-        # Owner mapping exists but the address has no _due_at entry; the
-        # attach helper must early-return without touching the worker.
-        sched._ownership._owner_by_address["AA:00:00:00:00:99"] = scanner.source
-        sched._ownership.hook_worker(scanner.source)
-        assert "AA:00:00:00:00:99" not in worker._owned_due_at
-        sched._ownership._owner_by_address.pop("AA:00:00:00:00:99", None)
-    finally:
-        register_cancel()
-
-
 @pytest.mark.asyncio
 async def test_ownership_index_clear_source_no_match() -> None:
     """clear_source over an index with no addresses for the source is a no-op."""
@@ -6127,3 +5944,23 @@ def test_ownership_index_clear_no_workers() -> None:
     idx._owner_by_address["AA:00:00:00:00:99"] = "ghost"
     idx.clear()
     assert idx._owner_by_address == {}
+
+
+@pytest.mark.asyncio
+async def test_ownership_assign_records_non_auto_owner() -> None:
+    """assign() records ownership for a non-AUTO source despite no worker."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    # ACTIVE scanner does not get an AUTO worker; advertising from it
+    # exercises the ``new_worker is None`` branch in assign().
+    passive = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.PASSIVE)
+    register_cancel = manager.async_register_scanner(passive)
+    try:
+        _inject(passive, address)
+        assert sched._ownership._owner_by_address[address] == passive.source
+        assert passive.source not in sched._workers
+    finally:
+        cancel()
+        register_cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -5918,3 +5918,57 @@ async def test_collect_due_buckets_resyncs_owned_view_on_drift() -> None:
         c_a()
         c_b()
         cancel()
+
+
+@pytest.mark.asyncio
+async def test_assign_owner_noop_when_source_unchanged() -> None:
+    """Repeated on_advertisement from the same scanner is a no-op."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        worker = sched._workers[scanner.source]
+        entries = sched._needs[address]
+        owned_before = worker._owned_needs[address]
+        # Second injection from the same scanner: owner unchanged,
+        # owned-view aliasing preserved (same dict object).
+        _inject(scanner, address)
+        assert sched._owner_by_address[address] == scanner.source
+        assert worker._owned_needs[address] is owned_before
+        assert sched._needs[address] is entries
+    finally:
+        cancel()
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_attach_to_worker_tolerates_missing_state() -> None:
+    """_attach_to_worker no-ops when needs entry or worker is absent."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        worker = sched._workers[scanner.source]
+        # No _needs entry for this address — defensive early return.
+        sched._attach_to_worker(scanner.source, "AA:00:00:00:00:99")
+        assert "AA:00:00:00:00:99" not in worker._owned_needs
+        # Worker not registered for this source — also a no-op.
+        sched._needs["BB:00:00:00:00:99"] = {}
+        sched._attach_to_worker("ZZ:99:99:99:99:99", "BB:00:00:00:00:99")
+        sched._needs.pop("BB:00:00:00:00:99", None)
+    finally:
+        register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_detach_from_worker_tolerates_missing_worker() -> None:
+    """_detach_from_worker no-ops when the worker has been removed."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    # No scanner registered for this source — helper must not raise.
+    sched._detach_from_worker("ZZ:99:99:99:99:99", "AA:00:00:00:00:99")

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -5963,3 +5963,29 @@ async def test_ownership_assign_records_non_auto_owner() -> None:
     finally:
         cancel()
         register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_ownership_flip_from_non_auto_to_auto_owner() -> None:
+    """assign() handles flipping from a non-AUTO owner whose worker is absent."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(address, scan_interval=60.0)
+    passive = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.PASSIVE)
+    auto = _RecordingAutoScanner("AA:BB:CC:DD:EE:02", BluetoothScanningMode.AUTO)
+    c_passive = manager.async_register_scanner(passive)
+    c_auto = manager.async_register_scanner(auto)
+    try:
+        # PASSIVE first with weak RSSI; records owner mapping with no worker.
+        _inject_with_rssi(passive, address, rssi=-80)
+        assert sched._schedule._owner_by_address[address] == passive.source
+        # AUTO flip with stronger RSSI: old_source has no worker (PASSIVE),
+        # so the detach branch in assign() hits ``old_worker is None``.
+        _inject_with_rssi(auto, address, rssi=-30)
+        assert sched._schedule._owner_by_address[address] == auto.source
+        assert address in sched._workers[auto.source]._owned_due_at
+    finally:
+        cancel()
+        c_passive()
+        c_auto()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -15,7 +15,6 @@ from freezegun import freeze_time
 from habluetooth import (
     BaseHaScanner,
     BluetoothScanningMode,
-    BluetoothServiceInfoBleak,
     get_manager,
 )
 from habluetooth.auto_scheduler import ActiveScanRequest, _ScanSchedule
@@ -1660,37 +1659,23 @@ async def test_on_advertisement_with_all_requests_already_tracked() -> None:
     scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
     register_cancel = manager.async_register_scanner(scanner)
     address = "11:22:33:44:55:66"
-    req_a = ActiveScanRequest(address, 60.0, 10.0)
-    req_b = ActiveScanRequest(address, 120.0, 10.0)
-    sched._requests_by_address[address] = {req_a, req_b}
-    sched._schedule._due_at[address] = {req_a: 0.0, req_b: 0.0}
+    cancel_a = manager.async_register_active_scan(address, scan_interval=60.0)
+    cancel_b = manager.async_register_active_scan(address, scan_interval=120.0)
     try:
-        si = BluetoothServiceInfoBleak(
-            name="x",
-            address=address,
-            rssi=-50,
-            manufacturer_data={},
-            service_data={},
-            service_uuids=[],
-            source=scanner.source,
-            device=generate_ble_device(address, "x"),
-            advertisement=generate_advertisement_data(local_name="x"),
-            connectable=True,
-            time=asyncio.get_running_loop().time(),
-            tx_power=None,
-            raw=None,
-        )
+        # First advertisement seeds + assigns + wakes.
+        _inject(scanner, address)
         worker = sched._workers[scanner.source]
+        entries_before = dict(sched._schedule._due_at[address])
         worker._wake.clear()
-        sched.on_advertisement(si)
-        # Wake fires unconditionally so ownership-flip detection still
-        # triggers when every request was already in _due_at.
+        # Second advertisement: all requests already tracked; assign
+        # still wakes for ownership-flip detection.
+        _inject(scanner, address)
         assert worker._wake.is_set()
         # Sanity: the entries we put in are untouched.
-        assert sched._schedule._due_at[address] == {req_a: 0.0, req_b: 0.0}
+        assert sched._schedule._due_at[address] == entries_before
     finally:
-        sched._requests_by_address.pop(address, None)
-        sched._schedule._due_at.pop(address, None)
+        cancel_a()
+        cancel_b()
         register_cancel()
 
 
@@ -5963,6 +5948,38 @@ async def test_ownership_assign_records_non_auto_owner() -> None:
     finally:
         cancel()
         register_cancel()
+
+
+@pytest.mark.asyncio
+async def test_remove_non_auto_scanner_clears_its_owned_addresses() -> None:
+    """clear_source's non-AUTO fallback prunes addresses owned by a PASSIVE source."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    own_addr = "11:22:33:44:55:66"
+    other_addr = "11:22:33:44:55:77"
+    cancel_own = manager.async_register_active_scan(own_addr, scan_interval=60.0)
+    cancel_other = manager.async_register_active_scan(other_addr, scan_interval=60.0)
+    passive = _RecordingAutoScanner("AA:BB:CC:DD:EE:01", BluetoothScanningMode.PASSIVE)
+    auto = _RecordingAutoScanner("AA:BB:CC:DD:EE:02", BluetoothScanningMode.AUTO)
+    c_passive = manager.async_register_scanner(passive)
+    c_auto = manager.async_register_scanner(auto)
+    try:
+        # PASSIVE owns own_addr; AUTO owns other_addr. Both end up in
+        # _owner_by_address, so the non-AUTO clear loop iterates past
+        # other_addr without matching.
+        _inject(passive, own_addr)
+        _inject(auto, other_addr)
+        assert sched._schedule._owner_by_address[own_addr] == passive.source
+        assert sched._schedule._owner_by_address[other_addr] == auto.source
+        c_passive()
+        assert own_addr not in sched._schedule._owner_by_address
+        assert own_addr not in sched._schedule._due_at
+        # The AUTO-owned address is untouched.
+        assert sched._schedule._owner_by_address[other_addr] == auto.source
+    finally:
+        cancel_own()
+        cancel_other()
+        c_auto()
 
 
 @pytest.mark.asyncio

--- a/tests/test_benchmark_auto_scheduler.py
+++ b/tests/test_benchmark_auto_scheduler.py
@@ -96,7 +96,7 @@ def _setup_scheduler(
 
     Each address is owned by exactly one scanner via a round-robin
     advertisement injection that populates manager history and
-    auto_scheduler._needs (and the per-worker _owned_needs view on
+    auto_scheduler._due_at (and the per-worker _owned_due_at view on
     branches that have it).
     """
     manager = get_manager()
@@ -140,7 +140,7 @@ async def test_next_event_at_single_worker_8_scanners_200_devices(
     One worker computing its next wake among 8 scanners and 200 tracked devices.
 
     Prior to the per-worker owned-needs optimization (PR #508 / issue #506),
-    every wake iterated the global ``_needs`` map (200 entries) and called
+    every wake iterated the global ``_due_at`` map (200 entries) and called
     ``async_last_service_info`` on each to filter by ownership. The
     optimization narrows the iteration to the ~25 entries the worker owns
     and removes the per-entry history lookup. This benchmark exercises the
@@ -199,7 +199,7 @@ async def test_collect_due_buckets_single_worker_8_scanners_200_devices(
     One worker collecting due buckets among 8 scanners and 200 devices.
 
     ``_collect_due_buckets`` shares the same iteration-scope problem as
-    ``_next_event_at``: pre-#508 it iterated the global ``_needs`` and
+    ``_next_event_at``: pre-#508 it iterated the global ``_due_at`` and
     called ``async_last_service_info`` on every address to skip foreign
     owners; post-#508 it iterates the per-worker owned view directly.
     With entries scheduled well into the future, this exercises the


### PR DESCRIPTION
`_ScannerWorker._next_event_at` and `_collect_due_buckets` used to scan the global schedule and call `async_last_service_info` per address on every wake; with K AUTO workers each waking on every advertisement burst that was K·N work for one worker's worth of useful output. Each worker now keeps an `_owned_due_at` view of the entries it actually owns, aliased so in-place advances by `_advance_due` and `_dispatch_to_fallback` stay visible, and the hot paths iterate only that view.

The scheduling state lives behind a single `_ScanSchedule` cdef class that owns `_due_at`, `_owner_by_address`, and references the scheduler's `_workers`. The scheduler holds it as `self._schedule`. All mutations on a worker's `_owned_due_at` go through three thin cpdef methods on `_ScannerWorker` (`_attach_owned`, `_detach_owned`, `_clear_owned`), so the schedule never reaches into worker internals. `seed`, `drop`, `assign`, and `unown` on the schedule keep `_due_at`, `_owner_by_address`, and each worker's view in lock step; defensive guards that would silently absorb an invariant break have been removed.

CodSpeed on the prior attempt reports about 3.3x on the relevant benchmarks; this PR keeps that hot-path shape.

Replaces #508; closes #506.