### PR TITLE
feat: add async_address_reachability_diagnostics for unreachable devices

### DIFF
--- a/src/habluetooth/__init__.py
+++ b/src/habluetooth/__init__.py
@@ -17,6 +17,7 @@ from .const import (
 )
 from .manager import BluetoothManager
 from .models import (
+    BluetoothReachabilityIntent,
     BluetoothServiceInfo,
     BluetoothServiceInfoBleak,
     HaBluetoothConnector,
@@ -51,6 +52,7 @@ __all__ = [
     "BaseHaRemoteScanner",
     "BaseHaScanner",
     "BluetoothManager",
+    "BluetoothReachabilityIntent",
     "BluetoothScannerDevice",
     "BluetoothScanningMode",
     "BluetoothServiceInfo",

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -256,6 +256,19 @@ class BaseHaScanner:
         """Return the number of failures."""
         return self._connect_failures.get(address, 0)
 
+    def connections_in_progress(self) -> int:
+        """Return the number of connection attempts currently in progress."""
+        return self._connections_in_progress()
+
+    def connection_failures(self, address: str) -> int:
+        """Return the number of failed connection attempts for an address."""
+        return self._connection_failures(address)
+
+    @property
+    def connecting_count(self) -> int:
+        """Return the number of in-flight connections that pause scanning."""
+        return self._connecting
+
     def time_since_last_detection(self) -> float:
         """Return the time since the last detection."""
         return monotonic_time_coarse() - self._last_detection

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -257,7 +257,12 @@ class BaseHaScanner:
         return self._connect_failures.get(address, 0)
 
     def connections_in_progress(self) -> int:
-        """Return the number of connection attempts currently in progress."""
+        """
+        Return the number of per-address connection attempts in progress.
+
+        This sums the in-flight connect attempts tracked per address; it is a
+        different counter from ``connecting_count`` (the scanning-pause counter).
+        """
         return self._connections_in_progress()
 
     def connection_failures(self, address: str) -> int:
@@ -266,7 +271,14 @@ class BaseHaScanner:
 
     @property
     def connecting_count(self) -> int:
-        """Return the number of in-flight connections that pause scanning."""
+        """
+        Return the number of connections currently pausing scanning.
+
+        This is the scanning-pause counter incremented for the duration of the
+        ``connecting()`` context manager; while it is non-zero ``scanning`` is
+        False. It is distinct from ``connections_in_progress()``, which counts
+        per-address connect attempts.
+        """
         return self._connecting
 
     def time_since_last_detection(self) -> float:

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1120,7 +1120,7 @@ class BluetoothManager:
             if (allocations := d.scanner.get_allocations()) is not None
             and allocations.slots > 0
         ]
-        if reported and all(allocations.free == 0 for allocations in reported):
+        if reported and all(a.free == 0 for a in reported):
             parts.append(
                 "connectable scanner(s) that report slot allocations are all full"
             )

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1007,6 +1007,10 @@ class BluetoothManager:
         connection slots, while a caller that wants to connect (``CONNECTION``)
         does. This is read-only and side-effect free, and is only meant for the
         cold error path, not the hot advertisement path.
+
+        The returned string is for embedding in human-readable error and log
+        messages only; its wording and format are not stable and must not be
+        parsed. The address is not included, callers already have it in context.
         """
         now = monotonic_time_coarse()
         parts: list[str] = []
@@ -1041,7 +1045,7 @@ class BluetoothManager:
                 f"last advertisement {now - info.time:.0f}s ago via {info.source}"
             )
 
-        return f"{address}: " + "; ".join(parts)
+        return "; ".join(parts)
 
     def _scanner_availability_summary(self) -> str:
         """

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -45,6 +45,7 @@ from .const import (
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .models import (
+    BluetoothReachabilityIntent,
     BluetoothServiceInfoBleak,
     HaBluetoothSlotAllocations,
     HaScannerModeChange,
@@ -993,46 +994,111 @@ class BluetoothManager:
         histories = self._connectable_history if connectable else self._all_history
         return histories.get(address)
 
-    def async_address_reachability_diagnostics(self, address: str) -> str:
+    def async_address_reachability_diagnostics(
+        self, address: str, intent: BluetoothReachabilityIntent
+    ) -> str:
         """
         Return a human-readable explanation of an address's reachability.
 
         Intended for embedding in error and log messages when a device cannot
-        be found or connected to. This is a read-only, side-effect free summary
-        of which scanners currently see the address, their RSSI, slot
-        availability and how recently the device last advertised. It is only
-        meant for the cold error path, not the hot advertisement path.
+        be found or used. The ``intent`` selects which facts are relevant: a
+        caller that only consumes advertisements (``PASSIVE_ADVERTISEMENT`` /
+        ``ACTIVE_ADVERTISEMENT``) does not care about connectable paths or
+        connection slots, while a caller that wants to connect (``CONNECTION``)
+        does. This is read-only and side-effect free, and is only meant for the
+        cold error path, not the hot advertisement path.
         """
         now = monotonic_time_coarse()
-        in_connectable = address in self._connectable_history
-        in_all = address in self._all_history
         parts: list[str] = []
+        # All scanners (connectable and non-connectable) that currently see the
+        # address. Materialized once; reused for the per-scanner detail below.
+        devices = self.async_scanner_devices_by_address(address, False)
 
-        if in_connectable:
+        if intent is BluetoothReachabilityIntent.CONNECTION:
+            self._append_connection_diagnostics(address, devices, parts)
+        else:
+            self._append_advertisement_diagnostics(address, devices, parts)
+
+        parts.append(self._scanner_availability_summary())
+
+        for device in devices:
+            scanner = device.scanner
+            detail = (
+                f"{scanner.name} (connectable={scanner.connectable}, "
+                f"rssi={device.advertisement.rssi}"
+            )
+            if intent is BluetoothReachabilityIntent.CONNECTION:
+                detail += (
+                    f", failures={scanner._connection_failures(address)}, "
+                    f"in_progress={scanner._connections_in_progress()}"
+                )
+                if (allocations := scanner.get_allocations()) is not None:
+                    detail += f", slots={allocations.free}/{allocations.slots}"
+            parts.append(detail + ")")
+
+        if (info := self._all_history.get(address)) is not None:
+            parts.append(
+                f"last advertisement {now - info.time:.0f}s ago via {info.source}"
+            )
+
+        return f"{address}: " + "; ".join(parts)
+
+    def _scanner_availability_summary(self) -> str:
+        """
+        Summarize how many scanners are registered, scanning and connectable.
+
+        A scanner pauses scanning while it has a connection in progress, so a
+        device can disappear from every scanner if they are all busy connecting;
+        this is called out explicitly because no advertisements can be received
+        while no scanner is scanning.
+        """
+        scanners = self.async_current_scanners()
+        total = len(scanners)
+        scanning = 0
+        connecting = 0
+        connectable = 0
+        for scanner in scanners:
+            if scanner.connectable:
+                connectable += 1
+            if scanner.scanning:
+                scanning += 1
+            elif scanner._connecting:
+                connecting += 1
+        summary = (
+            f"{total} scanner(s) registered, {scanning} scanning, "
+            f"{connectable} connectable"
+        )
+        if connecting:
+            summary += f", {connecting} paused while connecting"
+        if total and scanning == 0:
+            summary += (
+                "; no scanner is currently scanning so no advertisements can be "
+                "received"
+            )
+            if connecting == total:
+                summary += (
+                    " (all are paused retrying connections; the available adapters "
+                    "are overloaded, add more Bluetooth adapters or proxies)"
+                )
+        return summary
+
+    def _append_connection_diagnostics(
+        self,
+        address: str,
+        devices: list[BluetoothScannerDevice],
+        parts: list[str],
+    ) -> None:
+        """Append connectable-path reachability facts for a connect intent."""
+        if address in self._connectable_history:
             parts.append("in connectable history")
-        elif in_all:
+        elif address in self._all_history:
             parts.append("only in non-connectable history (no connectable path)")
         else:
             parts.append("unknown (never seen by any scanner)")
 
-        connectable_count = self.async_scanner_count(True)
-        total_count = self.async_scanner_count(False)
-        if connectable_count == 0:
-            parts.append(
-                f"no connectable scanners are registered ({total_count} total)"
-            )
-
-        # One pass over every scanner (connectable and non-connectable) that
-        # currently has this address discovered.
-        devices = self.async_scanner_devices_by_address(address, False)
         connectable_devices = [d for d in devices if d.scanner.connectable]
         non_connectable_devices = [d for d in devices if not d.scanner.connectable]
-
-        if (
-            not connectable_devices
-            and non_connectable_devices
-            and connectable_count != 0
-        ):
+        if not connectable_devices and non_connectable_devices:
             parts.append(
                 f"seen by {len(non_connectable_devices)} scanner(s) but none with"
                 " a connectable path"
@@ -1047,24 +1113,20 @@ class BluetoothManager:
                 "connectable scanner(s) see it but all connection slots are in use"
             )
 
-        for device in devices:
-            scanner = device.scanner
-            detail = (
-                f"{scanner.name} (connectable={scanner.connectable}, "
-                f"rssi={device.advertisement.rssi}, "
-                f"failures={scanner._connection_failures(address)}, "
-                f"in_progress={scanner._connections_in_progress()}"
-            )
-            if (allocations := scanner.get_allocations()) is not None:
-                detail += f", slots={allocations.free}/{allocations.slots}"
-            parts.append(detail + ")")
-
-        if (info := self._all_history.get(address)) is not None:
-            parts.append(
-                f"last advertisement {now - info.time:.0f}s ago via {info.source}"
-            )
-
-        return f"{address}: " + "; ".join(parts)
+    def _append_advertisement_diagnostics(
+        self,
+        address: str,
+        devices: list[BluetoothScannerDevice],
+        parts: list[str],
+    ) -> None:
+        """Append advertisement-only reachability facts for an advertisement intent."""
+        # Advertisement callers only need adverts, so connectable paths and
+        # connection slots are irrelevant; report only whether the device is
+        # being seen and by how many scanners.
+        if address in self._all_history:
+            parts.append(f"advertising, seen by {len(devices)} scanner(s)")
+        else:
+            parts.append("unknown (never seen by any scanner)")
 
     def _async_unregister_scanner_internal(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1033,8 +1033,8 @@ class BluetoothManager:
             )
             if intent is BluetoothReachabilityIntent.CONNECTION:
                 detail += (
-                    f", failures={scanner._connection_failures(address)}, "
-                    f"in_progress={scanner._connections_in_progress()}"
+                    f", failures={scanner.connection_failures(address)}, "
+                    f"in_progress={scanner.connections_in_progress()}"
                 )
                 if (allocations := scanner.get_allocations()) is not None:
                     detail += f", slots={allocations.free}/{allocations.slots}"
@@ -1066,7 +1066,7 @@ class BluetoothManager:
                 connectable += 1
             if scanner.scanning:
                 scanning += 1
-            elif scanner._connecting:
+            elif scanner.connecting_count:
                 connecting += 1
         summary = (
             f"{total} scanner(s) registered, {scanning} scanning, "

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -993,6 +993,79 @@ class BluetoothManager:
         histories = self._connectable_history if connectable else self._all_history
         return histories.get(address)
 
+    def async_address_reachability_diagnostics(self, address: str) -> str:
+        """
+        Return a human-readable explanation of an address's reachability.
+
+        Intended for embedding in error and log messages when a device cannot
+        be found or connected to. This is a read-only, side-effect free summary
+        of which scanners currently see the address, their RSSI, slot
+        availability and how recently the device last advertised. It is only
+        meant for the cold error path, not the hot advertisement path.
+        """
+        now = monotonic_time_coarse()
+        in_connectable = address in self._connectable_history
+        in_all = address in self._all_history
+        parts: list[str] = []
+
+        if in_connectable:
+            parts.append("in connectable history")
+        elif in_all:
+            parts.append("only in non-connectable history (no connectable path)")
+        else:
+            parts.append("unknown (never seen by any scanner)")
+
+        connectable_count = self.async_scanner_count(True)
+        total_count = self.async_scanner_count(False)
+        if connectable_count == 0:
+            parts.append(
+                f"no connectable scanners are registered ({total_count} total)"
+            )
+
+        # One pass over every scanner (connectable and non-connectable) that
+        # currently has this address discovered.
+        devices = self.async_scanner_devices_by_address(address, False)
+        connectable_devices = [d for d in devices if d.scanner.connectable]
+        non_connectable_devices = [d for d in devices if not d.scanner.connectable]
+
+        if (
+            not connectable_devices
+            and non_connectable_devices
+            and connectable_count != 0
+        ):
+            parts.append(
+                f"seen by {len(non_connectable_devices)} scanner(s) but none with"
+                " a connectable path"
+            )
+        elif connectable_devices and all(
+            (allocations := d.scanner.get_allocations()) is not None
+            and allocations.slots > 0
+            and allocations.free == 0
+            for d in connectable_devices
+        ):
+            parts.append(
+                "connectable scanner(s) see it but all connection slots are in use"
+            )
+
+        for device in devices:
+            scanner = device.scanner
+            detail = (
+                f"{scanner.name} (connectable={scanner.connectable}, "
+                f"rssi={device.advertisement.rssi}, "
+                f"failures={scanner._connection_failures(address)}, "
+                f"in_progress={scanner._connections_in_progress()}"
+            )
+            if (allocations := scanner.get_allocations()) is not None:
+                detail += f", slots={allocations.free}/{allocations.slots}"
+            parts.append(detail + ")")
+
+        if (info := self._all_history.get(address)) is not None:
+            parts.append(
+                f"last advertisement {now - info.time:.0f}s ago via {info.source}"
+            )
+
+        return f"{address}: " + "; ".join(parts)
+
     def _async_unregister_scanner_internal(
         self,
         scanners: set[BaseHaScanner],

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1061,12 +1061,16 @@ class BluetoothManager:
         scanning = 0
         connecting = 0
         connectable = 0
+        # A scanner pauses scanning while it has a connection in progress, so
+        # in normal operation scanning and connecting_count are mutually
+        # exclusive. Count them independently anyway so the "all paused
+        # connecting" advice below stays correct even if that invariant drifts.
         for scanner in scanners:
             if scanner.connectable:
                 connectable += 1
             if scanner.scanning:
                 scanning += 1
-            elif scanner.connecting_count:
+            if scanner.connecting_count:
                 connecting += 1
         summary = (
             f"{total} scanner(s) registered, {scanning} scanning, "

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1107,14 +1107,22 @@ class BluetoothManager:
                 f"seen by {len(non_connectable_devices)} scanner(s) but none with"
                 " a connectable path"
             )
-        elif connectable_devices and all(
-            (allocations := d.scanner.get_allocations()) is not None
-            and allocations.slots > 0
-            and allocations.free == 0
+            return
+
+        # Only consider scanners that actually report slot allocations; a
+        # scanner returning None (e.g. a local adapter that does not track
+        # slots) tells us nothing, so it must not suppress or trigger the
+        # message. We only claim the reporting scanners are full, not that
+        # every connectable path is exhausted.
+        reported = [
+            allocations
             for d in connectable_devices
-        ):
+            if (allocations := d.scanner.get_allocations()) is not None
+            and allocations.slots > 0
+        ]
+        if reported and all(allocations.free == 0 for allocations in reported):
             parts.append(
-                "connectable scanner(s) see it but all connection slots are in use"
+                "connectable scanner(s) that report slot allocations are all full"
             )
 
     def _append_advertisement_diagnostics(
@@ -1126,9 +1134,14 @@ class BluetoothManager:
         """Append advertisement-only reachability facts for an advertisement intent."""
         # Advertisement callers only need adverts, so connectable paths and
         # connection slots are irrelevant; report only whether the device is
-        # being seen and by how many scanners.
-        if address in self._all_history:
+        # being seen and by how many scanners. ``_all_history`` outlives any
+        # single scanner's discovered cache, so an address can be in history
+        # while no scanner currently has it cached; do not claim it is still
+        # advertising in that case.
+        if devices:
             parts.append(f"advertising, seen by {len(devices)} scanner(s)")
+        elif address in self._all_history:
+            parts.append("previously seen but no scanner currently has it cached")
         else:
             parts.append("unknown (never seen by any scanner)")
 

--- a/src/habluetooth/models.py
+++ b/src/habluetooth/models.py
@@ -101,6 +101,27 @@ class BluetoothScanningMode(Enum):
     AUTO = "auto"
 
 
+class BluetoothReachabilityIntent(Enum):
+    """
+    What a caller needs from a device, for reachability diagnostics.
+
+    The intent changes which facts are relevant when explaining why an address
+    is not usable. A caller that only consumes advertisements does not care
+    whether a connectable path or a free connection slot exists; a caller that
+    wants to open a connection does.
+    """
+
+    # The caller only needs to receive passive advertisements from the device.
+    PASSIVE_ADVERTISEMENT = "passive_advertisement"
+    # The caller needs scan response (SCAN_RSP) data, which is only received
+    # from a scanner that is actively scanning. Treated the same as
+    # PASSIVE_ADVERTISEMENT for now; kept distinct so the diagnostics can later
+    # report when no scanner seeing the device is actively scanning.
+    ACTIVE_ADVERTISEMENT = "active_advertisement"
+    # The caller needs to open an outbound connection to the device.
+    CONNECTION = "connection"
+
+
 class BluetoothServiceInfo:
     """Prepared info from bluetooth entries."""
 

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -650,13 +650,20 @@ class HaBleakClientWrapper(BleakClient):
                 )
                 raise BleakError(msg)
 
-        diagnostics = manager.async_address_reachability_diagnostics(
-            address, BluetoothReachabilityIntent.CONNECTION
-        )
         msg = (
             "No backend with an available connection slot that can reach address"
-            f" {address} was found: {diagnostics}"
+            f" {address} was found"
         )
+        # Best-effort diagnostics; never let a diagnostics failure mask the
+        # original "no backend" error we are about to raise.
+        try:
+            diagnostics = manager.async_address_reachability_diagnostics(
+                address, BluetoothReachabilityIntent.CONNECTION
+            )
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Error building reachability diagnostics for %s", address)
+        else:
+            msg = f"{msg}: {diagnostics}"
         raise BleakError(msg)
 
     async def disconnect(self) -> None:

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -649,9 +649,10 @@ class HaBleakClientWrapper(BleakClient):
                 )
                 raise BleakError(msg)
 
+        diagnostics = manager.async_address_reachability_diagnostics(address)
         msg = (
             "No backend with an available connection slot that can reach address"
-            f" {address} was found"
+            f" {address} was found: {diagnostics}"
         )
         raise BleakError(msg)
 

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -615,8 +615,8 @@ class HaBleakClientWrapper(BleakClient):
                     (
                         f"{device.scanner.name} "
                         f"(RSSI={device.advertisement.rssi}) "
-                        f"(failures={device.scanner._connection_failures(address)}) "
-                        f"(in_progress={device.scanner._connections_in_progress()}) "
+                        f"(failures={device.scanner.connection_failures(address)}) "
+                        f"(in_progress={device.scanner.connections_in_progress()}) "
                         + (
                             f"(slots={allocations.free}/{allocations.slots} free) "
                             if (allocations := device.scanner.get_allocations())

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -22,6 +22,7 @@ from bleak_retry_connector import (
 
 from .central_manager import get_manager
 from .const import BDADDR_LE_PUBLIC, BDADDR_LE_RANDOM, CALLBACK_TYPE, ConnectParams
+from .models import BluetoothReachabilityIntent
 
 FILTER_UUIDS: Final = "UUIDs"
 _LOGGER = logging.getLogger(__name__)
@@ -649,7 +650,9 @@ class HaBleakClientWrapper(BleakClient):
                 )
                 raise BleakError(msg)
 
-        diagnostics = manager.async_address_reachability_diagnostics(address)
+        diagnostics = manager.async_address_reachability_diagnostics(
+            address, BluetoothReachabilityIntent.CONNECTION
+        )
         msg = (
             "No backend with an available connection slot that can reach address"
             f" {address} was found: {diagnostics}"

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -30,6 +30,7 @@ from habluetooth import (
 from . import (
     HCI0_SOURCE_ADDRESS,
     HCI1_SOURCE_ADDRESS,
+    InjectableRemoteScanner,
     async_fire_time_changed,
     generate_advertisement_data,
     generate_ble_device,
@@ -1735,3 +1736,89 @@ async def test_async_refresh_adapters_recovers_after_prior_failure() -> None:
         await manager._async_refresh_adapters()
     assert call_count == 2
     assert manager._adapter_refresh_future is None
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_connectable() -> None:
+    """A connectable device in range reports its connectable scanner."""
+    manager = get_manager()
+    address = "44:44:33:11:23:45"
+    scanner = InjectableRemoteScanner("esphome_proxy", "esphome_proxy", None, True)
+    cancel = manager.async_register_scanner(scanner)
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-50)
+    scanner.inject_advertisement(device, adv)
+
+    diag = manager.async_address_reachability_diagnostics(address)
+    assert address in diag
+    assert "in connectable history" in diag
+    assert "esphome_proxy (connectable=True, rssi=-50" in diag
+    assert "last advertisement" in diag
+    cancel()
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_non_connectable_only() -> None:
+    """A device only seen by a non-connectable scanner has no connectable path."""
+    manager = get_manager()
+    address = "44:44:33:11:23:46"
+    connectable = InjectableRemoteScanner("hci0", "hci0", None, True)
+    cancel_c = manager.async_register_scanner(connectable)
+    non_connectable = InjectableRemoteScanner("proxy", "proxy", None, False)
+    cancel_n = manager.async_register_scanner(non_connectable)
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-70)
+    non_connectable.inject_advertisement(device, adv)
+
+    diag = manager.async_address_reachability_diagnostics(address)
+    assert "only in non-connectable history (no connectable path)" in diag
+    assert "seen by 1 scanner(s) but none with a connectable path" in diag
+    assert "proxy (connectable=False, rssi=-70" in diag
+    cancel_c()
+    cancel_n()
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_unknown() -> None:
+    """An address never seen reports as unknown."""
+    manager = get_manager()
+    diag = manager.async_address_reachability_diagnostics("44:44:33:11:23:47")
+    assert "unknown (never seen by any scanner)" in diag
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_no_connectable_scanners() -> None:
+    """With only a non-connectable scanner the message says so."""
+    manager = get_manager()
+    address = "44:44:33:11:23:48"
+    non_connectable = InjectableRemoteScanner("proxy", "proxy", None, False)
+    cancel = manager.async_register_scanner(non_connectable)
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-70)
+    non_connectable.inject_advertisement(device, adv)
+
+    diag = manager.async_address_reachability_diagnostics(address)
+    assert "no connectable scanners are registered (1 total)" in diag
+    cancel()
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_out_of_slots() -> None:
+    """A connectable scanner with no free slots is reported as full."""
+    manager = get_manager()
+    address = "44:44:33:11:23:49"
+    scanner = InjectableRemoteScanner("esphome_proxy", "esphome_proxy", None, True)
+    cancel = manager.async_register_scanner(scanner)
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-50)
+    scanner.inject_advertisement(device, adv)
+
+    with patch.object(
+        scanner,
+        "get_allocations",
+        return_value=Allocations("esphome_proxy", 3, 0, []),
+    ):
+        diag = manager.async_address_reachability_diagnostics(address)
+    assert "all connection slots are in use" in diag
+    assert "slots=0/3" in diag
+    cancel()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1753,7 +1753,8 @@ async def test_address_reachability_diagnostics_connectable() -> None:
     diag = manager.async_address_reachability_diagnostics(
         address, BluetoothReachabilityIntent.CONNECTION
     )
-    assert address in diag
+    # The address is intentionally not embedded; callers already have it.
+    assert address not in diag
     assert "in connectable history" in diag
     assert "1 scanner(s) registered, 1 scanning, 1 connectable" in diag
     assert "esphome_proxy (connectable=True, rssi=-50" in diag

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -17,6 +17,7 @@ from habluetooth import (
     TRACKER_BUFFERING_WOBBLE_SECONDS,
     UNAVAILABLE_TRACK_SECONDS,
     BluetoothManager,
+    BluetoothReachabilityIntent,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     HaBluetoothSlotAllocations,
@@ -1749,9 +1750,12 @@ async def test_address_reachability_diagnostics_connectable() -> None:
     adv = generate_advertisement_data(local_name="wohand", rssi=-50)
     scanner.inject_advertisement(device, adv)
 
-    diag = manager.async_address_reachability_diagnostics(address)
+    diag = manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.CONNECTION
+    )
     assert address in diag
     assert "in connectable history" in diag
+    assert "1 scanner(s) registered, 1 scanning, 1 connectable" in diag
     assert "esphome_proxy (connectable=True, rssi=-50" in diag
     assert "last advertisement" in diag
     cancel()
@@ -1770,7 +1774,9 @@ async def test_address_reachability_diagnostics_non_connectable_only() -> None:
     adv = generate_advertisement_data(local_name="wohand", rssi=-70)
     non_connectable.inject_advertisement(device, adv)
 
-    diag = manager.async_address_reachability_diagnostics(address)
+    diag = manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.CONNECTION
+    )
     assert "only in non-connectable history (no connectable path)" in diag
     assert "seen by 1 scanner(s) but none with a connectable path" in diag
     assert "proxy (connectable=False, rssi=-70" in diag
@@ -1779,16 +1785,42 @@ async def test_address_reachability_diagnostics_non_connectable_only() -> None:
 
 
 @pytest.mark.asyncio
+async def test_address_reachability_diagnostics_advertisement_intent() -> None:
+    """An advertisement intent ignores connectable paths and slots."""
+    manager = get_manager()
+    address = "44:44:33:11:23:4a"
+    non_connectable = InjectableRemoteScanner("proxy", "proxy", None, False)
+    cancel = manager.async_register_scanner(non_connectable)
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-70)
+    non_connectable.inject_advertisement(device, adv)
+
+    diag = manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT
+    )
+    assert "advertising, seen by 1 scanner(s)" in diag
+    assert "no connectable path" not in diag
+    assert "slots" not in diag
+    # ACTIVE_ADVERTISEMENT is treated the same as PASSIVE_ADVERTISEMENT for now.
+    assert diag == manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.ACTIVE_ADVERTISEMENT
+    )
+    cancel()
+
+
+@pytest.mark.asyncio
 async def test_address_reachability_diagnostics_unknown() -> None:
     """An address never seen reports as unknown."""
     manager = get_manager()
-    diag = manager.async_address_reachability_diagnostics("44:44:33:11:23:47")
+    diag = manager.async_address_reachability_diagnostics(
+        "44:44:33:11:23:47", BluetoothReachabilityIntent.CONNECTION
+    )
     assert "unknown (never seen by any scanner)" in diag
 
 
 @pytest.mark.asyncio
 async def test_address_reachability_diagnostics_no_connectable_scanners() -> None:
-    """With only a non-connectable scanner the message says so."""
+    """With only a non-connectable scanner the connectable count is zero."""
     manager = get_manager()
     address = "44:44:33:11:23:48"
     non_connectable = InjectableRemoteScanner("proxy", "proxy", None, False)
@@ -1797,8 +1829,10 @@ async def test_address_reachability_diagnostics_no_connectable_scanners() -> Non
     adv = generate_advertisement_data(local_name="wohand", rssi=-70)
     non_connectable.inject_advertisement(device, adv)
 
-    diag = manager.async_address_reachability_diagnostics(address)
-    assert "no connectable scanners are registered (1 total)" in diag
+    diag = manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.CONNECTION
+    )
+    assert "1 scanner(s) registered, 1 scanning, 0 connectable" in diag
     cancel()
 
 
@@ -1818,7 +1852,29 @@ async def test_address_reachability_diagnostics_out_of_slots() -> None:
         "get_allocations",
         return_value=Allocations("esphome_proxy", 3, 0, []),
     ):
-        diag = manager.async_address_reachability_diagnostics(address)
+        diag = manager.async_address_reachability_diagnostics(
+            address, BluetoothReachabilityIntent.CONNECTION
+        )
     assert "all connection slots are in use" in diag
     assert "slots=0/3" in diag
+    cancel()
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_all_scanners_connecting() -> None:
+    """When every scanner is paused connecting, the device cannot be seen."""
+    manager = get_manager()
+    address = "44:44:33:11:23:4b"
+    scanner = InjectableRemoteScanner("esphome_proxy", "esphome_proxy", None, True)
+    cancel = manager.async_register_scanner(scanner)
+
+    with scanner.connecting():
+        assert scanner.scanning is False
+        diag = manager.async_address_reachability_diagnostics(
+            address, BluetoothReachabilityIntent.CONNECTION
+        )
+    assert "1 scanner(s) registered, 0 scanning, 1 connectable" in diag
+    assert "1 paused while connecting" in diag
+    assert "no scanner is currently scanning" in diag
+    assert "add more Bluetooth adapters or proxies" in diag
     cancel()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1856,9 +1856,27 @@ async def test_address_reachability_diagnostics_out_of_slots() -> None:
         diag = manager.async_address_reachability_diagnostics(
             address, BluetoothReachabilityIntent.CONNECTION
         )
-    assert "all connection slots are in use" in diag
+    assert "connectable scanner(s) that report slot allocations are all full" in diag
     assert "slots=0/3" in diag
     cancel()
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_in_history_no_scanner() -> None:
+    """An address in history but cached by no scanner is not called advertising."""
+    manager = get_manager()
+    address = "44:44:33:11:23:4c"
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-70)
+    # Injected from a source with no registered scanner; lands in history but
+    # no scanner currently has it cached.
+    inject_advertisement_with_source(device, adv, "ghost")
+
+    diag = manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT
+    )
+    assert "previously seen but no scanner currently has it cached" in diag
+    assert "advertising" not in diag
 
 
 @pytest.mark.asyncio

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1809,13 +1809,21 @@ async def test_address_reachability_diagnostics_advertisement_intent() -> None:
     cancel()
 
 
+@pytest.mark.parametrize(
+    "intent",
+    [
+        BluetoothReachabilityIntent.CONNECTION,
+        BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT,
+        BluetoothReachabilityIntent.ACTIVE_ADVERTISEMENT,
+    ],
+)
 @pytest.mark.asyncio
-async def test_address_reachability_diagnostics_unknown() -> None:
-    """An address never seen reports as unknown."""
+async def test_address_reachability_diagnostics_unknown(
+    intent: BluetoothReachabilityIntent,
+) -> None:
+    """An address never seen reports as unknown for every intent."""
     manager = get_manager()
-    diag = manager.async_address_reachability_diagnostics(
-        "44:44:33:11:23:47", BluetoothReachabilityIntent.CONNECTION
-    )
+    diag = manager.async_address_reachability_diagnostics("44:44:33:11:23:47", intent)
     assert "unknown (never seen by any scanner)" in diag
 
 
@@ -1896,4 +1904,24 @@ async def test_address_reachability_diagnostics_all_scanners_connecting() -> Non
     assert "1 paused while connecting" in diag
     assert "no scanner is currently scanning" in diag
     assert "add more Bluetooth adapters or proxies" in diag
+    cancel()
+
+
+@pytest.mark.asyncio
+async def test_address_reachability_diagnostics_scanner_stopped_not_connecting() -> (
+    None
+):
+    """A stopped scanner (not connecting) reports no scanning without the advice."""
+    manager = get_manager()
+    scanner = InjectableRemoteScanner("esphome_proxy", "esphome_proxy", None, True)
+    cancel = manager.async_register_scanner(scanner)
+    scanner.scanning = False
+
+    diag = manager.async_address_reachability_diagnostics(
+        "44:44:33:11:23:4d", BluetoothReachabilityIntent.CONNECTION
+    )
+    assert "1 scanner(s) registered, 0 scanning, 1 connectable" in diag
+    assert "no scanner is currently scanning" in diag
+    assert "paused while connecting" not in diag
+    assert "add more Bluetooth adapters or proxies" not in diag
     cancel()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -281,7 +281,13 @@ async def test_test_switch_adapters_when_out_of_slots(
     ):
         ble_device = hci0_device_advs["00:00:00:00:00:02"][0]
         client = bleak.BleakClient(ble_device)
-        with pytest.raises(bleak.exc.BleakError):
+        with pytest.raises(
+            bleak.exc.BleakError,
+            match=(
+                r"No backend with an available connection slot that can reach "
+                r"address .* was found:.*connectable=True"
+            ),
+        ):
             await client.connect()
         assert allocate_slot_mock.call_count == 2
         assert release_slot_mock.call_count == 0

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -313,6 +313,39 @@ async def test_test_switch_adapters_when_out_of_slots(
 
 
 @pytest.mark.asyncio
+async def test_no_backend_error_survives_diagnostics_failure(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """A failing diagnostics builder must not mask the no-backend BleakError."""
+    manager = _get_manager()
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+    with (
+        patch.object(manager.slot_manager, "allocate_slot", return_value=False),
+        patch.object(
+            manager,
+            "async_address_reachability_diagnostics",
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        ble_device = hci0_device_advs["00:00:00:00:00:02"][0]
+        client = bleak.BleakClient(ble_device)
+        with pytest.raises(
+            bleak.exc.BleakError,
+            match=(
+                r"No backend with an available connection slot that can reach "
+                r"address .* was found$"
+            ),
+        ):
+            await client.connect()
+
+    cancel_hci0()
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
 async def test_backend_id_property(
     two_adapters: None,
     enable_bluetooth: None,


### PR DESCRIPTION
When a device cannot be found, callers only get a bare "not found" with no way to tell why. This adds `BluetoothManager.async_address_reachability_diagnostics(address, intent)`, a read only, side effect free helper that returns a human readable summary tailored to what the caller needs.

The intent comes from a new `BluetoothReachabilityIntent` enum; `PASSIVE_ADVERTISEMENT` and `ACTIVE_ADVERTISEMENT` (scan response, treated the same as passive for now) only report whether the device is being seen, while `CONNECTION` also reports connectable history, whether a connectable path exists, per scanner failures, in progress connections and slot allocations.

Every result includes a scanner availability summary; how many scanners are registered, scanning and connectable. It calls out the common failure where scanners pause scanning while connecting, so if they are all stuck retrying connections no advertisements can be received at all and the device vanishes; in that case it advises adding more adapters or proxies since the available ones are overloaded.

The wrappers "No backend with an available connection slot" BleakError now embeds the connection intent summary so the cause shows up in logs.

Meant to be surfaced by Home Assistant (switchbot reports "Could not find Switchbot ... with address X" with no reason today); see home-assistant/core#170232.