### PR TITLE
fix: promote non-connectable advertisement when a registered connectable path exists

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -880,16 +880,26 @@ class BluetoothManager:
         ):
             return
 
-        if not service_info.connectable and old_connectable_service_info is not None:
-            # Since we have a connectable path and our BleakClient will
-            # route any connection attempts to the connectable path, we
-            # mark the service_info as connectable so that the callbacks
-            # will be called and the device can be discovered.
+        # A non-connectable scanner may currently be the closest path, but if a
+        # still-registered connectable scanner also has a path to the device we
+        # surface this advertisement as connectable so connectable callbacks and
+        # discovery fire (the BleakClient routes any connection attempt to the
+        # connectable path). connectable_history is only pruned by the periodic
+        # unavailable check, so validate the stored entry's source is still
+        # registered before trusting it as a live connectable path. This lookup is
+        # deferred to here (after the identical-advertisement short-circuit above)
+        # so the dominant non-connectable rebroadcast hot path never pays it.
+        if (
+            not service_info.connectable
+            and (
+                connectable_path := self._connectable_history.get(service_info.address)
+            )
+            is not None
+            and connectable_path.source in self._sources
+        ):
             service_info = service_info._as_connectable()
 
-        if (
-            service_info.connectable or old_connectable_service_info is not None
-        ) and self._bleak_callbacks:
+        if service_info.connectable and self._bleak_callbacks:
             # Bleak callbacks must get a connectable device
             advertisement_data = service_info._advertisement_internal()
             for bleak_callback in self._bleak_callbacks:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock, PropertyMock, patch
 
 import pytest
+from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bleak_retry_connector import AllocationChange, Allocations, BleakSlotManager
 from bluetooth_adapters import ADAPTER_ADDRESS, ADAPTER_PASSIVE_SCAN
 from bluetooth_adapters.systems.linux import LinuxAdapters
@@ -34,6 +35,7 @@ from habluetooth.central_manager import CentralBluetoothManager
 from . import (
     HCI0_SOURCE_ADDRESS,
     HCI1_SOURCE_ADDRESS,
+    NON_CONNECTABLE_REMOTE_SOURCE_ADDRESS,
     InjectableRemoteScanner,
     async_fire_time_changed,
     generate_advertisement_data,
@@ -2284,3 +2286,170 @@ async def test_should_keep_previous_adv_switches_without_debug_logging(
     assert latest is not None
     assert latest.source == HCI0_SOURCE_ADDRESS
     assert "Switching from" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_non_connectable_adv_promoted_when_connectable_path_registered(
+    register_hci0_scanner: None,
+) -> None:
+    """
+    A changed non-connectable adv is promoted when a connectable path is live.
+
+    Regression test for #534: a connectable scanner has a path to the device, but
+    the current best advertisement arrives from a non-connectable source. The
+    service_info must surface as connectable so connectable callbacks and discovery
+    fire, otherwise Home Assistant believes there is no connectable path.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:45"
+    now = time.monotonic()
+
+    discovered: list[BluetoothServiceInfoBleak] = []
+    manager._subclass_discover_info = Mock(side_effect=discovered.append)
+    bleak_devices: list[BLEDevice] = []
+
+    def _on_bleak(dev: BLEDevice, _adv: AdvertisementData) -> None:
+        bleak_devices.append(dev)
+
+    # Register up front so the connectable_history replay on registration cannot
+    # be mistaken for a promotion dispatch.
+    cancel = manager.async_register_bleak_callback(_on_bleak, {})
+    try:
+        # Connectable adv from the registered hci0 scanner populates
+        # connectable_history.
+        device = generate_ble_device(address, "wohand")
+        connectable_adv = generate_advertisement_data(
+            local_name="wohand",
+            service_uuids=[],
+            manufacturer_data={1: b"\x01"},
+            rssi=-60,
+        )
+        inject_advertisement_with_time_and_source_connectable(
+            device, connectable_adv, now, HCI0_SOURCE_ADDRESS, True
+        )
+
+        discovered.clear()
+        bleak_devices.clear()
+
+        # A stronger non-connectable adv from another source wins the best-path
+        # comparison and carries changed data so the identical-adv short-circuit
+        # does not skip dispatch.
+        non_connectable_adv = generate_advertisement_data(
+            local_name="wohand",
+            service_uuids=[],
+            manufacturer_data={1: b"\x02"},
+            rssi=-20,
+        )
+        inject_advertisement_with_time_and_source_connectable(
+            device,
+            non_connectable_adv,
+            now,
+            NON_CONNECTABLE_REMOTE_SOURCE_ADDRESS,
+            False,
+        )
+    finally:
+        cancel()
+
+    assert discovered
+    assert discovered[-1].connectable is True
+    assert bleak_devices
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_non_connectable_adv_not_promoted_after_connectable_scanner_unregisters() -> (  # noqa: E501
+    None
+):
+    """
+    A lingering connectable_history entry does not promote once its source is gone.
+
+    connectable_history is only pruned by the periodic unavailable check, so an
+    unregistered connectable scanner can leave a stale entry behind. The promotion
+    must verify the stored source is still registered before claiming a live path.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:46"
+    now = time.monotonic()
+
+    discovered: list[BluetoothServiceInfoBleak] = []
+    manager._subclass_discover_info = Mock(side_effect=discovered.append)
+    bleak_devices: list[BLEDevice] = []
+
+    def _on_bleak(dev: BLEDevice, _adv: AdvertisementData) -> None:
+        bleak_devices.append(dev)
+
+    # Register up front so the connectable_history replay on registration cannot
+    # be mistaken for a promotion dispatch.
+    cancel = manager.async_register_bleak_callback(_on_bleak, {})
+    try:
+        connectable_scanner = FakeScanner(HCI0_SOURCE_ADDRESS, "hci0")
+        connectable_scanner.connectable = True
+        cancel_scanner = manager.async_register_scanner(connectable_scanner)
+
+        device = generate_ble_device(address, "wohand")
+        connectable_adv = generate_advertisement_data(
+            local_name="wohand",
+            service_uuids=[],
+            manufacturer_data={1: b"\x01"},
+            rssi=-60,
+        )
+        inject_advertisement_with_time_and_source_connectable(
+            device, connectable_adv, now, HCI0_SOURCE_ADDRESS, True
+        )
+
+        # Unregister the only connectable scanner; the connectable_history entry
+        # intentionally lingers since unregister does not prune it.
+        cancel_scanner()
+        assert HCI0_SOURCE_ADDRESS not in manager._sources
+        assert address in manager._connectable_history
+
+        discovered.clear()
+        bleak_devices.clear()
+
+        non_connectable_adv = generate_advertisement_data(
+            local_name="wohand",
+            service_uuids=[],
+            manufacturer_data={1: b"\x02"},
+            rssi=-20,
+        )
+        inject_advertisement_with_time_and_source_connectable(
+            device,
+            non_connectable_adv,
+            now,
+            NON_CONNECTABLE_REMOTE_SOURCE_ADDRESS,
+            False,
+        )
+    finally:
+        cancel()
+
+    assert discovered
+    assert discovered[-1].connectable is False
+    assert not bleak_devices
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_connectable_adv_still_dispatches_to_bleak_callbacks(
+    register_hci0_scanner: None,
+) -> None:
+    """A normal connectable adv still dispatches to bleak callbacks unchanged."""
+    manager = get_manager()
+    address = "44:44:33:11:23:47"
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", service_uuids=[], rssi=-40)
+
+    bleak_devices: list[BLEDevice] = []
+
+    def _on_bleak(dev: BLEDevice, _adv: AdvertisementData) -> None:
+        bleak_devices.append(dev)
+
+    cancel = manager.async_register_bleak_callback(_on_bleak, {})
+    try:
+        inject_advertisement_with_time_and_source_connectable(
+            device, adv, time.monotonic(), HCI0_SOURCE_ADDRESS, True
+        )
+    finally:
+        cancel()
+
+    assert bleak_devices == [device]


### PR DESCRIPTION
Fixes #534.

The non-connectable to connectable promotion in `_scanner_adv_received` has been unreachable since `old_connectable_service_info` got gated on `connectable`; for a non-connectable advertisement it is forced to `None`, so the promotion and the bleak dispatch it feeds never run. So when a device is only advertising through a closer non-connectable scanner, Home Assistant sees `connectable=False`, the matcher in core rejects it, and connectable discovery never fires even though a connectable path exists. It has been like this for a long time.

This restores the promotion with a fresh `connectable_history` lookup done after the identical-advertisement short-circuit, so the dominant rebroadcast hot path does not pay for it. The lookup is gated on `source in self._sources`; `connectable_history` is only pruned by the periodic unavailable check, so a lingering entry from an unregistered scanner must not be trusted as a live connectable path. The bleak dispatch guard becomes simply `service_info.connectable`, since promotion now happens immediately above.

Adds regression tests for the promotion firing, no false promotion once the connectable scanner unregisters, and connectable advertisements still dispatching as before.
