### PR TITLE
fix: propagate refresh errors to concurrent adapter refresh waiters

### DIFF
--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -57,7 +57,7 @@ cdef class BluetoothManager:
     cdef public bint _debug
     cdef public bint shutdown
     cdef public object _loop
-    cdef public object _adapter_refresh_future
+    cdef public object _adapter_refresh_waiters
     cdef public object _recovery_lock
     cdef public set _disappeared_callbacks
     cdef public dict _allocations_callbacks

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -57,7 +57,7 @@ cdef class BluetoothManager:
     cdef public bint _debug
     cdef public bint shutdown
     cdef public object _loop
-    cdef public object _adapter_refresh_waiters
+    cdef public object _adapter_refresh_future
     cdef public object _recovery_lock
     cdef public set _disappeared_callbacks
     cdef public dict _allocations_callbacks

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -7,7 +7,6 @@ import itertools
 import logging
 import math
 import platform
-from contextlib import suppress
 from dataclasses import asdict
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final
@@ -204,7 +203,7 @@ class BluetoothManager:
         self.has_advertising_side_channel = False
         self._side_channel_scanners: dict[int, HaScanner] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._adapter_refresh_future: asyncio.Future[None] | None = None
+        self._adapter_refresh_future: asyncio.Future[BaseException | None] | None = None
         self._recovery_lock: asyncio.Lock = asyncio.Lock()
         self._disappeared_callbacks: set[Callable[[str], None]] = set()
         self._allocations_callbacks: dict[
@@ -305,21 +304,29 @@ class BluetoothManager:
 
     async def _async_refresh_adapters(self) -> None:
         """Refresh the adapters."""
-        if self._adapter_refresh_future:
-            await self._adapter_refresh_future
+        if (future := self._adapter_refresh_future) is not None:
+            # asyncio.wait does not propagate cancellation of the awaiting
+            # task onto the shared future, so a cancelled waiter cannot
+            # poison the leader or its siblings.
+            await asyncio.wait((future,))
+            if (result := future.result()) is not None:
+                raise result
             return
         if TYPE_CHECKING:
             assert self._loop is not None
-        self._adapter_refresh_future = self._loop.create_future()
+        self._adapter_refresh_future = future = self._loop.create_future()
         try:
             await self._bluetooth_adapters.refresh()
-            self._adapters = self._bluetooth_adapters.adapters
-            self._adapter_refresh_future.set_result(None)
         except BaseException as ex:
-            self._adapter_refresh_future.set_exception(ex)
-            with suppress(BaseException):
-                self._adapter_refresh_future.result()
+            # Store exception as the future's result (HA loader.py pattern)
+            # so waiters can read it via future.result() and re-raise. Using
+            # set_result avoids "exception was never retrieved" warnings
+            # when no waiters are parked.
+            future.set_result(ex)
             raise
+        else:
+            self._adapters = self._bluetooth_adapters.adapters
+            future.set_result(None)
         finally:
             self._adapter_refresh_future = None
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -53,7 +53,7 @@ from .models import (
 )
 from .scanner_device import BluetoothScannerDevice
 from .usage import install_multiple_bleak_catcher, uninstall_multiple_bleak_catcher
-from .util import async_reset_adapter
+from .util import async_reset_adapter, coalesce_concurrent_future
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -203,7 +203,7 @@ class BluetoothManager:
         self.has_advertising_side_channel = False
         self._side_channel_scanners: dict[int, HaScanner] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._adapter_refresh_future: asyncio.Future[BaseException | None] | None = None
+        self._adapter_refresh_future: asyncio.Future[None] | None = None
         self._recovery_lock: asyncio.Lock = asyncio.Lock()
         self._disappeared_callbacks: set[Callable[[str], None]] = set()
         self._allocations_callbacks: dict[
@@ -302,34 +302,11 @@ class BluetoothManager:
         self._disappeared_callbacks.add(callback)
         return partial(self._disappeared_callbacks.discard, callback)
 
+    @coalesce_concurrent_future("_adapter_refresh_future")
     async def _async_refresh_adapters(self) -> None:
         """Refresh the adapters."""
-        if (future := self._adapter_refresh_future) is not None:
-            # asyncio.wait does not propagate cancellation of the awaiting
-            # task onto the shared future, so a cancelled waiter cannot
-            # poison the leader or its siblings.
-            await asyncio.wait((future,))
-            if (result := future.result()) is not None:
-                raise result
-            return
-        if TYPE_CHECKING:
-            assert self._loop is not None
-        self._adapter_refresh_future = future = self._loop.create_future()
-        try:
-            await self._bluetooth_adapters.refresh()
-            self._adapters = self._bluetooth_adapters.adapters
-        except BaseException as ex:
-            # Store exception as the future's result (HA loader.py pattern)
-            # so waiters can read it via future.result() and re-raise. Using
-            # set_result avoids "exception was never retrieved" warnings
-            # when no waiters are parked. Covers both refresh() and the
-            # adapters property access so waiters never hang.
-            future.set_result(ex)
-            raise
-        else:
-            future.set_result(None)
-        finally:
-            self._adapter_refresh_future = None
+        await self._bluetooth_adapters.refresh()
+        self._adapters = self._bluetooth_adapters.adapters
 
     def get_cached_bluetooth_adapters(self) -> dict[str, AdapterDetails] | None:
         """Get cached bluetooth adapters synchronously."""

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -317,15 +317,16 @@ class BluetoothManager:
         self._adapter_refresh_future = future = self._loop.create_future()
         try:
             await self._bluetooth_adapters.refresh()
+            self._adapters = self._bluetooth_adapters.adapters
         except BaseException as ex:
             # Store exception as the future's result (HA loader.py pattern)
             # so waiters can read it via future.result() and re-raise. Using
             # set_result avoids "exception was never retrieved" warnings
-            # when no waiters are parked.
+            # when no waiters are parked. Covers both refresh() and the
+            # adapters property access so waiters never hang.
             future.set_result(ex)
             raise
         else:
-            self._adapters = self._bluetooth_adapters.adapters
             future.set_result(None)
         finally:
             self._adapter_refresh_future = None

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import math
 import platform
+from contextlib import suppress
 from dataclasses import asdict
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final
@@ -101,20 +102,6 @@ def _dispatch_bleak_callback(
         _LOGGER.exception("Error in callback: %s", bleak_callback.callback)
 
 
-def _resolve_waiters(
-    waiters: list[asyncio.Future[None]], exc: BaseException | None
-) -> None:
-    """Resolve pending refresh waiters with a result or exception."""
-    if exc is None:
-        for w in waiters:
-            if not w.done():
-                w.set_result(None)
-        return
-    for w in waiters:
-        if not w.done():
-            w.set_exception(exc)
-
-
 class BleakCallback:
     """Bleak callback."""
 
@@ -132,7 +119,7 @@ class BluetoothManager:
     """Manage Bluetooth."""
 
     __slots__ = (
-        "_adapter_refresh_waiters",
+        "_adapter_refresh_future",
         "_adapter_sources",
         "_adapters",
         "_advertisement_tracker",
@@ -217,7 +204,7 @@ class BluetoothManager:
         self.has_advertising_side_channel = False
         self._side_channel_scanners: dict[int, HaScanner] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._adapter_refresh_waiters: list[asyncio.Future[None]] | None = None
+        self._adapter_refresh_future: asyncio.Future[None] | None = None
         self._recovery_lock: asyncio.Lock = asyncio.Lock()
         self._disappeared_callbacks: set[Callable[[str], None]] = set()
         self._allocations_callbacks: dict[
@@ -318,35 +305,23 @@ class BluetoothManager:
 
     async def _async_refresh_adapters(self) -> None:
         """Refresh the adapters."""
+        if self._adapter_refresh_future:
+            await self._adapter_refresh_future
+            return
         if TYPE_CHECKING:
             assert self._loop is not None
-        if (waiters := self._adapter_refresh_waiters) is not None:
-            # Each waiter gets its own future so a cancelled waiter cannot
-            # transitively cancel siblings or the leader.
-            waiter = self._loop.create_future()
-            waiters.append(waiter)
-            await waiter
-            return
-        waiters = self._adapter_refresh_waiters = []
+        self._adapter_refresh_future = self._loop.create_future()
         try:
             await self._bluetooth_adapters.refresh()
             self._adapters = self._bluetooth_adapters.adapters
-        except asyncio.CancelledError:
-            # Map cancellation onto a non-cancellation exception for waiters
-            # so the leader's cancel does not transitively cancel unrelated
-            # callers parked on this refresh.
-            _resolve_waiters(
-                waiters,
-                RuntimeError("Adapter refresh cancelled before completion"),
-            )
-            raise
+            self._adapter_refresh_future.set_result(None)
         except BaseException as ex:
-            _resolve_waiters(waiters, ex)
+            self._adapter_refresh_future.set_exception(ex)
+            with suppress(BaseException):
+                self._adapter_refresh_future.result()
             raise
-        else:
-            _resolve_waiters(waiters, None)
         finally:
-            self._adapter_refresh_waiters = None
+            self._adapter_refresh_future = None
 
     def get_cached_bluetooth_adapters(self) -> dict[str, AdapterDetails] | None:
         """Get cached bluetooth adapters synchronously."""

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -101,6 +101,20 @@ def _dispatch_bleak_callback(
         _LOGGER.exception("Error in callback: %s", bleak_callback.callback)
 
 
+def _resolve_waiters(
+    waiters: list[asyncio.Future[None]], exc: BaseException | None
+) -> None:
+    """Resolve pending refresh waiters with a result or exception."""
+    if exc is None:
+        for w in waiters:
+            if not w.done():
+                w.set_result(None)
+        return
+    for w in waiters:
+        if not w.done():
+            w.set_exception(exc)
+
+
 class BleakCallback:
     """Bleak callback."""
 
@@ -321,20 +335,16 @@ class BluetoothManager:
             # Map cancellation onto a non-cancellation exception for waiters
             # so the leader's cancel does not transitively cancel unrelated
             # callers parked on this refresh.
-            cancel_exc = RuntimeError("Adapter refresh cancelled before completion")
-            for w in waiters:
-                if not w.done():
-                    w.set_exception(cancel_exc)
+            _resolve_waiters(
+                waiters,
+                RuntimeError("Adapter refresh cancelled before completion"),
+            )
             raise
         except BaseException as ex:
-            for w in waiters:
-                if not w.done():
-                    w.set_exception(ex)
+            _resolve_waiters(waiters, ex)
             raise
         else:
-            for w in waiters:
-                if not w.done():
-                    w.set_result(None)
+            _resolve_waiters(waiters, None)
         finally:
             self._adapter_refresh_waiters = None
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -118,7 +118,7 @@ class BluetoothManager:
     """Manage Bluetooth."""
 
     __slots__ = (
-        "_adapter_refresh_future",
+        "_adapter_refresh_waiters",
         "_adapter_sources",
         "_adapters",
         "_advertisement_tracker",
@@ -203,7 +203,7 @@ class BluetoothManager:
         self.has_advertising_side_channel = False
         self._side_channel_scanners: dict[int, HaScanner] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._adapter_refresh_future: asyncio.Future[None] | None = None
+        self._adapter_refresh_waiters: list[asyncio.Future[None]] | None = None
         self._recovery_lock: asyncio.Lock = asyncio.Lock()
         self._disappeared_callbacks: set[Callable[[str], None]] = set()
         self._allocations_callbacks: dict[
@@ -304,32 +304,39 @@ class BluetoothManager:
 
     async def _async_refresh_adapters(self) -> None:
         """Refresh the adapters."""
-        if (in_flight := self._adapter_refresh_future) is not None:
-            # ``shield`` so a cancelled waiter does not strand siblings or
-            # the leader still mid-refresh.
-            await asyncio.shield(in_flight)
-            return
         if TYPE_CHECKING:
             assert self._loop is not None
-        future = self._adapter_refresh_future = self._loop.create_future()
+        if (waiters := self._adapter_refresh_waiters) is not None:
+            # Each waiter gets its own future so a cancelled waiter cannot
+            # transitively cancel siblings or the leader.
+            waiter = self._loop.create_future()
+            waiters.append(waiter)
+            await waiter
+            return
+        waiters = self._adapter_refresh_waiters = []
         try:
             await self._bluetooth_adapters.refresh()
             self._adapters = self._bluetooth_adapters.adapters
         except asyncio.CancelledError:
             # Map cancellation onto a non-cancellation exception for waiters
             # so the leader's cancel does not transitively cancel unrelated
-            # callers parked on the shared future.
-            future.set_exception(
-                RuntimeError("Adapter refresh cancelled before completion")
-            )
+            # callers parked on this refresh.
+            cancel_exc = RuntimeError("Adapter refresh cancelled before completion")
+            for w in waiters:
+                if not w.done():
+                    w.set_exception(cancel_exc)
             raise
         except BaseException as ex:
-            future.set_exception(ex)
+            for w in waiters:
+                if not w.done():
+                    w.set_exception(ex)
             raise
         else:
-            future.set_result(None)
+            for w in waiters:
+                if not w.done():
+                    w.set_result(None)
         finally:
-            self._adapter_refresh_future = None
+            self._adapter_refresh_waiters = None
 
     def get_cached_bluetooth_adapters(self) -> dict[str, AdapterDetails] | None:
         """Get cached bluetooth adapters synchronously."""

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -304,17 +304,33 @@ class BluetoothManager:
 
     async def _async_refresh_adapters(self) -> None:
         """Refresh the adapters."""
-        if self._adapter_refresh_future:
-            await self._adapter_refresh_future
+        if (in_flight := self._adapter_refresh_future) is not None:
+            # ``shield`` so a cancelled waiter does not strand siblings or
+            # the leader still mid-refresh.
+            await asyncio.shield(in_flight)
             return
         if TYPE_CHECKING:
             assert self._loop is not None
-        self._adapter_refresh_future = self._loop.create_future()
+        future = self._adapter_refresh_future = self._loop.create_future()
         try:
             await self._bluetooth_adapters.refresh()
             self._adapters = self._bluetooth_adapters.adapters
+        except asyncio.CancelledError:
+            # Map cancellation onto a non-cancellation exception for waiters
+            # so the leader's cancel does not transitively cancel unrelated
+            # callers parked on the shared future.
+            if not future.done():
+                future.set_exception(
+                    RuntimeError("Adapter refresh cancelled before completion")
+                )
+            raise
+        except BaseException as ex:
+            if not future.done():
+                future.set_exception(ex)
+            raise
+        else:
+            future.set_result(None)
         finally:
-            self._adapter_refresh_future.set_result(None)
             self._adapter_refresh_future = None
 
     def get_cached_bluetooth_adapters(self) -> dict[str, AdapterDetails] | None:

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -319,14 +319,12 @@ class BluetoothManager:
             # Map cancellation onto a non-cancellation exception for waiters
             # so the leader's cancel does not transitively cancel unrelated
             # callers parked on the shared future.
-            if not future.done():
-                future.set_exception(
-                    RuntimeError("Adapter refresh cancelled before completion")
-                )
+            future.set_exception(
+                RuntimeError("Adapter refresh cancelled before completion")
+            )
             raise
         except BaseException as ex:
-            if not future.done():
-                future.set_exception(ex)
+            future.set_exception(ex)
             raise
         else:
             future.set_result(None)

--- a/src/habluetooth/util.py
+++ b/src/habluetooth/util.py
@@ -1,9 +1,21 @@
 """The bluetooth utilities."""
 
+from __future__ import annotations
+
+import asyncio
+import functools
+from contextlib import suppress
 from functools import cache
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from bluetooth_auto_recovery import recover_adapter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 async def async_reset_adapter(
@@ -20,3 +32,52 @@ async def async_reset_adapter(
 def is_docker_env() -> bool:
     """Return True if we run in a docker env."""
     return Path("/.dockerenv").exists()
+
+
+def coalesce_concurrent_future(
+    attr: str,
+) -> Callable[
+    [Callable[_P, Coroutine[Any, Any, _R]]],
+    Callable[_P, Coroutine[Any, Any, _R]],
+]:
+    """
+    Coalesce concurrent async method calls onto a single shared future.
+
+    Mirrors the home-assistant ``loader.py`` shared-future pattern. The
+    first caller runs the wrapped coroutine and the result (or exception)
+    is published on a future stored at ``self.<attr>``; concurrent callers
+    wait on the same future and observe the same outcome. ``asyncio.wait``
+    is used on the waiter side so a cancelled waiter does not transitively
+    cancel the shared future and strand the leader or its siblings.
+    """
+
+    def decorator(
+        func: Callable[_P, Coroutine[Any, Any, _R]],
+    ) -> Callable[_P, Coroutine[Any, Any, _R]]:
+        @functools.wraps(func)
+        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            self = args[0]
+            future: asyncio.Future[_R] | None = getattr(self, attr)
+            if future is not None:
+                await asyncio.wait((future,))
+                return future.result()
+            future = asyncio.get_running_loop().create_future()
+            setattr(self, attr, future)
+            try:
+                result = await func(*args, **kwargs)
+            except BaseException as ex:
+                future.set_exception(ex)
+                # Mark the exception as retrieved so asyncio does not warn
+                # when no concurrent waiters consume it.
+                with suppress(BaseException):
+                    future.result()
+                raise
+            else:
+                future.set_result(result)
+                return result
+            finally:
+                setattr(self, attr, None)
+
+        return wrapper
+
+    return decorator

--- a/src/habluetooth/util.py
+++ b/src/habluetooth/util.py
@@ -50,10 +50,15 @@ def coalesce_concurrent_future(
     is used on the waiter side so a cancelled waiter does not transitively
     cancel the shared future and strand the leader or its siblings.
 
+    Cancellation contract: if the leader is cancelled the ``CancelledError``
+    is forwarded as-is to every waiter via ``set_exception`` (matching
+    ``loader.py``); callers that need to be insulated from leader
+    cancellation should wrap their own call in ``asyncio.shield``.
+
     Pre-condition: ``self.<attr>`` must already exist on the instance and
     be initialised to ``None`` before the first call. The decorator reads
     it via ``getattr`` (no default) and resets it to ``None`` in ``finally``
-    once the leader completes. Only usable on instance methods — ``self``
+    once the leader completes. Only usable on instance methods, ``self``
     is taken from ``args[0]``.
     """
 

--- a/src/habluetooth/util.py
+++ b/src/habluetooth/util.py
@@ -49,6 +49,12 @@ def coalesce_concurrent_future(
     wait on the same future and observe the same outcome. ``asyncio.wait``
     is used on the waiter side so a cancelled waiter does not transitively
     cancel the shared future and strand the leader or its siblings.
+
+    Pre-condition: ``self.<attr>`` must already exist on the instance and
+    be initialised to ``None`` before the first call. The decorator reads
+    it via ``getattr`` (no default) and resets it to ``None`` in ``finally``
+    once the leader completes. Only usable on instance methods — ``self``
+    is taken from ``args[0]``.
     """
 
     def decorator(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Iterable
 from datetime import timedelta
 from typing import Any
-from unittest.mock import ANY, AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 from bleak_retry_connector import AllocationChange, Allocations, BleakSlotManager
@@ -1681,4 +1681,57 @@ async def test_async_refresh_adapters_waiter_cancellation_does_not_break_leader(
         release_refresh.set()
         await leader
         await waiter_b
+    assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_adapters_property_failure_propagates() -> None:
+    """Property access failure after refresh() must not strand waiters."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def slow_refresh() -> None:
+        refresh_started.set()
+        await release_refresh.wait()
+
+    failing_adapters = PropertyMock(side_effect=RuntimeError("adapters boom"))
+    with (
+        patch.object(manager._bluetooth_adapters, "refresh", new=slow_refresh),
+        patch.object(type(manager._bluetooth_adapters), "adapters", failing_adapters),
+    ):
+        leader = asyncio.create_task(manager._async_refresh_adapters())
+        await refresh_started.wait()
+        waiter = asyncio.create_task(manager._async_refresh_adapters())
+        await asyncio.sleep(0)
+        release_refresh.set()
+        with pytest.raises(RuntimeError, match="adapters boom"):
+            await leader
+        with pytest.raises(RuntimeError, match="adapters boom"):
+            await waiter
+    assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_recovers_after_prior_failure() -> None:
+    """Sequential call after a failed refresh must start fresh and succeed."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    call_count = 0
+
+    async def flaky_refresh() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            msg = "first boom"
+            raise RuntimeError(msg)
+
+    with patch.object(manager._bluetooth_adapters, "refresh", new=flaky_refresh):
+        with pytest.raises(RuntimeError, match="first boom"):
+            await manager._async_refresh_adapters()
+        assert manager._adapter_refresh_future is None
+        # Second call must start a fresh refresh, not reuse stale future state.
+        await manager._async_refresh_adapters()
+    assert call_count == 2
     assert manager._adapter_refresh_future is None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1594,8 +1594,8 @@ async def test_async_refresh_adapters_propagates_exception_to_waiters() -> None:
             await waiter_a
         with pytest.raises(RuntimeError, match="boom"):
             await waiter_b
-    # Waiter list must be cleared so the next call refreshes again.
-    assert manager._adapter_refresh_waiters is None
+    # Shared future must be cleared so the next call refreshes again.
+    assert manager._adapter_refresh_future is None
 
 
 @pytest.mark.asyncio
@@ -1624,7 +1624,7 @@ async def test_async_refresh_adapters_success_resolves_waiters() -> None:
         await waiter_a
         await waiter_b
     assert call_count == 1
-    assert manager._adapter_refresh_waiters is None
+    assert manager._adapter_refresh_future is None
 
 
 @pytest.mark.asyncio
@@ -1651,31 +1651,4 @@ async def test_async_refresh_adapters_leader_cancellation_does_not_silently_succ
         # Waiter must observe a failure, not silently complete.
         with pytest.raises(BaseException):  # noqa: B017, PT011
             await waiter
-    assert manager._adapter_refresh_waiters is None
-
-
-@pytest.mark.asyncio
-async def test_async_refresh_adapters_waiter_cancellation_does_not_break_leader() -> (
-    None
-):
-    """A cancelled waiter must not break the leader's refresh."""
-    manager = get_manager()
-    assert manager._bluetooth_adapters is not None
-    refresh_started = asyncio.Event()
-    release_refresh = asyncio.Event()
-
-    async def slow_refresh() -> None:
-        refresh_started.set()
-        await release_refresh.wait()
-
-    with patch.object(manager._bluetooth_adapters, "refresh", new=slow_refresh):
-        leader = asyncio.create_task(manager._async_refresh_adapters())
-        await refresh_started.wait()
-        waiter = asyncio.create_task(manager._async_refresh_adapters())
-        await asyncio.sleep(0)
-        waiter.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await waiter
-        release_refresh.set()
-        await leader
-    assert manager._adapter_refresh_waiters is None
+    assert manager._adapter_refresh_future is None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1594,8 +1594,8 @@ async def test_async_refresh_adapters_propagates_exception_to_waiters() -> None:
             await waiter_a
         with pytest.raises(RuntimeError, match="boom"):
             await waiter_b
-    # Future must be cleared so the next call refreshes again.
-    assert manager._adapter_refresh_future is None
+    # Waiter list must be cleared so the next call refreshes again.
+    assert manager._adapter_refresh_waiters is None
 
 
 @pytest.mark.asyncio
@@ -1624,7 +1624,7 @@ async def test_async_refresh_adapters_success_resolves_waiters() -> None:
         await waiter_a
         await waiter_b
     assert call_count == 1
-    assert manager._adapter_refresh_future is None
+    assert manager._adapter_refresh_waiters is None
 
 
 @pytest.mark.asyncio
@@ -1651,14 +1651,14 @@ async def test_async_refresh_adapters_leader_cancellation_does_not_silently_succ
         # Waiter must observe a failure, not silently complete.
         with pytest.raises(BaseException):  # noqa: B017, PT011
             await waiter
-    assert manager._adapter_refresh_future is None
+    assert manager._adapter_refresh_waiters is None
 
 
 @pytest.mark.asyncio
 async def test_async_refresh_adapters_waiter_cancellation_does_not_break_leader() -> (
     None
 ):
-    """A cancelled waiter must not poison the shared refresh future."""
+    """A cancelled waiter must not break the leader's refresh."""
     manager = get_manager()
     assert manager._bluetooth_adapters is not None
     refresh_started = asyncio.Event()
@@ -1678,4 +1678,4 @@ async def test_async_refresh_adapters_waiter_cancellation_does_not_break_leader(
             await waiter
         release_refresh.set()
         await leader
-    assert manager._adapter_refresh_future is None
+    assert manager._adapter_refresh_waiters is None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1564,3 +1564,118 @@ async def test_async_get_bluetooth_adapters_cached_false_triggers_refresh() -> N
     ) as mock_refresh:
         await manager.async_get_bluetooth_adapters(cached=False)
     mock_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_propagates_exception_to_waiters() -> None:
+    """Concurrent callers must see the refresh exception, not silent success."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def slow_failing_refresh() -> None:
+        refresh_started.set()
+        await release_refresh.wait()
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with patch.object(manager._bluetooth_adapters, "refresh", new=slow_failing_refresh):
+        leader = asyncio.create_task(manager._async_refresh_adapters())
+        await refresh_started.wait()
+        waiter_a = asyncio.create_task(manager._async_refresh_adapters())
+        waiter_b = asyncio.create_task(manager._async_refresh_adapters())
+        # Yield so waiters register on the shared future.
+        await asyncio.sleep(0)
+        release_refresh.set()
+        with pytest.raises(RuntimeError, match="boom"):
+            await leader
+        with pytest.raises(RuntimeError, match="boom"):
+            await waiter_a
+        with pytest.raises(RuntimeError, match="boom"):
+            await waiter_b
+    # Future must be cleared so the next call refreshes again.
+    assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_success_resolves_waiters() -> None:
+    """Concurrent callers all see success and share the same refresh call."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+    call_count = 0
+
+    async def slow_refresh() -> None:
+        nonlocal call_count
+        call_count += 1
+        refresh_started.set()
+        await release_refresh.wait()
+
+    with patch.object(manager._bluetooth_adapters, "refresh", new=slow_refresh):
+        leader = asyncio.create_task(manager._async_refresh_adapters())
+        await refresh_started.wait()
+        waiter_a = asyncio.create_task(manager._async_refresh_adapters())
+        waiter_b = asyncio.create_task(manager._async_refresh_adapters())
+        await asyncio.sleep(0)
+        release_refresh.set()
+        await leader
+        await waiter_a
+        await waiter_b
+    assert call_count == 1
+    assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_leader_cancellation_does_not_silently_succeed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Leader cancellation must not let waiters proceed as if refresh succeeded."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    refresh_started = asyncio.Event()
+
+    async def hanging_refresh() -> None:
+        refresh_started.set()
+        await asyncio.Event().wait()  # never resolves
+
+    with patch.object(manager._bluetooth_adapters, "refresh", new=hanging_refresh):
+        leader = asyncio.create_task(manager._async_refresh_adapters())
+        await refresh_started.wait()
+        waiter = asyncio.create_task(manager._async_refresh_adapters())
+        await asyncio.sleep(0)
+        leader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await leader
+        # Waiter must observe a failure, not silently complete.
+        with pytest.raises(BaseException):  # noqa: B017, PT011
+            await waiter
+    assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_waiter_cancellation_does_not_break_leader() -> (
+    None
+):
+    """A cancelled waiter must not poison the shared refresh future."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def slow_refresh() -> None:
+        refresh_started.set()
+        await release_refresh.wait()
+
+    with patch.object(manager._bluetooth_adapters, "refresh", new=slow_refresh):
+        leader = asyncio.create_task(manager._async_refresh_adapters())
+        await refresh_started.wait()
+        waiter = asyncio.create_task(manager._async_refresh_adapters())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        release_refresh.set()
+        await leader
+    assert manager._adapter_refresh_future is None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1648,7 +1648,37 @@ async def test_async_refresh_adapters_leader_cancellation_does_not_silently_succ
         leader.cancel()
         with pytest.raises(asyncio.CancelledError):
             await leader
-        # Waiter must observe a failure, not silently complete.
-        with pytest.raises(BaseException):  # noqa: B017, PT011
+        # Waiter must observe a CancelledError, not silently complete.
+        with pytest.raises(asyncio.CancelledError):
             await waiter
+    assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_adapters_waiter_cancellation_does_not_break_leader() -> (
+    None
+):
+    """Cancelling one waiter must not strand the leader or other siblings."""
+    manager = get_manager()
+    assert manager._bluetooth_adapters is not None
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def slow_refresh() -> None:
+        refresh_started.set()
+        await release_refresh.wait()
+
+    with patch.object(manager._bluetooth_adapters, "refresh", new=slow_refresh):
+        leader = asyncio.create_task(manager._async_refresh_adapters())
+        await refresh_started.wait()
+        waiter_a = asyncio.create_task(manager._async_refresh_adapters())
+        waiter_b = asyncio.create_task(manager._async_refresh_adapters())
+        await asyncio.sleep(0)
+        waiter_a.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter_a
+        # Leader and surviving waiter must still complete normally.
+        release_refresh.set()
+        await leader
+        await waiter_b
     assert manager._adapter_refresh_future is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from habluetooth.util import async_reset_adapter, is_docker_env
+from habluetooth.util import (
+    async_reset_adapter,
+    coalesce_concurrent_future,
+    is_docker_env,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -65,3 +70,131 @@ def test_is_docker_env_false(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("habluetooth.util.Path.exists", lambda self: False)
     assert is_docker_env() is False
     is_docker_env.cache_clear()
+
+
+class _Coalesced:
+    """Test fixture instance for the coalesce_concurrent_future decorator."""
+
+    def __init__(self) -> None:
+        self._fut: asyncio.Future[int] | None = None
+        self.call_count = 0
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.return_value = 42
+        self.raise_exc: BaseException | None = None
+
+    @coalesce_concurrent_future("_fut")
+    async def work(self) -> int:
+        self.call_count += 1
+        self.started.set()
+        await self.release.wait()
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return self.return_value
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_single_call_returns_result() -> None:
+    """A lone caller runs the wrapped coroutine and gets its result."""
+    obj = _Coalesced()
+    obj.release.set()
+    assert await obj.work() == 42
+    assert obj.call_count == 1
+    assert obj._fut is None
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_concurrent_callers_share_one_call() -> None:
+    """Concurrent callers share a single underlying invocation."""
+    obj = _Coalesced()
+    leader = asyncio.create_task(obj.work())
+    await obj.started.wait()
+    waiter_a = asyncio.create_task(obj.work())
+    waiter_b = asyncio.create_task(obj.work())
+    await asyncio.sleep(0)
+    obj.release.set()
+    assert await leader == 42
+    assert await waiter_a == 42
+    assert await waiter_b == 42
+    assert obj.call_count == 1
+    assert obj._fut is None
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_propagates_exception_to_waiters() -> None:
+    """Leader exception is observed by every concurrent waiter."""
+    obj = _Coalesced()
+    obj.raise_exc = RuntimeError("boom")
+    leader = asyncio.create_task(obj.work())
+    await obj.started.wait()
+    waiter = asyncio.create_task(obj.work())
+    await asyncio.sleep(0)
+    obj.release.set()
+    with pytest.raises(RuntimeError, match="boom"):
+        await leader
+    with pytest.raises(RuntimeError, match="boom"):
+        await waiter
+    assert obj._fut is None
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_leader_cancellation_surfaces_to_waiters() -> (
+    None
+):
+    """Leader cancellation propagates to waiters, future is cleared."""
+    obj = _Coalesced()
+    leader = asyncio.create_task(obj.work())
+    await obj.started.wait()
+    waiter = asyncio.create_task(obj.work())
+    await asyncio.sleep(0)
+    leader.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await leader
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert obj._fut is None
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_waiter_cancel_does_not_strand_leader() -> (
+    None
+):
+    """Cancelling a waiter does not poison the shared future."""
+    obj = _Coalesced()
+    leader = asyncio.create_task(obj.work())
+    await obj.started.wait()
+    waiter_a = asyncio.create_task(obj.work())
+    waiter_b = asyncio.create_task(obj.work())
+    await asyncio.sleep(0)
+    waiter_a.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_a
+    obj.release.set()
+    assert await leader == 42
+    assert await waiter_b == 42
+    assert obj._fut is None
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_resets_between_sequential_calls() -> None:
+    """Future state resets so a later call runs fresh."""
+    obj = _Coalesced()
+    obj.release.set()
+    assert await obj.work() == 42
+    assert obj._fut is None
+    obj.return_value = 7
+    assert await obj.work() == 7
+    assert obj.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_coalesce_concurrent_future_requires_attribute_initialised() -> None:
+    """Missing attribute on the instance raises AttributeError."""
+
+    class _Missing:
+        @coalesce_concurrent_future("_fut")
+        async def work(self) -> int:
+            return 1
+
+    with pytest.raises(AttributeError):
+        await _Missing().work()


### PR DESCRIPTION
`_async_refresh_adapters` coalesced concurrent callers onto a shared future but always resolved with `set_result(None)` in `finally`, so waiters silently proceeded against a stale `_adapters` map even when the leader's `refresh()` raised; only the leader saw the real error.

Lift the shared future pattern from Home Assistant's `loader.py` into a reusable `coalesce_concurrent_future` decorator and apply it to `_async_refresh_adapters`, so the leader's success or failure is propagated to every awaiter; the property read on `self._bluetooth_adapters.adapters` after `refresh()` returns also flows through the same path so a late failure cannot strand waiters.

Closes #504