### PR TITLE
fix: show scanner name in reachability diagnostics via line

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1041,9 +1041,11 @@ class BluetoothManager:
             parts.append(detail + ")")
 
         if (info := self._all_history.get(address)) is not None:
-            parts.append(
-                f"last advertisement {now - info.time:.0f}s ago via {info.source}"
-            )
+            if (via_scanner := self._sources.get(info.source)) is not None:
+                via = via_scanner.name
+            else:
+                via = info.source
+            parts.append(f"last advertisement {now - info.time:.0f}s ago via {via}")
 
         return "; ".join(parts)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1744,7 +1744,9 @@ async def test_address_reachability_diagnostics_connectable() -> None:
     """A connectable device in range reports its connectable scanner."""
     manager = get_manager()
     address = "44:44:33:11:23:45"
-    scanner = InjectableRemoteScanner("esphome_proxy", "esphome_proxy", None, True)
+    scanner = InjectableRemoteScanner(
+        "AA:BB:CC:DD:EE:FF", "Living Room Proxy", None, True
+    )
     cancel = manager.async_register_scanner(scanner)
     device = generate_ble_device(address, "wohand")
     adv = generate_advertisement_data(local_name="wohand", rssi=-50)
@@ -1757,8 +1759,10 @@ async def test_address_reachability_diagnostics_connectable() -> None:
     assert address not in diag
     assert "in connectable history" in diag
     assert "1 scanner(s) registered, 1 scanning, 1 connectable" in diag
-    assert "esphome_proxy (connectable=True, rssi=-50" in diag
+    assert "Living Room Proxy (AA:BB:CC:DD:EE:FF) (connectable=True, rssi=-50" in diag
+    # The "via" source resolves to the scanner name rather than a bare address.
     assert "last advertisement" in diag
+    assert "via Living Room Proxy (AA:BB:CC:DD:EE:FF)" in diag
     cancel()
 
 


### PR DESCRIPTION
The reachability diagnostics ended the summary with "last advertisement Ns ago via <source>", where <source> was a bare adapter MAC; that address is meaningless to anyone reading a log since it does not say which scanner saw the device.

This resolves the source to the registered scanner's name (which already carries the address in parens) when we know it, falling back to the raw source when the scanner is no longer registered. So instead of "via 34:B7:DA:88:8B:B6" you get "via Living Room Proxy (34:B7:DA:88:8B:B6)".

Follow up to #517.