### PR TITLE
refactor: move raw bluez advertisement adaptation into the bluez channel

### DIFF
--- a/src/habluetooth/channels/bluez.pxd
+++ b/src/habluetooth/channels/bluez.pxd
@@ -1,7 +1,7 @@
 
 import cython
 
-from ..scanner_bleak cimport HaScanner
+from ..base_scanner cimport BaseHaScanner
 cdef bint TYPE_CHECKING
 
 cdef unsigned short DEVICE_FOUND
@@ -36,10 +36,10 @@ cdef class BluetoothMGMTProtocol:
         controller_idx="unsigned short",
         param_len="unsigned short",
         rssi="short",
-        flags="unsigned int",
         data="bytes",
         parse_offset="unsigned short",
-        scanner=HaScanner,
+        address_str=str,
+        scanner=BaseHaScanner,
         opcode="unsigned short",
         status="unsigned char",
         param_offset="unsigned short",

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -4,9 +4,11 @@ import asyncio
 import logging
 from asyncio import timeout as asyncio_timeout
 from contextlib import asynccontextmanager
+from functools import lru_cache
 from struct import Struct
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
+from bluetooth_data_tools import monotonic_time_coarse
 from btsocket import btmgmt_socket
 from btsocket.btmgmt_socket import BluetoothSocketError
 
@@ -26,7 +28,7 @@ if TYPE_CHECKING:
     import socket
     from collections.abc import AsyncIterator, Callable
 
-    from ..scanner_bleak import HaScanner
+    from ..base_scanner import BaseHaScanner
 
 _LOGGER = logging.getLogger(__name__)
 _int = int
@@ -88,13 +90,31 @@ def _set_future_if_not_done(future: asyncio.Future[None] | None) -> None:
         future.set_result(None)
 
 
+@lru_cache(maxsize=512)
+def bytes_mac_to_str(mac: bytes) -> str:
+    """Convert a MAC address in bytes to a string in big-endian (MSB-first) order."""
+    return ":".join(f"{b:02X}" for b in reversed(mac))
+
+
+@lru_cache(maxsize=512)
+def make_bluez_details(address: str, adapter: str) -> dict[str, Any]:
+    """Make the BlueZ details dict for a raw advertisement."""
+    base_path = f"/org/bluez/{adapter}"
+    return {
+        "path": f"{base_path}/dev_{address.replace(':', '_')}",
+        "props": {
+            "Adapter": base_path,
+        },
+    }
+
+
 class BluetoothMGMTProtocol:
     """Bluetooth MGMT protocol."""
 
     def __init__(
         self,
         connection_made_future: asyncio.Future[None],
-        scanners: dict[int, HaScanner],
+        scanners: dict[int, BaseHaScanner],
         on_connection_lost: Callable[[], None],
         is_shutting_down: Callable[[], bool],
         sock: socket.socket,
@@ -260,31 +280,27 @@ class BluetoothMGMTProtocol:
                 self._remove_from_buffer()
                 continue
             address = header[parse_offset : parse_offset + 6]
-            address_type = header[parse_offset + 6]
             rssi = header[parse_offset + 7]
             if rssi > 128:
                 rssi -= 256
 
-            flags = (
-                header[parse_offset + 8]
-                | (header[parse_offset + 9] << 8)
-                | (header[parse_offset + 10] << 16)
-                | (header[parse_offset + 11] << 24)
-            )
-
-            # Skip AD_Data_Length (2 bytes) at parse_offset+12 and +13
+            # Skip address_type (+6), flags (+8..+11) and AD_Data_Length
+            # (+12..+13); the advertising data payload starts at +14.
             data = header[parse_offset + 14 : self._pos]
             self._remove_from_buffer()
 
             if (scanner := self._scanners.get(controller_idx)) is not None:
-                # We have a scanner for this controller, so we can
-                # pass the data to it.
-                scanner._async_on_raw_bluez_advertisement(
-                    address,
-                    address_type,
+                # Adapt the raw BlueZ advertisement onto the generic ingestion
+                # path. The BlueZ-specific bits (MAC byte order, object path)
+                # live here in the channel rather than on the scanner classes,
+                # which only expose the platform-agnostic _async_on_raw_advertisement.
+                address_str = bytes_mac_to_str(address)
+                scanner._async_on_raw_advertisement(
+                    address_str,
                     rssi,
-                    flags,
                     data,
+                    make_bluez_details(address_str, scanner.adapter),
+                    monotonic_time_coarse(),
                 )
 
     def _handle_load_conn_param_response(
@@ -318,7 +334,7 @@ class BluetoothMGMTProtocol:
 class MGMTBluetoothCtl:
     """Class to control interfaces using the BlueZ management API."""
 
-    def __init__(self, timeout: float, scanners: dict[int, HaScanner]) -> None:
+    def __init__(self, timeout: float, scanners: dict[int, BaseHaScanner]) -> None:
         """Initialize the control class."""
         # Internal state
         self.timeout = timeout

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -63,7 +63,6 @@ if TYPE_CHECKING:
     from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
 
     from .base_scanner import BaseHaScanner
-    from .scanner_bleak import HaScanner
 
 
 SYSTEM = platform.system()
@@ -202,7 +201,7 @@ class BluetoothManager:
         self._debug = _LOGGER.isEnabledFor(logging.DEBUG)
         self.shutdown = False
         self.has_advertising_side_channel = False
-        self._side_channel_scanners: dict[int, HaScanner] = {}
+        self._side_channel_scanners: dict[int, BaseHaScanner] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._adapter_refresh_future: asyncio.Future[None] | None = None
         self._recovery_lock: asyncio.Lock = asyncio.Lock()
@@ -1204,7 +1203,7 @@ class BluetoothManager:
         self._sources[scanner.source] = scanner
         self._adapter_sources[scanner.adapter] = scanner.source
         if (idx := scanner.adapter_idx) is not None:
-            self._side_channel_scanners[idx] = scanner  # type: ignore[assignment]
+            self._side_channel_scanners[idx] = scanner
         if connection_slots:
             self.slot_manager.register_adapter(scanner.adapter, connection_slots)
             self.async_on_allocation_changed(

--- a/src/habluetooth/scanner_bleak.pxd
+++ b/src/habluetooth/scanner_bleak.pxd
@@ -29,12 +29,3 @@ cdef class HaScanner(BaseHaScanner):
         object device,
         object advertisement_data
     )
-
-    cpdef void _async_on_raw_bluez_advertisement(
-        self,
-        bytes address,
-        unsigned short address_type,
-        short rssi,
-        unsigned int flags,
-        bytes data,
-    ) except *

--- a/src/habluetooth/scanner_bleak.py
+++ b/src/habluetooth/scanner_bleak.py
@@ -7,7 +7,6 @@ import contextlib
 import logging
 import math
 import platform
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any, no_type_check
 
 import async_interrupt
@@ -36,8 +35,6 @@ if TYPE_CHECKING:
 
     from bleak.backends.device import BLEDevice
     from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
-
-int_ = int
 
 SYSTEM = platform.system()
 IS_LINUX = SYSTEM == "Linux"
@@ -216,24 +213,6 @@ def _error_indicates_wait_for_adapter_to_init(error_str: str) -> bool:
     )
 
 
-@lru_cache(maxsize=512)
-def bytes_mac_to_str(mac: bytes) -> str:
-    """Convert a MAC address in bytes to a string in big-endian (MSB-first) order."""
-    return ":".join(f"{b:02X}" for b in reversed(mac))
-
-
-@lru_cache(maxsize=512)
-def make_bluez_details(address: str, adapter: str) -> dict[str, Any]:
-    """Make the details for a bluez advertisement."""
-    base_path = f"/org/bluez/{adapter}"
-    return {
-        "path": f"{base_path}/dev_{address.replace(':', '_')}",
-        "props": {
-            "Adapter": base_path,
-        },
-    }
-
-
 class HaScanner(BaseHaScanner):
     """
     Operate and automatically recover a BleakScanner.
@@ -329,24 +308,6 @@ class HaScanner(BaseHaScanner):
         """Return diagnostic information about the scanner."""
         base_diag = await super().async_diagnostics()
         return base_diag | {"adapter": self.adapter}
-
-    def _async_on_raw_bluez_advertisement(
-        self,
-        address: bytes,
-        address_type: int_,
-        rssi: int_,
-        flags: int_,
-        data: bytes,
-    ) -> None:
-        """Handle raw advertisement data."""
-        address_str = bytes_mac_to_str(address)
-        self._async_on_raw_advertisement(
-            address_str,
-            rssi,
-            data,
-            make_bluez_details(address_str, self.adapter),
-            monotonic_time_coarse(),
-        )
 
     def _async_detection_callback(
         self,

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 from btsocket.btmgmt_socket import BluetoothSocketError
@@ -18,6 +18,8 @@ from habluetooth.channels.bluez import (
     SCAN_TYPE_LE,
     BluetoothMGMTProtocol,
     MGMTBluetoothCtl,
+    bytes_mac_to_str,
+    make_bluez_details,
 )
 from habluetooth.const import (
     BDADDR_LE_PUBLIC,
@@ -37,6 +39,8 @@ from habluetooth.scanner_bleak import HaScanner
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from habluetooth.base_scanner import BaseHaScanner
+
 
 class MockHaScanner(HaScanner):
     """Mock HaScanner for testing with Cython."""
@@ -44,9 +48,10 @@ class MockHaScanner(HaScanner):
     def __init__(self):
         """Initialize without calling parent __init__ to avoid BleakScanner setup."""
         self.source = "test"
+        self.adapter = "hci0"
         self.connectable = True
         # Mock the method that will be called
-        self._async_on_raw_bluez_advertisement: Any = Mock()
+        self._async_on_raw_advertisement: Any = Mock()
 
 
 @pytest.fixture
@@ -80,7 +85,7 @@ def test_connection_made(
 ) -> None:
     """Test connection_made sets up the protocol correctly."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -100,7 +105,7 @@ def test_connection_lost(
 ) -> None:
     """Test connection_lost handles disconnection."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -123,7 +128,7 @@ def test_connection_lost_no_exception(
 ) -> None:
     """Test connection_lost without exception."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -143,7 +148,7 @@ def test_data_received_device_found(
 ) -> None:
     """Test data_received handles DEVICE_FOUND event."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -172,12 +177,13 @@ def test_data_received_device_found(
 
     protocol.data_received(header + params)
 
-    mock_scanner._async_on_raw_bluez_advertisement.assert_called_once_with(
-        b"\xaa\xbb\xcc\xdd\xee\xff",
-        1,
+    expected_address = bytes_mac_to_str(b"\xaa\xbb\xcc\xdd\xee\xff")
+    mock_scanner._async_on_raw_advertisement.assert_called_once_with(
+        expected_address,
         -56,
-        0,
         ad_data,
+        make_bluez_details(expected_address, "hci0"),
+        ANY,
     )
 
 
@@ -186,7 +192,7 @@ def test_data_received_adv_monitor_device_found(
 ) -> None:
     """Test data_received handles ADV_MONITOR_DEVICE_FOUND event."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -214,12 +220,13 @@ def test_data_received_adv_monitor_device_found(
 
     protocol.data_received(header + params)
 
-    mock_scanner._async_on_raw_bluez_advertisement.assert_called_once_with(
-        b"\xaa\xbb\xcc\xdd\xee\xff",
-        2,
+    expected_address = bytes_mac_to_str(b"\xaa\xbb\xcc\xdd\xee\xff")
+    mock_scanner._async_on_raw_advertisement.assert_called_once_with(
+        expected_address,
         100,
-        0,
         ad_data,
+        make_bluez_details(expected_address, "hci0"),
+        ANY,
     )
 
 
@@ -229,7 +236,7 @@ def test_data_received_cmd_complete_success(
 ) -> None:
     """Test data_received handles successful MGMT_EV_CMD_COMPLETE."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -257,7 +264,7 @@ def test_data_received_cmd_complete_failure(
 ) -> None:
     """Test data_received handles failed MGMT_EV_CMD_COMPLETE."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -284,7 +291,7 @@ def test_data_received_cmd_status(
 ) -> None:
     """Test data_received handles MGMT_EV_CMD_STATUS."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -311,7 +318,7 @@ def test_data_received_partial_data(
 ) -> None:
     """Test data_received handles partial data correctly."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -330,11 +337,11 @@ def test_data_received_partial_data(
 
     # Send header first
     protocol.data_received(full_data[:6])
-    mock_scanner._async_on_raw_bluez_advertisement.assert_not_called()
+    mock_scanner._async_on_raw_advertisement.assert_not_called()
 
     # Send rest of data
     protocol.data_received(full_data[6:])
-    mock_scanner._async_on_raw_bluez_advertisement.assert_called_once()
+    mock_scanner._async_on_raw_advertisement.assert_called_once()
 
 
 def test_data_received_partial_data_split_in_params(
@@ -342,7 +349,7 @@ def test_data_received_partial_data_split_in_params(
 ) -> None:
     """Test data_received handles data split in the middle of params."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -361,16 +368,17 @@ def test_data_received_partial_data_split_in_params(
 
     # Split in the middle of the address
     protocol.data_received(full_data[:10])  # Header + part of address
-    mock_scanner._async_on_raw_bluez_advertisement.assert_not_called()
+    mock_scanner._async_on_raw_advertisement.assert_not_called()
 
     # Send rest of data
     protocol.data_received(full_data[10:])
-    mock_scanner._async_on_raw_bluez_advertisement.assert_called_once_with(
-        b"\xaa\xbb\xcc\xdd\xee\xff",
-        1,
+    expected_address = bytes_mac_to_str(b"\xaa\xbb\xcc\xdd\xee\xff")
+    mock_scanner._async_on_raw_advertisement.assert_called_once_with(
+        expected_address,
         -56,
-        0,
         ad_data,
+        make_bluez_details(expected_address, "hci0"),
+        ANY,
     )
 
 
@@ -379,7 +387,7 @@ def test_data_received_multiple_small_chunks(
 ) -> None:
     """Test data_received handles data sent in many small chunks."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -400,10 +408,10 @@ def test_data_received_multiple_small_chunks(
     for i in range(len(full_data)):
         protocol.data_received(full_data[i : i + 1])
         if i < len(full_data) - 1:
-            mock_scanner._async_on_raw_bluez_advertisement.assert_not_called()
+            mock_scanner._async_on_raw_advertisement.assert_not_called()
 
     # After all bytes are sent, callback should be called once
-    mock_scanner._async_on_raw_bluez_advertisement.assert_called_once()
+    mock_scanner._async_on_raw_advertisement.assert_called_once()
 
 
 def test_data_received_multiple_events_in_one_chunk(
@@ -413,7 +421,7 @@ def test_data_received_multiple_events_in_one_chunk(
 ) -> None:
     """Test data_received handles multiple events in one data chunk."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -437,7 +445,7 @@ def test_data_received_multiple_events_in_one_chunk(
     protocol.data_received(event1 + event2)
 
     # Both events should be processed
-    mock_scanner._async_on_raw_bluez_advertisement.assert_called_once()
+    mock_scanner._async_on_raw_advertisement.assert_called_once()
     assert "Connection parameters loaded successfully" in caplog.text
 
 
@@ -446,7 +454,7 @@ def test_data_received_partial_then_multiple_events(
 ) -> None:
     """Test partial data followed by multiple complete events."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {0: mock_scanner}
+    scanners: dict[int, BaseHaScanner] = {0: mock_scanner}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -472,31 +480,33 @@ def test_data_received_partial_then_multiple_events(
 
     # Send partial first event
     protocol.data_received(event1[:15])
-    mock_scanner._async_on_raw_bluez_advertisement.assert_not_called()
+    mock_scanner._async_on_raw_advertisement.assert_not_called()
 
     # Send rest of first event + second event
     protocol.data_received(event1[15:] + event2)
 
     # Both callbacks should be called
-    assert mock_scanner._async_on_raw_bluez_advertisement.call_count == 2
-    calls = mock_scanner._async_on_raw_bluez_advertisement.call_args_list
+    assert mock_scanner._async_on_raw_advertisement.call_count == 2
+    calls = mock_scanner._async_on_raw_advertisement.call_args_list
 
     # First call
+    first_address = bytes_mac_to_str(b"\x11\x22\x33\x44\x55\x66")
     assert calls[0][0] == (
-        b"\x11\x22\x33\x44\x55\x66",
-        1,
+        first_address,
         -56,
-        0,
         ad_data1,
+        make_bluez_details(first_address, "hci0"),
+        ANY,
     )
 
     # Second call
+    second_address = bytes_mac_to_str(b"\x77\x88\x99\xaa\xbb\xcc")
     assert calls[1][0] == (
-        b"\x77\x88\x99\xaa\xbb\xcc",
-        2,
+        second_address,
         100,
-        0,
         ad_data2,
+        make_bluez_details(second_address, "hci0"),
+        ANY,
     )
 
 
@@ -505,7 +515,7 @@ def test_data_received_cmd_complete_different_opcode(
 ) -> None:
     """Test data_received handles CMD_COMPLETE for different opcodes."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -533,7 +543,7 @@ def test_data_received_cmd_status_different_opcode(
 ) -> None:
     """Test data_received handles CMD_STATUS for different opcodes."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -561,7 +571,7 @@ def test_data_received_cmd_complete_short_params(
 ) -> None:
     """Test data_received handles CMD_COMPLETE with param_len < 3."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -588,7 +598,7 @@ def test_data_received_cmd_status_param_len_1(
 ) -> None:
     """Test data_received handles CMD_STATUS with param_len = 1."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -615,7 +625,7 @@ def test_data_received_cmd_complete_param_len_0(
 ) -> None:
     """Test data_received handles CMD_COMPLETE with param_len = 0."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -638,7 +648,7 @@ def test_data_received_cmd_complete_param_len_0(
 def test_data_received_unknown_event(event_loop: asyncio.AbstractEventLoop) -> None:
     """Test data_received ignores unknown events."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -662,7 +672,7 @@ def test_data_received_no_scanner_for_controller(
 ) -> None:
     """Test data_received handles missing scanner gracefully."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}  # No scanner for controller 0
+    scanners: dict[int, BaseHaScanner] = {}  # No scanner for controller 0
     on_connection_lost = Mock()
 
     is_shutting_down = Mock(return_value=False)
@@ -1003,7 +1013,7 @@ def test_kernel_bug_workaround_send_returns_zero(
 ) -> None:
     """Test that the kernel bug workaround handles send returning 0."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
     is_shutting_down = Mock(return_value=False)
 
@@ -1029,7 +1039,7 @@ def test_kernel_bug_workaround_send_raises_exception(
 ) -> None:
     """Test that _write_to_socket handles and re-raises exceptions."""
     future = event_loop.create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
     is_shutting_down = Mock(return_value=False)
 
@@ -1231,7 +1241,7 @@ async def test_command_response_context_manager() -> None:
     """Test the command_response context manager."""
     future = asyncio.get_running_loop().create_future()
     future.set_result(None)  # Mark connection as made
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
     is_shutting_down = Mock(return_value=False)
 
@@ -1270,7 +1280,7 @@ async def test_command_response_context_manager() -> None:
 async def test_command_response_cleanup_on_exception() -> None:
     """Test that command_response cleans up even if an exception occurs."""
     future = asyncio.get_running_loop().create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
     is_shutting_down = Mock(return_value=False)
 
@@ -1299,7 +1309,7 @@ async def test_command_response_cleanup_on_exception() -> None:
 async def test_get_connections_response_handling() -> None:
     """Test handling of GET_CONNECTIONS command response."""
     future = asyncio.get_running_loop().create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
     is_shutting_down = Mock(return_value=False)
 
@@ -1333,7 +1343,7 @@ async def test_get_connections_response_handling() -> None:
 async def test_get_connections_response_with_data() -> None:
     """Test GET_CONNECTIONS response with additional data."""
     future = asyncio.get_running_loop().create_future()
-    scanners: dict[int, HaScanner] = {}
+    scanners: dict[int, BaseHaScanner] = {}
     on_connection_lost = Mock()
     is_shutting_down = Mock(return_value=False)
 
@@ -1894,3 +1904,17 @@ async def test_per_controller_command_response_isolation() -> None:
         assert not fut0.done()
         status, _ = await fut1
         assert status == 0x00
+
+
+def test_bytes_mac_to_str() -> None:
+    """Test bytes_mac_to_str."""
+    assert bytes_mac_to_str(b"\xff\xee\xdd\xcc\xbb\xaa") == "AA:BB:CC:DD:EE:FF"
+    assert bytes_mac_to_str(b"\xff\xee\xdd\xcc\xbb\xaa") == "AA:BB:CC:DD:EE:FF"
+
+
+def test_make_bluez_details() -> None:
+    """Test make_bluez_details."""
+    assert make_bluez_details("AA:BB:CC:DD:EE:FF", "hci0") == {
+        "path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+        "props": {"Adapter": "/org/bluez/hci0"},
+    }

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from bleak.backends.scanner import AdvertisementData
     from pytest_codspeed import BenchmarkFixture
 
+    from habluetooth.base_scanner import BaseHaScanner
+
 pytestmark = pytest.mark.timeout(60)
 
 
@@ -937,7 +939,7 @@ async def test_inject_100_bluez_raw_end_to_end_unchanged(
     scanner.async_setup()
     cancel = manager.async_register_scanner(scanner)
 
-    scanners: dict[int, HaScanner] = {0: scanner}
+    scanners: dict[int, BaseHaScanner] = {0: scanner}
     future: asyncio.Future[None] = loop.create_future()
     mock_sock = MagicMock()
     protocol = BluetoothMGMTProtocol(
@@ -988,7 +990,7 @@ async def test_inject_100_bluez_raw_end_to_end_changed(
     scanner.async_setup()
     cancel = manager.async_register_scanner(scanner)
 
-    scanners: dict[int, HaScanner] = {0: scanner}
+    scanners: dict[int, BaseHaScanner] = {0: scanner}
     future: asyncio.Future[None] = loop.create_future()
     mock_sock = MagicMock()
     protocol = BluetoothMGMTProtocol(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -33,12 +33,12 @@ from habluetooth import scanner_bleak as scanner
 from habluetooth.channels.bluez import (
     BluetoothMGMTProtocol,
     MGMTBluetoothCtl,
+    bytes_mac_to_str,
+    make_bluez_details,
 )
 from habluetooth.scanner_bleak import (
     InvalidMessageError,
-    bytes_mac_to_str,
     create_bleak_scanner,
-    make_bluez_details,
 )
 
 from . import (
@@ -136,20 +136,6 @@ def mock_btmgmt_socket():
 def test_scanner_module_aliases_scanner_bleak() -> None:
     """habluetooth.scanner is a back-compat alias of the scanner_bleak module."""
     assert scanner_shim is scanner
-
-
-def test_bytes_mac_to_str() -> None:
-    """Test bytes_mac_to_str."""
-    assert bytes_mac_to_str(b"\xff\xee\xdd\xcc\xbb\xaa") == "AA:BB:CC:DD:EE:FF"
-    assert bytes_mac_to_str(b"\xff\xee\xdd\xcc\xbb\xaa") == "AA:BB:CC:DD:EE:FF"
-
-
-def test_make_bluez_details() -> None:
-    """Test make_bluez_details."""
-    assert make_bluez_details("AA:BB:CC:DD:EE:FF", "hci0") == {
-        "path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
-        "props": {"Adapter": "/org/bluez/hci0"},
-    }
 
 
 def test_create_bleak_scanner_linux_no_adapter_active() -> None:
@@ -1094,7 +1080,6 @@ async def test_scanner_with_bluez_mgmt_side_channel(mock_btmgmt_socket: Mock) ->
         # Simulate the protocol calling the scanner's raw advertisement handler
         test_address = b"\xaa\xbb\xcc\xdd\xee\xff"
         test_rssi = -60
-        test_flags = 0x06
         # Create valid advertisement data with flags
         # Each AD structure is: length (1 byte), type (1 byte), data
         test_data = (
@@ -1103,13 +1088,15 @@ async def test_scanner_with_bluez_mgmt_side_channel(mock_btmgmt_socket: Mock) ->
             b"\x08\x09TestDev"
         )
 
-        # Call the method that the protocol would call
-        scanner._async_on_raw_bluez_advertisement(
-            test_address,
-            1,  # address_type: BDADDR_LE_PUBLIC
+        # Replicate what the BlueZ channel does on a raw advertisement: convert
+        # the address and build the details, then call the generic handler.
+        test_address_str = bytes_mac_to_str(test_address)
+        scanner._async_on_raw_advertisement(
+            test_address_str,
             test_rssi,
-            test_flags,
             test_data,
+            make_bluez_details(test_address_str, scanner.adapter),
+            time.monotonic(),
         )
 
         # Allow time for processing


### PR DESCRIPTION
Groundwork for the mgmt based local scanner; pure refactor with no behavior change.

The BlueZ specific adaptation (raw MAC byte order, org.bluez object path) moves out of the scanner classes and into the bluez channel. data_received now converts the address and builds the details, then calls the platform agnostic _async_on_raw_advertisement on whichever scanner registered for that controller. No scanner class carries a bluez method anymore, so BlueZ handling stays off the cross platform base and off the macOS local scanner entirely.

_side_channel_scanners and the channel are retyped from HaScanner to BaseHaScanner, which also drops a type ignore at the registration site. The bytes_mac_to_str and make_bluez_details helpers now live in the bluez channel where they are used.

Green in pure python and compiled builds, and home-assistant tests/components/bluetooth passes unchanged.