### PR TITLE
feat: add mgmt discovery commands to bluez channel

### DIFF
--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -40,17 +40,39 @@ ADV_MONITOR_DEVICE_FOUND = 0x002F
 
 # Management commands
 MGMT_OP_GET_CONNECTIONS = 0x0015
+MGMT_OP_START_DISCOVERY = 0x0023
+MGMT_OP_STOP_DISCOVERY = 0x0024
 MGMT_OP_LOAD_CONN_PARAM = 0x0035
+MGMT_OP_ADD_ADV_PATTERNS_MONITOR = 0x0052
+MGMT_OP_REMOVE_ADV_MONITOR = 0x0053
 
 # Management events
 MGMT_EV_CMD_COMPLETE = 0x0001
 MGMT_EV_CMD_STATUS = 0x0002
+
+# Discovery address-type bitmask: BR/EDR (0x01) | LE Public (0x02) | LE Random (0x04).
+# We only scan for LE devices, so we combine the two LE bits.
+SCAN_TYPE_LE = 0x06
+
+# Management command status codes
+MGMT_STATUS_SUCCESS = 0x00
+# Busy means another mgmt client (e.g. bluetoothd) already started discovery;
+# device-found events are still delivered to every open socket, so we treat it
+# as success for our purposes.
+MGMT_STATUS_BUSY = 0x0A
 
 # Pre-compiled struct formats for performance
 COMMAND_HEADER = Struct("<HHH")
 COMMAND_HEADER_PACK = COMMAND_HEADER.pack
 CONN_PARAM_STRUCT = Struct("<H6sBHHHH")
 CONN_PARAM_PACK = CONN_PARAM_STRUCT.pack
+# START/STOP_DISCOVERY carry a single address-type bitmask byte.
+DISCOVERY_STRUCT = Struct("<B")
+DISCOVERY_PACK = DISCOVERY_STRUCT.pack
+# REMOVE_ADV_MONITOR carries a uint16 monitor handle.
+MONITOR_HANDLE_STRUCT = Struct("<H")
+MONITOR_HANDLE_PACK = MONITOR_HANDLE_STRUCT.pack
+MONITOR_HANDLE_UNPACK = MONITOR_HANDLE_STRUCT.unpack
 
 CONNECTION_ERRORS = (
     BluetoothSocketError,
@@ -86,7 +108,11 @@ class BluetoothMGMTProtocol:
         self._scanners = scanners
         self._on_connection_lost = on_connection_lost
         self._is_shutting_down = is_shutting_down
-        self._pending_commands: dict[int, asyncio.Future[tuple[int, bytes]]] = {}
+        # Keyed by (opcode, controller_idx) so the same command can be in flight
+        # on more than one adapter at once without the responses colliding.
+        self._pending_commands: dict[
+            tuple[int, int], asyncio.Future[tuple[int, bytes]]
+        ] = {}
         self._sock = sock
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
@@ -122,25 +148,31 @@ class BluetoothMGMTProtocol:
 
     @asynccontextmanager
     async def command_response(
-        self, opcode: int
+        self, opcode: int, controller_idx: int
     ) -> AsyncIterator[asyncio.Future[tuple[int, bytes]]]:
         """
         Context manager for handling command responses.
 
+        Only one command per (opcode, controller_idx) may be in flight at a
+        time: a second concurrent call with the same key overwrites the first
+        waiter, which would then never resolve. The mgmt command wrappers never
+        double-issue the same command on one adapter, so this is sufficient.
+
         Usage:
-            async with protocol.command_response(opcode) as future:
+            async with protocol.command_response(opcode, controller_idx) as future:
                 transport.write(command)
                 status, data = await future
         """
         future: asyncio.Future[tuple[int, bytes]] = (
             asyncio.get_running_loop().create_future()
         )
-        self._pending_commands[opcode] = future
+        key = (opcode, controller_idx)
+        self._pending_commands[key] = future
         try:
             yield future
         finally:
             # Clean up if the future wasn't resolved
-            self._pending_commands.pop(opcode, None)
+            self._pending_commands.pop(key, None)
 
     def _add_to_buffer(self, data: bytes | bytearray | memoryview) -> None:
         """Add data to the buffer."""
@@ -209,15 +241,15 @@ class BluetoothMGMTProtocol:
                     opcode = header[6] | (header[7] << 8)
                     status = header[8]
                     if opcode == MGMT_OP_LOAD_CONN_PARAM:
+                        # Fire-and-forget command, no waiter to resolve.
                         self._handle_load_conn_param_response(status, controller_idx)
                     elif (
-                        opcode == MGMT_OP_GET_CONNECTIONS
-                        and opcode in self._pending_commands
-                    ):
-                        # Handle GET_CONNECTIONS response for capability check
-                        future = self._pending_commands.pop(opcode)
+                        future := self._pending_commands.get((opcode, controller_idx))
+                    ) is not None:
+                        # Resolve whatever awaited this (opcode, controller_idx):
+                        # capability check, discovery, advertisement monitor, etc.
+                        del self._pending_commands[(opcode, controller_idx)]
                         if not future.done():
-                            # Return status and any response data
                             response_data = (
                                 header[9 : self._pos] if param_len > 3 else b""
                             )
@@ -296,6 +328,9 @@ class MGMTBluetoothCtl:
         self._reconnect_task: asyncio.Task[None] | None = None
         self._on_connection_lost_future: asyncio.Future[None] | None = None
         self._shutting_down = False
+        # Set once setup() confirms NET_ADMIN/NET_RAW; the same privileges that
+        # allow the capability probe allow driving discovery over the socket.
+        self.can_discover = False
 
     def close(self) -> None:
         """Close the management interface."""
@@ -427,7 +462,7 @@ class MGMTBluetoothCtl:
             assert self.protocol.transport is not None
 
         async with self.protocol.command_response(
-            MGMT_OP_GET_CONNECTIONS
+            MGMT_OP_GET_CONNECTIONS, 0
         ) as response_future:
             self.protocol._write_to_socket(header)
             # Wait for response with timeout
@@ -450,7 +485,127 @@ class MGMTBluetoothCtl:
             msg = "Missing NET_ADMIN/NET_RAW capabilities for Bluetooth management"
             raise PermissionError(msg)
 
+        self.can_discover = True
         self._reconnect_task = asyncio.create_task(self.reconnect_task())
+
+    async def _send_command_await(
+        self, opcode: int, adapter_idx: int, cmd_data: bytes
+    ) -> tuple[int, bytes] | None:
+        """
+        Send a mgmt command and await its command-complete/status response.
+
+        Returns ``(status, response_params)``, or ``None`` if the socket is
+        down, the write fails, or no response arrives within the timeout.
+        """
+        if not self.protocol or not self.protocol.transport:
+            _LOGGER.error("Cannot send mgmt command %#x: no connection", opcode)
+            return None
+        header = COMMAND_HEADER_PACK(opcode, adapter_idx, len(cmd_data))
+        try:
+            async with self.protocol.command_response(opcode, adapter_idx) as future:
+                # _write_to_socket can raise OSError or BluetoothSocketError when
+                # the socket has gone away; treat any of these as a soft failure.
+                self.protocol._write_to_socket(header + cmd_data)
+                async with asyncio_timeout(self.timeout):
+                    return await future
+        except (TimeoutError, OSError, BluetoothSocketError) as ex:
+            _LOGGER.debug("hci%u: mgmt command %#x failed: %s", adapter_idx, opcode, ex)
+            return None
+
+    async def start_discovery(self, adapter_idx: int) -> bool:
+        """
+        Start LE discovery on an adapter over the management socket.
+
+        Returns True if discovery is running, including the case where another
+        mgmt client (e.g. bluetoothd) already started it (BUSY); device-found
+        events are delivered to every open socket regardless of who started
+        discovery. A failure here means the adapter produces no advertisements,
+        so it is logged at warning level.
+        """
+        result = await self._send_command_await(
+            MGMT_OP_START_DISCOVERY, adapter_idx, DISCOVERY_PACK(SCAN_TYPE_LE)
+        )
+        if result is not None and result[0] in (
+            MGMT_STATUS_SUCCESS,
+            MGMT_STATUS_BUSY,
+        ):
+            return True
+        _LOGGER.warning(
+            "hci%u: failed to start discovery: %s",
+            adapter_idx,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def stop_discovery(self, adapter_idx: int) -> bool:
+        """
+        Stop LE discovery on an adapter over the management socket.
+
+        Only MGMT_STATUS_SUCCESS means discovery actually stopped. Unlike start,
+        a BUSY status here means the kernel did NOT stop discovery (e.g. another
+        mgmt client is still discovering), so it is not treated as success.
+        """
+        result = await self._send_command_await(
+            MGMT_OP_STOP_DISCOVERY, adapter_idx, DISCOVERY_PACK(SCAN_TYPE_LE)
+        )
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        # Best-effort cleanup on a shared socket, so this stays at debug, but
+        # log the no-response case too for parity with the other wrappers.
+        _LOGGER.debug(
+            "hci%u: stop discovery did not stop: %s",
+            adapter_idx,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def add_adv_pattern_monitor(self, adapter_idx: int) -> int | None:
+        """
+        Register a match-all advertisement monitor for passive scanning.
+
+        A pattern_count of 0 tells the controller to report every
+        advertisement via ADV_MONITOR_DEVICE_FOUND. Returns the assigned
+        monitor handle (for later removal), or None on failure.
+        """
+        result = await self._send_command_await(
+            MGMT_OP_ADD_ADV_PATTERNS_MONITOR, adapter_idx, b"\x00"
+        )
+        if result is None:
+            return None
+        status, data = result
+        if status == MGMT_STATUS_SUCCESS:
+            if len(data) >= 2:
+                return MONITOR_HANDLE_UNPACK(data[:2])[0]
+            # Success without the 2-byte handle: the monitor may be registered
+            # in the controller but we cannot track it for later removal.
+            _LOGGER.warning(
+                "hci%u: add advertisement monitor succeeded without a handle",
+                adapter_idx,
+            )
+            return None
+        _LOGGER.warning(
+            "hci%u: failed to add advertisement monitor: status=%#x",
+            adapter_idx,
+            status,
+        )
+        return None
+
+    async def remove_adv_monitor(self, adapter_idx: int, handle: int) -> bool:
+        """Remove a previously registered advertisement monitor by handle."""
+        result = await self._send_command_await(
+            MGMT_OP_REMOVE_ADV_MONITOR, adapter_idx, MONITOR_HANDLE_PACK(handle)
+        )
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        # A failed removal leaves the monitor registered controller-side, so
+        # surface it at warning level to make a leaked handle diagnosable.
+        _LOGGER.warning(
+            "hci%u: failed to remove advertisement monitor %u: %s",
+            adapter_idx,
+            handle,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
 
     def load_conn_params(
         self,

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
 import pytest
 from btsocket.btmgmt_socket import BluetoothSocketError
 
 from habluetooth.channels.bluez import (
+    MGMT_OP_ADD_ADV_PATTERNS_MONITOR,
+    MGMT_OP_REMOVE_ADV_MONITOR,
+    MGMT_OP_START_DISCOVERY,
+    MGMT_OP_STOP_DISCOVERY,
+    SCAN_TYPE_LE,
     BluetoothMGMTProtocol,
     MGMTBluetoothCtl,
 )
@@ -28,6 +33,9 @@ from habluetooth.const import (
     ConnectParams,
 )
 from habluetooth.scanner_bleak import HaScanner
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class MockHaScanner(HaScanner):
@@ -1234,7 +1242,7 @@ async def test_command_response_context_manager() -> None:
 
     # Test successful command response
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
-    async with protocol.command_response(opcode) as response_future:
+    async with protocol.command_response(opcode, 0) as response_future:
         # Verify we got a future
         assert response_future is not None
         assert isinstance(response_future, asyncio.Future)
@@ -1275,7 +1283,7 @@ async def test_command_response_cleanup_on_exception() -> None:
 
     # Test cleanup on exception
     async def _raise_inside_command_response() -> None:
-        async with protocol.command_response(opcode) as response_future:
+        async with protocol.command_response(opcode, 0) as response_future:
             assert response_future is not None
             msg = "Test exception"
             raise ValueError(msg)
@@ -1303,7 +1311,7 @@ async def test_get_connections_response_handling() -> None:
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
 
     # Use the command_response context manager to register the command
-    async with protocol.command_response(opcode) as response_future:
+    async with protocol.command_response(opcode, 0) as response_future:
         # Test with permission denied status (0x14)
         response_data = (
             b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
@@ -1337,7 +1345,7 @@ async def test_get_connections_response_with_data() -> None:
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
 
     # Use the command_response context manager to register the command
-    async with protocol.command_response(opcode) as response_future:
+    async with protocol.command_response(opcode, 0) as response_future:
         # Test with success status and additional data
         extra_data = b"\x01\x02\x03\x04"
         response_data = (
@@ -1391,7 +1399,7 @@ async def test_check_capabilities_success() -> None:
     mgmt_ctl.protocol = mock_protocol
 
     # Mock command_response to return success
-    def mock_command_response(opcode: int) -> object:
+    def mock_command_response(opcode: int, controller_idx: int) -> object:
         future = asyncio.get_running_loop().create_future()
         future.set_result((0x00, b""))  # Success status
 
@@ -1431,7 +1439,7 @@ async def test_check_capabilities_permission_denied() -> None:
     mgmt_ctl.protocol = mock_protocol
 
     # Mock command_response to return permission denied
-    def mock_command_response(opcode: int) -> object:
+    def mock_command_response(opcode: int, controller_idx: int) -> object:
         future = asyncio.get_running_loop().create_future()
         future.set_result((0x14, b""))  # Permission denied status
 
@@ -1463,7 +1471,7 @@ async def test_check_capabilities_invalid_index() -> None:
     mgmt_ctl.protocol = mock_protocol
 
     # Mock command_response to return invalid index
-    def mock_command_response(opcode: int) -> object:
+    def mock_command_response(opcode: int, controller_idx: int) -> object:
         future = asyncio.get_running_loop().create_future()
         future.set_result((0x11, b""))  # Invalid index
 
@@ -1496,7 +1504,7 @@ async def test_check_capabilities_unknown_status() -> None:
     mgmt_ctl.protocol = mock_protocol
 
     # Mock command_response to return unknown status
-    def mock_command_response(opcode: int) -> object:
+    def mock_command_response(opcode: int, controller_idx: int) -> object:
         future = asyncio.get_running_loop().create_future()
         future.set_result((0xFF, b""))  # Unknown status
 
@@ -1528,7 +1536,7 @@ async def test_check_capabilities_timeout() -> None:
     mgmt_ctl.protocol = mock_protocol
 
     # Mock command_response to timeout
-    def mock_command_response(opcode: int) -> object:
+    def mock_command_response(opcode: int, controller_idx: int) -> object:
         future = asyncio.get_running_loop().create_future()
         # Never resolve the future
 
@@ -1614,3 +1622,275 @@ async def test_setup_with_failed_capabilities() -> None:
         assert mgmt_ctl._shutting_down is True
         mock_transport.close.assert_called_once()
         mock_btmgmt.close.assert_called_once_with(mock_socket)
+
+
+def _stub_command_response(
+    status: int, data: bytes = b""
+) -> Callable[[int, int], object]:
+    """Build a command_response stub that resolves with (status, data)."""
+
+    def _command_response(opcode: int, controller_idx: int) -> object:
+        future = asyncio.get_running_loop().create_future()
+        future.set_result((status, data))
+
+        class MockContext:
+            async def __aenter__(self) -> asyncio.Future[tuple[int, bytes]]:
+                return future
+
+            async def __aexit__(self, *args: object) -> None:
+                pass
+
+        return MockContext()
+
+    return _command_response
+
+
+def _mgmt_ctl_with_mock_protocol() -> tuple[MGMTBluetoothCtl, Mock]:
+    """Return a MGMTBluetoothCtl wired to a mock protocol/transport."""
+    mgmt_ctl = MGMTBluetoothCtl(timeout=5.0, scanners={})
+    mock_protocol = Mock(spec=BluetoothMGMTProtocol)
+    mock_protocol.transport = Mock()
+    mock_protocol._write_to_socket = Mock()
+    mgmt_ctl.protocol = mock_protocol
+    return mgmt_ctl, mock_protocol
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [0x00, 0x0A])
+async def test_start_discovery_success(status: int) -> None:
+    """start_discovery returns True on success or busy and sends the LE bitmask."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(status)
+
+    assert await mgmt_ctl.start_discovery(0) is True
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    # header opcode (2) + controller_idx (2) + param_len (2) + address-type byte
+    assert sent[0:2] == MGMT_OP_START_DISCOVERY.to_bytes(2, "little")
+    assert sent[2:4] == b"\x00\x00"
+    assert sent[6] == SCAN_TYPE_LE
+
+
+@pytest.mark.asyncio
+async def test_start_discovery_failure() -> None:
+    """start_discovery returns False on an error status."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x0C)
+
+    assert await mgmt_ctl.start_discovery(0) is False
+
+
+@pytest.mark.asyncio
+async def test_stop_discovery_success() -> None:
+    """stop_discovery returns True and targets the requested controller."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert await mgmt_ctl.stop_discovery(2) is True
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_STOP_DISCOVERY.to_bytes(2, "little")
+    assert sent[2:4] == (2).to_bytes(2, "little")
+
+
+@pytest.mark.asyncio
+async def test_stop_discovery_busy_is_not_success() -> None:
+    """BUSY on stop means discovery did not stop, so it must report False."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x0A)
+
+    assert await mgmt_ctl.stop_discovery(0) is False
+
+
+@pytest.mark.asyncio
+async def test_discovery_command_timeout() -> None:
+    """A command whose response never arrives times out and reports failure."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mgmt_ctl.timeout = 0.01
+
+    def _never_resolving(opcode: int, controller_idx: int) -> object:
+        future = asyncio.get_running_loop().create_future()  # never resolved
+
+        class MockContext:
+            async def __aenter__(self) -> asyncio.Future[tuple[int, bytes]]:
+                return future
+
+            async def __aexit__(self, *args: object) -> None:
+                pass
+
+        return MockContext()
+
+    mock_protocol.command_response = _never_resolving
+
+    assert await mgmt_ctl.start_discovery(0) is False
+
+
+@pytest.mark.asyncio
+async def test_discovery_no_connection() -> None:
+    """Discovery and monitor commands fail gracefully when the socket is down."""
+    mgmt_ctl = MGMTBluetoothCtl(timeout=5.0, scanners={})
+    assert mgmt_ctl.protocol is None
+    assert await mgmt_ctl.start_discovery(0) is False
+    assert await mgmt_ctl.stop_discovery(0) is False
+    assert await mgmt_ctl.add_adv_pattern_monitor(0) is None
+    assert await mgmt_ctl.remove_adv_monitor(0, 7) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_type", [OSError, BluetoothSocketError])
+async def test_discovery_command_response_error(exc_type: type[Exception]) -> None:
+    """
+    A socket error while sending a command is handled, not raised.
+
+    BluetoothSocketError is not an OSError subclass, so it must be caught
+    explicitly; _write_to_socket can raise either one.
+    """
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+
+    def _raising_command_response(opcode: int, controller_idx: int) -> object:
+        class MockContext:
+            async def __aenter__(self) -> asyncio.Future[tuple[int, bytes]]:
+                msg = "socket gone"
+                raise exc_type(msg)
+
+            async def __aexit__(self, *args: object) -> None:
+                pass
+
+        return MockContext()
+
+    mock_protocol.command_response = _raising_command_response
+
+    assert await mgmt_ctl.start_discovery(0) is False
+    assert await mgmt_ctl.add_adv_pattern_monitor(0) is None
+    assert await mgmt_ctl.remove_adv_monitor(0, 7) is False
+
+
+@pytest.mark.asyncio
+async def test_command_response_skips_already_resolved_future() -> None:
+    """A command-complete for an already-resolved future does not re-set it."""
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    future.set_result(None)
+    protocol = BluetoothMGMTProtocol(
+        future, {}, Mock(), Mock(return_value=False), Mock()
+    )
+    async with protocol.command_response(MGMT_OP_START_DISCOVERY, 0) as fut:
+        # Resolve early, then deliver a late response for the same command.
+        fut.set_result((0x00, b""))
+        protocol.data_received(
+            b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
+            b"\x00\x00"  # controller index 0
+            b"\x03\x00"  # param_len
+            + MGMT_OP_START_DISCOVERY.to_bytes(2, "little")
+            + b"\x05"  # different status, must be ignored
+        )
+        assert fut.result() == (0x00, b"")
+
+
+@pytest.mark.asyncio
+async def test_command_response_for_unregistered_command_is_ignored() -> None:
+    """A command-complete with no waiter is dropped without breaking later ones."""
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    future.set_result(None)
+    protocol = BluetoothMGMTProtocol(
+        future, {}, Mock(), Mock(return_value=False), Mock()
+    )
+    # No command_response registered for this opcode/controller: must not raise.
+    protocol.data_received(
+        b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
+        b"\x00\x00"  # controller index 0
+        b"\x03\x00"  # param_len
+        + MGMT_OP_START_DISCOVERY.to_bytes(2, "little")
+        + b"\x00"  # status success
+    )
+    # A subsequently registered command still resolves normally.
+    async with protocol.command_response(MGMT_OP_STOP_DISCOVERY, 0) as fut:
+        protocol.data_received(
+            b"\x01\x00"
+            b"\x00\x00"
+            b"\x03\x00" + MGMT_OP_STOP_DISCOVERY.to_bytes(2, "little") + b"\x00"
+        )
+        status, _ = await fut
+        assert status == 0x00
+
+
+@pytest.mark.asyncio
+async def test_add_adv_pattern_monitor_success() -> None:
+    """add_adv_pattern_monitor returns the handle and sends a match-all monitor."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    # Command complete returns the assigned monitor handle (uint16 little-endian).
+    mock_protocol.command_response = _stub_command_response(0x00, b"\x07\x00")
+
+    assert await mgmt_ctl.add_adv_pattern_monitor(0) == 7
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_ADD_ADV_PATTERNS_MONITOR.to_bytes(2, "little")
+    # param_len 1, pattern_count 0 (match all)
+    assert sent[4:6] == b"\x01\x00"
+    assert sent[6] == 0x00
+
+
+@pytest.mark.asyncio
+async def test_add_adv_pattern_monitor_failure() -> None:
+    """add_adv_pattern_monitor returns None on an error status."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x0C, b"")
+
+    assert await mgmt_ctl.add_adv_pattern_monitor(0) is None
+
+
+@pytest.mark.asyncio
+async def test_add_adv_pattern_monitor_success_without_handle() -> None:
+    """A success response missing the 2-byte handle is reported as failure."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00, b"")
+
+    assert await mgmt_ctl.add_adv_pattern_monitor(0) is None
+
+
+@pytest.mark.asyncio
+async def test_remove_adv_monitor() -> None:
+    """remove_adv_monitor returns True on success and sends the handle."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert await mgmt_ctl.remove_adv_monitor(0, 7) is True
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_REMOVE_ADV_MONITOR.to_bytes(2, "little")
+    assert sent[6:8] == (7).to_bytes(2, "little")
+
+
+@pytest.mark.asyncio
+async def test_remove_adv_monitor_failure() -> None:
+    """remove_adv_monitor returns False on an error status."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x0C)
+
+    assert await mgmt_ctl.remove_adv_monitor(0, 7) is False
+
+
+@pytest.mark.asyncio
+async def test_per_controller_command_response_isolation() -> None:
+    """Concurrent same-opcode commands on two controllers do not collide."""
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    future.set_result(None)
+    protocol = BluetoothMGMTProtocol(
+        future, {}, Mock(), Mock(return_value=False), Mock()
+    )
+
+    async with (
+        protocol.command_response(MGMT_OP_START_DISCOVERY, 0) as fut0,
+        protocol.command_response(MGMT_OP_START_DISCOVERY, 1) as fut1,
+    ):
+        # Command complete for controller 1 only.
+        protocol.data_received(
+            b"\x01\x00"  # MGMT_EV_CMD_COMPLETE
+            b"\x01\x00"  # controller index 1
+            b"\x03\x00"  # param_len
+            + MGMT_OP_START_DISCOVERY.to_bytes(2, "little")
+            + b"\x00"  # status success
+        )
+        assert fut1.done()
+        assert not fut0.done()
+        status, _ = await fut1
+        assert status == 0x00


### PR DESCRIPTION
Second step toward a dbus free local backend; this adds the management socket plumbing a future mgmt scanner will use to start and stop scanning without DBus.

MGMTBluetoothCtl gains start_discovery and stop_discovery for active scanning, add_adv_pattern_monitor and remove_adv_monitor for passive scanning, and a can_discover flag that is set once setup confirms NET_ADMIN/NET_RAW. Pending command futures are now keyed by (opcode, controller_idx) so the same command can be in flight on more than one adapter at once, and command complete handling was generalized to resolve any awaited command rather than just the capability probe. Nothing consumes these yet; the mgmt scanner lands in a follow up.

Green in pure python and compiled builds with new unit tests for every command and its failure paths.