### PR TITLE
test: implement default_adapter on FakeBluetoothAdapters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,10 @@ class FakeBluetoothAdapters(BluetoothAdapters):
     def adapters(self) -> dict[str, AdapterDetails]:
         return {}
 
+    @property
+    def default_adapter(self) -> str:
+        return "hci0"
+
 
 class FakeScannerMixin:
     def get_discovered_device_advertisement_data(


### PR DESCRIPTION
## What

bluetooth-adapters 2.4.0 ships [#270](https://github.com/Bluetooth-Devices/bluetooth-adapters/pull/270) ("make `BluetoothAdapters` a real ABC"). The `default_adapter` property has been decorated `@abstractproperty` since 2.1.x, but it was never *enforced* because the base class was a plain class. Now that it's a true `ABCMeta` ABC, any subclass that doesn't implement `default_adapter` can no longer be instantiated.

`tests/conftest.py`'s `FakeBluetoothAdapters` only implemented `adapters`, so under 2.4.0 every test errors with:

```
TypeError: Can't instantiate abstract class FakeBluetoothAdapters with abstract method default_adapter
```

This adds a `default_adapter` property to the fake (returning `"hci0"`, matching the Linux default). habluetooth source never calls `default_adapter`, so any valid string suffices.

## Why a separate PR

Implementing an already-declared abstract property is fully backward-compatible with the currently-pinned 2.2.0, so this lands safely ahead of the dependabot bump #541. Once merged, rebasing #541 turns its CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)