### PR TITLE
feat: add att/gatt protocol codec

### DIFF
--- a/src/habluetooth/channels/att.py
+++ b/src/habluetooth/channels/att.py
@@ -1,0 +1,624 @@
+"""
+ATT protocol client and GATT discovery for the kernel/L2CAP backend.
+
+This is the pure ATT/GATT logic for talking to a peripheral over an L2CAP ATT
+channel: it encodes ATT requests, decodes responses, and drives the central
+(client) subset of GATT, namely MTU exchange, primary-service / characteristic
+/ descriptor discovery, reads (with long-read continuation), writes (with and
+without response), and notification / indication handling.
+
+It is deliberately transport-agnostic. Outbound PDUs are written through the
+``send`` coroutine supplied at construction, and inbound PDUs are delivered by
+the transport via :meth:`ATTClient.data_received`. Nothing here opens a socket,
+so the whole module is unit-testable without Bluetooth hardware. The L2CAP
+socket that feeds it lands in a later change.
+
+ATT is strictly sequential: at most one request is outstanding at a time, so a
+single transaction lock plus one pending future is sufficient. Notifications
+and indications are demultiplexed out of the same inbound stream by opcode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import struct
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bleak import BleakError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+_LOGGER = logging.getLogger(__name__)
+
+# -- ATT opcodes ----------------------------------------------------------
+ATT_ERROR_RSP = 0x01
+ATT_EXCHANGE_MTU_REQ = 0x02
+ATT_EXCHANGE_MTU_RSP = 0x03
+ATT_FIND_INFO_REQ = 0x04
+ATT_FIND_INFO_RSP = 0x05
+ATT_READ_BY_TYPE_REQ = 0x08
+ATT_READ_BY_TYPE_RSP = 0x09
+ATT_READ_REQ = 0x0A
+ATT_READ_RSP = 0x0B
+ATT_READ_BLOB_REQ = 0x0C
+ATT_READ_BLOB_RSP = 0x0D
+ATT_READ_BY_GROUP_TYPE_REQ = 0x10
+ATT_READ_BY_GROUP_TYPE_RSP = 0x11
+ATT_WRITE_REQ = 0x12
+ATT_WRITE_RSP = 0x13
+ATT_WRITE_CMD = 0x52
+ATT_HANDLE_VALUE_NTF = 0x1B
+ATT_HANDLE_VALUE_IND = 0x1D
+ATT_HANDLE_VALUE_CFM = 0x1E
+
+# -- ATT error codes ------------------------------------------------------
+ATT_ERR_INVALID_HANDLE = 0x01
+ATT_ERR_READ_NOT_PERMITTED = 0x02
+ATT_ERR_INSUFFICIENT_AUTHENTICATION = 0x05
+ATT_ERR_REQUEST_NOT_SUPPORTED = 0x06
+ATT_ERR_INVALID_OFFSET = 0x07
+ATT_ERR_ATTRIBUTE_NOT_FOUND = 0x0A
+ATT_ERR_ATTRIBUTE_NOT_LONG = 0x0B
+ATT_ERR_INSUFFICIENT_ENCRYPTION = 0x0F
+
+# -- GATT well-known attribute types (16-bit, little-endian on the wire) --
+GATT_PRIMARY_SERVICE = b"\x00\x28"  # 0x2800
+GATT_CHARACTERISTIC = b"\x03\x28"  # 0x2803
+CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
+
+# -- characteristic property flags (Core Vol 3 Part G 3.3.1.1) ------------
+CHAR_PROP_BROADCAST = 0x01
+CHAR_PROP_READ = 0x02
+CHAR_PROP_WRITE_NO_RESPONSE = 0x04
+CHAR_PROP_WRITE = 0x08
+CHAR_PROP_NOTIFY = 0x10
+CHAR_PROP_INDICATE = 0x20
+CHAR_PROP_AUTH_SIGNED_WRITES = 0x40
+CHAR_PROP_EXTENDED = 0x80
+
+_PROPERTY_MAP: list[tuple[int, str]] = [
+    (CHAR_PROP_BROADCAST, "broadcast"),
+    (CHAR_PROP_READ, "read"),
+    (CHAR_PROP_WRITE_NO_RESPONSE, "write-without-response"),
+    (CHAR_PROP_WRITE, "write"),
+    (CHAR_PROP_NOTIFY, "notify"),
+    (CHAR_PROP_INDICATE, "indicate"),
+    (CHAR_PROP_AUTH_SIGNED_WRITES, "authenticated-signed-writes"),
+    (CHAR_PROP_EXTENDED, "extended-properties"),
+]
+
+DEFAULT_MTU = 23
+PREFERRED_MTU = 247
+ATT_TIMEOUT = 30.0
+
+_BASE_UUID_SUFFIX = "-0000-1000-8000-00805f9b34fb"
+
+_ERROR_RSP = struct.Struct("<BHB")
+
+
+def properties_to_strings(properties: int) -> list[str]:
+    """Expand a characteristic property bitmask into bleak property names."""
+    return [name for flag, name in _PROPERTY_MAP if properties & flag]
+
+
+def uuid_from_bytes(data: bytes) -> str:
+    """
+    Convert a little-endian ATT UUID (2 or 16 bytes) to a string.
+
+    16-bit UUIDs are expanded against the Bluetooth base UUID so callers always
+    receive a full 128-bit UUID string. Any other length is a malformed PDU and
+    raises rather than producing a bogus UUID.
+    """
+    if len(data) == 2:
+        return f"0000{int.from_bytes(data, 'little'):04x}{_BASE_UUID_SUFFIX}"
+    if len(data) == 16:
+        # 128-bit UUID, stored little-endian on the wire.
+        hexs = data[::-1].hex()
+        return f"{hexs[0:8]}-{hexs[8:12]}-{hexs[12:16]}-{hexs[16:20]}-{hexs[20:32]}"
+    msg = f"invalid ATT UUID length {len(data)}"
+    raise BleakError(msg)
+
+
+class ATTError(BleakError):
+    """An ATT error response from the peer."""
+
+    def __init__(self, req_opcode: int, handle: int, error_code: int) -> None:
+        """Record the request opcode, handle, and ATT error code."""
+        self.req_opcode = req_opcode
+        self.handle = handle
+        self.error_code = error_code
+        super().__init__(
+            f"ATT error 0x{error_code:02x} "
+            f"(req 0x{req_opcode:02x}, handle 0x{handle:04x})"
+        )
+
+
+# -- GATT model -----------------------------------------------------------
+@dataclass(slots=True)
+class GattDescriptor:
+    """A discovered GATT descriptor."""
+
+    handle: int
+    uuid: str
+
+
+@dataclass(slots=True)
+class GattCharacteristic:
+    """A discovered GATT characteristic and its descriptors."""
+
+    handle: int  # declaration handle
+    value_handle: int
+    uuid: str
+    properties: int
+    end_handle: int = 0
+    descriptors: list[GattDescriptor] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class GattService:
+    """A discovered GATT primary service and its characteristics."""
+
+    handle: int
+    end_handle: int
+    uuid: str
+    characteristics: list[GattCharacteristic] = field(default_factory=list)
+
+
+class ATTClient:
+    """
+    An ATT client driven over a transport-agnostic byte stream.
+
+    ``send`` is awaited to write one ATT PDU; the transport must deliver each
+    inbound PDU to :meth:`data_received` and report loss via
+    :meth:`connection_lost`.
+
+    ATT requests are serialized by a transaction lock, but write commands and
+    indication confirmations are sent independently of an outstanding request
+    (as ATT permits), so ``send`` may be called concurrently. Each call carries
+    exactly one PDU, so on a datagram transport (an L2CAP ``SOCK_SEQPACKET``
+    socket) the writes stay framed; the injected ``send`` must therefore be safe
+    to call concurrently and write each PDU atomically.
+    """
+
+    def __init__(
+        self,
+        send: Callable[[bytes], Awaitable[None]],
+        on_disconnect: Callable[[Exception | None], None] | None = None,
+    ) -> None:
+        """Bind the client to a transport ``send`` coroutine."""
+        self._send = send
+        self._on_disconnect = on_disconnect
+        self._txn_lock = asyncio.Lock()
+        self._pending: asyncio.Future[bytes] | None = None
+        self._mtu = DEFAULT_MTU
+        self._notify_handlers: dict[int, Callable[[bytearray], None]] = {}
+        # Strong references to fire-and-forget confirm tasks so they cannot be
+        # garbage-collected before they run.
+        self._background_tasks: set[asyncio.Task[None]] = set()
+        # Set once the channel can no longer be trusted (disconnect or a request
+        # timeout, after which a late response could be misattributed to a new
+        # request since ATT has no transaction id).
+        self._closed = False
+
+    @property
+    def mtu(self) -> int:
+        """Return the negotiated ATT MTU (23 until exchanged)."""
+        return self._mtu
+
+    # -- inbound demux -----------------------------------------------------
+    def data_received(self, data: bytes) -> None:
+        """Demultiplex one inbound ATT PDU into a notify or a response."""
+        if not data:
+            return
+        if self._closed:
+            # The channel has been poisoned (e.g. a request timed out) or torn
+            # down; the transport may still be open but is no longer trusted, so
+            # drop late inbound PDUs rather than delivering a stale notification
+            # or confirming an indication on a channel we are abandoning.
+            return
+        opcode = data[0]
+        if opcode in (ATT_HANDLE_VALUE_NTF, ATT_HANDLE_VALUE_IND):
+            # opcode (1) + handle (2); a shorter frame is malformed, so drop it
+            # rather than fabricating a handle and dispatching an empty value.
+            if len(data) < 3:
+                _LOGGER.debug(
+                    "Dropping truncated ATT handle-value PDU 0x%02x (%d bytes)",
+                    opcode,
+                    len(data),
+                )
+                return
+            self._dispatch_notify(int.from_bytes(data[1:3], "little"), data[3:])
+            if opcode == ATT_HANDLE_VALUE_IND:
+                # Acknowledge the indication; retain a strong reference so the
+                # task is not garbage-collected before it runs, and surface any
+                # send failure via the done callback rather than as an
+                # unretrieved task exception.
+                task = asyncio.get_running_loop().create_task(self._confirm())
+                self._background_tasks.add(task)
+                task.add_done_callback(self._on_confirm_done)
+            return
+        if (fut := self._pending) is not None and not fut.done():
+            fut.set_result(bytes(data))
+        else:
+            _LOGGER.debug("Dropping ATT PDU 0x%02x with no pending transaction", opcode)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        """Fail any in-flight transaction and notify the disconnect callback."""
+        if (fut := self._pending) is not None and not fut.done():
+            fut.set_exception(exc or BleakError("disconnected"))
+        self._poison(exc)
+
+    def _poison(self, exc: Exception | None) -> None:
+        """Close the channel and notify the disconnect callback once."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._on_disconnect is not None:
+            self._on_disconnect(exc)
+
+    async def _confirm(self) -> None:
+        await self._send(bytes([ATT_HANDLE_VALUE_CFM]))
+
+    def _on_confirm_done(self, task: asyncio.Task[None]) -> None:
+        self._background_tasks.discard(task)
+        if not task.cancelled() and (exc := task.exception()) is not None:
+            # A CFM send only fails when the transport is already failing, in
+            # which case connection_lost fires and poisons the channel; this is
+            # the supplementary detail, so debug is deliberate, not an oversight.
+            _LOGGER.debug("Failed to confirm ATT indication: %s", exc)
+
+    def _dispatch_notify(self, value_handle: int, value: bytes) -> None:
+        if (cb := self._notify_handlers.get(value_handle)) is None:
+            _LOGGER.debug(
+                "Notification for unhandled value handle 0x%04x dropped", value_handle
+            )
+            return
+        # Isolate the subscriber: data_received runs in the transport read loop,
+        # so a raising callback must not tear down inbound demux for the whole
+        # connection (and for indications it would also skip the confirmation).
+        try:
+            cb(bytearray(value))
+        except Exception:
+            _LOGGER.exception(
+                "Error in notification handler for value handle 0x%04x", value_handle
+            )
+
+    # -- transactions ------------------------------------------------------
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            msg = "ATT channel closed"
+            raise BleakError(msg)
+
+    async def _request(self, payload: bytes, expected_opcode: int) -> bytes:
+        self._raise_if_closed()
+        async with self._txn_lock:
+            fut: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
+            self._pending = fut
+            try:
+                await self._send(payload)
+                data = await asyncio.wait_for(fut, ATT_TIMEOUT)
+            except TimeoutError as exc:
+                # The timed-out request may still be in flight; ATT has no
+                # transaction id, so a late response could be matched to the
+                # next request. Poison the channel so nothing else is sent.
+                self._poison(exc)
+                msg = "ATT request timed out"
+                raise BleakError(msg) from exc
+            finally:
+                self._pending = None
+        opcode = data[0]
+        if opcode == ATT_ERROR_RSP:
+            if len(data) < 5:
+                msg = "truncated ATT error response"
+                raise BleakError(msg)
+            req_op, handle, err = _ERROR_RSP.unpack_from(data, 1)
+            raise ATTError(req_op, handle, err)
+        if opcode != expected_opcode:
+            msg = (
+                f"unexpected ATT opcode 0x{opcode:02x} (wanted 0x{expected_opcode:02x})"
+            )
+            raise BleakError(msg)
+        return data
+
+    async def exchange_mtu(self, mtu: int = PREFERRED_MTU) -> int:
+        """Negotiate the ATT MTU and return the agreed value."""
+        payload = bytes([ATT_EXCHANGE_MTU_REQ]) + mtu.to_bytes(2, "little")
+        try:
+            data = await self._request(payload, ATT_EXCHANGE_MTU_RSP)
+        except ATTError as err:
+            # Only a peer that does not implement MTU exchange is a benign
+            # fallback to the default MTU; surface any other error (e.g. an
+            # encryption/authentication rejection) rather than reporting it as a
+            # successful negotiation.
+            if err.error_code != ATT_ERR_REQUEST_NOT_SUPPORTED:
+                raise
+            _LOGGER.debug(
+                "Peer does not support MTU exchange; keeping default MTU %d",
+                self._mtu,
+            )
+            return self._mtu
+        if len(data) < 3:
+            msg = "truncated ATT MTU response"
+            raise BleakError(msg)
+        server_mtu = int.from_bytes(data[1:3], "little")
+        self._mtu = max(DEFAULT_MTU, min(mtu, server_mtu))
+        return self._mtu
+
+    # -- reads -------------------------------------------------------------
+    async def read(self, handle: int) -> bytes:
+        """Read an attribute value, continuing with Read Blob if it is long."""
+        data = await self._request(
+            bytes([ATT_READ_REQ]) + handle.to_bytes(2, "little"), ATT_READ_RSP
+        )
+        value = bytearray(data[1:])
+        # A chunk that exactly fills the PDU may be truncated, so continue with
+        # Read Blob; a short chunk means we have the whole value. Keying on the
+        # last chunk (not the running total) avoids an extra round-trip on a
+        # value whose length happens to be a multiple of the chunk size.
+        while len(value) >= self._mtu - 1:
+            # The Read Blob offset is a 16-bit field, so a value cannot extend
+            # past 0xFFFF; stop with a clear error rather than letting a peer
+            # that always returns a full chunk overflow offset.to_bytes(2).
+            if len(value) > 0xFFFF:
+                msg = "ATT value exceeds the 16-bit Read Blob offset range"
+                raise BleakError(msg)
+            blob = await self._read_blob(handle, len(value))
+            value += blob
+            if len(blob) < self._mtu - 1:
+                break
+        return bytes(value)
+
+    async def _read_blob(self, handle: int, offset: int) -> bytes:
+        payload = (
+            bytes([ATT_READ_BLOB_REQ])
+            + handle.to_bytes(2, "little")
+            + offset.to_bytes(2, "little")
+        )
+        try:
+            data = await self._request(payload, ATT_READ_BLOB_RSP)
+        except ATTError as err:
+            if err.error_code in (ATT_ERR_INVALID_OFFSET, ATT_ERR_ATTRIBUTE_NOT_LONG):
+                # Normal end of a long read (a blob read at offset == length
+                # returns INVALID_OFFSET); logged for field observability.
+                _LOGGER.debug(
+                    "Read Blob for handle 0x%04x ended at offset %d: error 0x%02x",
+                    handle,
+                    offset,
+                    err.error_code,
+                )
+                return b""
+            raise
+        return data[1:]
+
+    # -- writes ------------------------------------------------------------
+    def _check_write_length(self, value: bytes) -> None:
+        # An ATT write carries at most MTU - 3 bytes of value; longer values
+        # need the Prepare/Execute Write (long write) procedure, which this
+        # codec does not implement, so reject them explicitly rather than emit
+        # an over-MTU PDU the transport or peer will opaquely fail.
+        if len(value) > self._mtu - 3:
+            msg = (
+                f"value too long for an ATT write: {len(value)} > {self._mtu - 3} "
+                "(long writes are not supported)"
+            )
+            raise BleakError(msg)
+
+    async def write(self, handle: int, value: bytes) -> None:
+        """
+        Write an attribute value with a response (Write Request).
+
+        Values longer than ``mtu - 3`` are rejected; long writes are not
+        supported.
+        """
+        self._check_write_length(value)
+        payload = bytes([ATT_WRITE_REQ]) + handle.to_bytes(2, "little") + bytes(value)
+        await self._request(payload, ATT_WRITE_RSP)
+
+    async def write_command(self, handle: int, value: bytes) -> None:
+        """
+        Write an attribute value without a response (Write Command).
+
+        Values longer than ``mtu - 3`` are rejected; long writes are not
+        supported.
+        """
+        self._raise_if_closed()
+        self._check_write_length(value)
+        payload = bytes([ATT_WRITE_CMD]) + handle.to_bytes(2, "little") + bytes(value)
+        await self._send(payload)
+
+    # -- discovery primitives ---------------------------------------------
+    async def read_by_group_type(
+        self, start: int, end: int, group_uuid: bytes
+    ) -> list[tuple[int, int, bytes]]:
+        """Enumerate grouping attributes (e.g. primary services) in a range."""
+        results: list[tuple[int, int, bytes]] = []
+        while start <= end:
+            payload = (
+                bytes([ATT_READ_BY_GROUP_TYPE_REQ])
+                + start.to_bytes(2, "little")
+                + end.to_bytes(2, "little")
+                + group_uuid
+            )
+            try:
+                data = await self._request(payload, ATT_READ_BY_GROUP_TYPE_RSP)
+            except ATTError as err:
+                if err.error_code == ATT_ERR_ATTRIBUTE_NOT_FOUND:
+                    break
+                raise
+            # Each entry is handle(2) + end_handle(2) + value; reject an
+            # untrusted peer's malformed stride before it crashes range().
+            if len(data) < 2 or (length := data[1]) < 4:
+                msg = "malformed read-by-group-type response"
+                raise BleakError(msg)
+            entries = data[2:]
+            # A real server returns ATTRIBUTE_NOT_FOUND when nothing remains, so
+            # a response carrying no full entry is malformed; reject it (like the
+            # bad-stride case) rather than re-requesting and amplifying or
+            # silently returning a partial discovery tree. A body that is not a
+            # whole multiple of the stride is malformed for the same reason; a
+            # trailing partial entry is rejected rather than silently dropped.
+            if len(entries) < length or len(entries) % length:
+                msg = "malformed read-by-group-type response (truncated entries)"
+                raise BleakError(msg)
+            last = start
+            for i in range(0, len(entries), length):
+                entry = entries[i : i + length]
+                handle = int.from_bytes(entry[0:2], "little")
+                end_handle = int.from_bytes(entry[2:4], "little")
+                results.append((handle, end_handle, bytes(entry[4:length])))
+                last = end_handle
+            # last >= start here, so the cursor strictly advances each round and
+            # the loop is bounded by the handle space. An entry whose handle is
+            # exactly the cursor is legitimate for sparse consecutive attributes
+            # (the first match can sit at start), so we accept the bounded
+            # worst case of one entry per round rather than truncate valid
+            # discovery; the entry-less guard above already stops zero progress.
+            if last >= 0xFFFF or last < start:
+                break
+            start = last + 1
+        return results
+
+    async def read_by_type(
+        self, start: int, end: int, type_uuid: bytes
+    ) -> list[tuple[int, bytes]]:
+        """Enumerate attributes of a given type (e.g. characteristics)."""
+        results: list[tuple[int, bytes]] = []
+        while start <= end:
+            payload = (
+                bytes([ATT_READ_BY_TYPE_REQ])
+                + start.to_bytes(2, "little")
+                + end.to_bytes(2, "little")
+                + type_uuid
+            )
+            try:
+                data = await self._request(payload, ATT_READ_BY_TYPE_RSP)
+            except ATTError as err:
+                if err.error_code == ATT_ERR_ATTRIBUTE_NOT_FOUND:
+                    break
+                raise
+            # Each entry is handle(2) + value; reject an untrusted peer's
+            # malformed stride before it crashes range().
+            if len(data) < 2 or (length := data[1]) < 2:
+                msg = "malformed read-by-type response"
+                raise BleakError(msg)
+            entries = data[2:]
+            # An entry-less response is malformed (a real server sends
+            # ATTRIBUTE_NOT_FOUND); a body that is not a whole multiple of the
+            # stride is malformed too. Reject both rather than re-requesting or
+            # silently dropping a trailing partial entry.
+            if len(entries) < length or len(entries) % length:
+                msg = "malformed read-by-type response (truncated entries)"
+                raise BleakError(msg)
+            last = start
+            for i in range(0, len(entries), length):
+                entry = entries[i : i + length]
+                handle = int.from_bytes(entry[0:2], "little")
+                results.append((handle, bytes(entry[2:length])))
+                last = handle
+            if last >= 0xFFFF or last < start:
+                break
+            start = last + 1
+        return results
+
+    async def find_information(self, start: int, end: int) -> list[tuple[int, str]]:
+        """Enumerate attribute handles and UUIDs (used for descriptors)."""
+        results: list[tuple[int, str]] = []
+        while start <= end:
+            payload = (
+                bytes([ATT_FIND_INFO_REQ])
+                + start.to_bytes(2, "little")
+                + end.to_bytes(2, "little")
+            )
+            try:
+                data = await self._request(payload, ATT_FIND_INFO_RSP)
+            except ATTError as err:
+                if err.error_code == ATT_ERR_ATTRIBUTE_NOT_FOUND:
+                    break
+                raise
+            # The format byte is 0x01 (16-bit) or 0x02 (128-bit); anything else
+            # is a malformed PDU and must not be mis-parsed as a 128-bit UUID.
+            fmt = data[1] if len(data) >= 2 else 0
+            if fmt == 0x01:
+                uuid_len = 2
+            elif fmt == 0x02:
+                uuid_len = 16
+            else:
+                msg = f"invalid find-information format 0x{fmt:02x}"
+                raise BleakError(msg)
+            entry_len = 2 + uuid_len
+            entries = data[2:]
+            # An entry-less response is malformed (a real server sends
+            # ATTRIBUTE_NOT_FOUND); a body that is not a whole multiple of the
+            # entry size is malformed too. Reject both rather than re-requesting
+            # or silently dropping a trailing partial entry.
+            if len(entries) < entry_len or len(entries) % entry_len:
+                msg = "malformed find-information response (truncated entries)"
+                raise BleakError(msg)
+            last = start
+            for i in range(0, len(entries), entry_len):
+                entry = entries[i : i + entry_len]
+                handle = int.from_bytes(entry[0:2], "little")
+                results.append((handle, uuid_from_bytes(entry[2:entry_len])))
+                last = handle
+            if last >= 0xFFFF or last < start:
+                break
+            start = last + 1
+        return results
+
+    # -- notifications -----------------------------------------------------
+    def set_notify_handler(
+        self, value_handle: int, callback: Callable[[bytearray], None]
+    ) -> None:
+        """Route notifications/indications for a value handle to ``callback``."""
+        self._notify_handlers[value_handle] = callback
+
+    def remove_notify_handler(self, value_handle: int) -> None:
+        """Stop routing notifications for a value handle."""
+        self._notify_handlers.pop(value_handle, None)
+
+    # -- high-level GATT discovery ----------------------------------------
+    async def discover(self) -> list[GattService]:
+        """Discover the full primary-service / characteristic / descriptor tree."""
+        services = [
+            GattService(handle, end_handle, uuid_from_bytes(value))
+            for handle, end_handle, value in await self.read_by_group_type(
+                0x0001, 0xFFFF, GATT_PRIMARY_SERVICE
+            )
+        ]
+        for svc in services:
+            chars: list[GattCharacteristic] = []
+            for decl_handle, value in await self.read_by_type(
+                svc.handle, svc.end_handle, GATT_CHARACTERISTIC
+            ):
+                # A declaration value is properties(1) + value_handle(2) +
+                # uuid(2|16); reject a malformed peer's short declaration rather
+                # than indexing past the end of it.
+                if len(value) < 5:
+                    msg = "malformed characteristic declaration"
+                    raise BleakError(msg)
+                chars.append(
+                    GattCharacteristic(
+                        decl_handle,
+                        int.from_bytes(value[1:3], "little"),
+                        uuid_from_bytes(value[3:]),
+                        value[0],
+                    )
+                )
+            # Each characteristic ends just before the next one (or the service
+            # end); descriptors live between the value handle and that end.
+            for i, char in enumerate(chars):
+                char.end_handle = (
+                    chars[i + 1].handle - 1 if i + 1 < len(chars) else svc.end_handle
+                )
+                if char.end_handle > char.value_handle:
+                    char.descriptors = [
+                        GattDescriptor(handle, uuid)
+                        for handle, uuid in await self.find_information(
+                            char.value_handle + 1, char.end_handle
+                        )
+                    ]
+            svc.characteristics = chars
+        return services

--- a/tests/channels/test_att.py
+++ b/tests/channels/test_att.py
@@ -1,0 +1,736 @@
+"""Tests for the ATT/GATT codec."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bleak import BleakError
+
+from habluetooth.channels.att import (
+    ATT_ERR_ATTRIBUTE_NOT_FOUND,
+    ATT_ERR_INSUFFICIENT_AUTHENTICATION,
+    ATT_ERR_INVALID_OFFSET,
+    ATT_ERR_READ_NOT_PERMITTED,
+    ATT_ERR_REQUEST_NOT_SUPPORTED,
+    ATT_ERROR_RSP,
+    ATT_EXCHANGE_MTU_RSP,
+    ATT_FIND_INFO_REQ,
+    ATT_FIND_INFO_RSP,
+    ATT_HANDLE_VALUE_CFM,
+    ATT_HANDLE_VALUE_IND,
+    ATT_HANDLE_VALUE_NTF,
+    ATT_READ_BLOB_RSP,
+    ATT_READ_BY_GROUP_TYPE_REQ,
+    ATT_READ_BY_GROUP_TYPE_RSP,
+    ATT_READ_BY_TYPE_REQ,
+    ATT_READ_BY_TYPE_RSP,
+    ATT_READ_RSP,
+    ATT_WRITE_CMD,
+    ATT_WRITE_RSP,
+    CCCD_UUID,
+    DEFAULT_MTU,
+    ATTClient,
+    ATTError,
+    properties_to_strings,
+    uuid_from_bytes,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakePeer:
+    """A fake ATT peer that captures sent PDUs and auto-replies."""
+
+    def __init__(
+        self, responder: Callable[[bytes], bytes | None] | None = None
+    ) -> None:
+        """Create the bound ATTClient and optionally script replies."""
+        self.sent: list[bytes] = []
+        self.responder = responder
+        self.client = ATTClient(self.send)
+
+    async def send(self, data: bytes) -> None:
+        """Capture an outbound PDU and feed back the scripted response."""
+        self.sent.append(bytes(data))
+        if self.responder is not None:
+            response = self.responder(bytes(data))
+            if response is not None:
+                self.client.data_received(response)
+
+
+def _att_error(req_opcode: int, handle: int, code: int) -> bytes:
+    return (
+        bytes([ATT_ERROR_RSP, req_opcode])
+        + handle.to_bytes(2, "little")
+        + bytes([code])
+    )
+
+
+# -- pure helpers ---------------------------------------------------------
+async def test_uuid_from_bytes_16_bit() -> None:
+    """A 16-bit UUID expands against the Bluetooth base UUID."""
+    assert uuid_from_bytes(b"\x02\x29") == CCCD_UUID
+    assert uuid_from_bytes(b"\x0d\x18") == "0000180d-0000-1000-8000-00805f9b34fb"
+
+
+async def test_uuid_from_bytes_128_bit() -> None:
+    """A 128-bit UUID is byte-reversed and formatted."""
+    raw = bytes.fromhex("fb349b5f8000008000100000661a0a05")
+    assert uuid_from_bytes(raw) == "050a1a66-0000-1000-8000-00805f9b34fb"
+
+
+async def test_properties_to_strings() -> None:
+    """The property bitmask expands to bleak property names."""
+    # 0x12 sets the read and notify bits
+    assert properties_to_strings(0x12) == ["read", "notify"]
+    assert properties_to_strings(0x00) == []
+
+
+# -- MTU ------------------------------------------------------------------
+async def test_exchange_mtu_negotiates_minimum() -> None:
+    """The negotiated MTU is the minimum of ours and the server's."""
+    peer = FakePeer(
+        lambda _req: bytes([ATT_EXCHANGE_MTU_RSP]) + (185).to_bytes(2, "little")
+    )
+    assert await peer.client.exchange_mtu(247) == 185
+    assert peer.client.mtu == 185
+
+
+async def test_exchange_mtu_unsupported_keeps_default() -> None:
+    """A peer that does not support MTU exchange falls back to the default."""
+    peer = FakePeer(lambda req: _att_error(req[0], 0, ATT_ERR_REQUEST_NOT_SUPPORTED))
+    assert await peer.client.exchange_mtu(247) == DEFAULT_MTU
+    assert peer.client.mtu == DEFAULT_MTU
+
+
+async def test_exchange_mtu_propagates_other_errors() -> None:
+    """An MTU rejection other than 'not supported' is surfaced, not swallowed."""
+    peer = FakePeer(
+        lambda req: _att_error(req[0], 0, ATT_ERR_INSUFFICIENT_AUTHENTICATION)
+    )
+    with pytest.raises(ATTError) as exc_info:
+        await peer.client.exchange_mtu(247)
+    assert exc_info.value.error_code == ATT_ERR_INSUFFICIENT_AUTHENTICATION
+
+
+# -- reads ----------------------------------------------------------------
+async def test_read_short_value() -> None:
+    """A short value is returned without a Read Blob follow-up."""
+    peer = FakePeer(lambda _req: bytes([ATT_READ_RSP]) + b"\x01\x02\x03")
+    assert await peer.client.read(0x0010) == b"\x01\x02\x03"
+
+
+async def test_read_long_value_continues_with_blob() -> None:
+    """A value is read across multiple full Read Blob chunks until a short one."""
+    # With the default MTU (23) a full chunk is mtu - 1 = 22 bytes; a chunk
+    # shorter than that ends the read without an extra empty round-trip.
+    first = bytes(range(22))  # full -> blob read
+    blob_full = bytes(range(100, 122))  # full (22) -> continue
+    blob_short = b"\xaa\xbb\xcc\xdd"  # short (4) -> stop
+
+    def responder(req: bytes) -> bytes:
+        if req[0] == 0x0A:  # ATT_READ_REQ
+            return bytes([ATT_READ_RSP]) + first
+        offset = int.from_bytes(req[3:5], "little")
+        if offset == 22:
+            return bytes([ATT_READ_BLOB_RSP]) + blob_full
+        return bytes([ATT_READ_BLOB_RSP]) + blob_short
+
+    peer = FakePeer(responder)
+    assert await peer.client.read(0x0010) == first + blob_full + blob_short
+    # READ + two READ_BLOB; the short final chunk avoids a trailing empty read.
+    assert len(peer.sent) == 3
+
+
+async def test_read_blob_invalid_offset_stops() -> None:
+    """An invalid-offset error during a long read ends the read cleanly."""
+    full = bytes(range(22))
+
+    def responder(req: bytes) -> bytes:
+        if req[0] == 0x0A:  # ATT_READ_REQ
+            return bytes([ATT_READ_RSP]) + full
+        return _att_error(req[0], 0x10, ATT_ERR_INVALID_OFFSET)
+
+    peer = FakePeer(responder)
+    assert await peer.client.read(0x0010) == full
+
+
+# -- writes ---------------------------------------------------------------
+async def test_write_with_response() -> None:
+    """Write Request waits for the Write Response."""
+    peer = FakePeer(lambda _req: bytes([ATT_WRITE_RSP]))
+    await peer.client.write(0x0011, b"\x01\x00")
+    assert peer.sent[0][0] == 0x12  # ATT_WRITE_REQ
+    assert peer.sent[0][1:3] == (0x0011).to_bytes(2, "little")
+    assert peer.sent[0][3:] == b"\x01\x00"
+
+
+async def test_write_command_has_no_response() -> None:
+    """Write Command is fire-and-forget."""
+    peer = FakePeer()
+    await peer.client.write_command(0x0011, b"\x09")
+    assert peer.sent == [bytes([ATT_WRITE_CMD]) + b"\x11\x00\x09"]
+
+
+# -- error handling -------------------------------------------------------
+async def test_error_response_raises_att_error() -> None:
+    """An ATT error response raises ATTError with the details."""
+    peer = FakePeer(lambda req: _att_error(req[0], 0x0010, ATT_ERR_READ_NOT_PERMITTED))
+    with pytest.raises(ATTError) as exc_info:
+        await peer.client.read(0x0010)
+    assert exc_info.value.error_code == ATT_ERR_READ_NOT_PERMITTED
+    assert exc_info.value.handle == 0x0010
+
+
+async def test_unexpected_opcode_raises() -> None:
+    """A response with the wrong opcode raises a BleakError."""
+    peer = FakePeer(lambda _req: bytes([ATT_WRITE_RSP]))  # wrong for a read
+    with pytest.raises(BleakError, match="unexpected ATT opcode"):
+        await peer.client.read(0x0010)
+
+
+# -- notifications --------------------------------------------------------
+async def test_notification_dispatched_to_handler() -> None:
+    """A handle value notification reaches the registered handler."""
+    peer = FakePeer()
+    received: list[bytearray] = []
+    peer.client.set_notify_handler(0x0003, received.append)
+    peer.client.data_received(
+        bytes([ATT_HANDLE_VALUE_NTF]) + (0x0003).to_bytes(2, "little") + b"\x10\x20"
+    )
+    assert received == [bytearray(b"\x10\x20")]
+
+
+async def test_indication_dispatched_and_confirmed() -> None:
+    """An indication reaches the handler and is acknowledged."""
+    peer = FakePeer()
+    received: list[bytearray] = []
+    peer.client.set_notify_handler(0x0005, received.append)
+    peer.client.data_received(
+        bytes([ATT_HANDLE_VALUE_IND]) + (0x0005).to_bytes(2, "little") + b"\x99"
+    )
+    await asyncio.sleep(0)  # let the fire-and-forget confirm run
+    assert received == [bytearray(b"\x99")]
+    assert peer.sent == [bytes([ATT_HANDLE_VALUE_CFM])]
+
+
+async def test_remove_notify_handler() -> None:
+    """A removed handler no longer receives notifications."""
+    peer = FakePeer()
+    received: list[bytearray] = []
+    peer.client.set_notify_handler(0x0003, received.append)
+    peer.client.remove_notify_handler(0x0003)
+    peer.client.data_received(
+        bytes([ATT_HANDLE_VALUE_NTF]) + (0x0003).to_bytes(2, "little") + b"\x10"
+    )
+    assert received == []
+
+
+async def test_data_received_empty_is_ignored() -> None:
+    """An empty inbound PDU is ignored."""
+    peer = FakePeer()
+    peer.client.data_received(b"")  # must not raise
+
+
+# -- connection loss ------------------------------------------------------
+async def test_connection_lost_fails_pending_and_notifies() -> None:
+    """Connection loss fails the in-flight request and calls the callback."""
+    disconnects: list[Exception | None] = []
+    peer = FakePeer()  # no responder: the request will hang awaiting a reply
+    client = ATTClient(peer.send, on_disconnect=disconnects.append)
+
+    task = asyncio.create_task(client.read(0x0010))
+    await asyncio.sleep(0)  # let the request go out and await the response
+    err = OSError("link lost")
+    client.connection_lost(err)
+    with pytest.raises(OSError, match="link lost"):
+        await task
+    assert disconnects == [err]
+
+
+# -- discovery primitives -------------------------------------------------
+async def test_read_by_group_type_parses_entries() -> None:
+    """Primary-service discovery parses (handle, end, uuid) entries."""
+
+    def responder(req: bytes) -> bytes:
+        start = int.from_bytes(req[1:3], "little")
+        if start <= 0x0001:
+            return bytes([ATT_READ_BY_GROUP_TYPE_RSP, 6]) + b"\x01\x00\x05\x00\x0d\x18"
+        return _att_error(req[0], start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+
+    peer = FakePeer(responder)
+    # End the search at 0x0005 so the loop terminates on the range, not an error.
+    results = await peer.client.read_by_group_type(0x0001, 0x0005, b"\x00\x28")
+    assert results == [(0x0001, 0x0005, b"\x0d\x18")]
+    assert len(peer.sent) == 1
+
+
+async def test_read_by_type_parses_entries() -> None:
+    """Characteristic discovery parses (handle, value) entries."""
+
+    def responder(req: bytes) -> bytes:
+        start = int.from_bytes(req[1:3], "little")
+        if start <= 0x0002:
+            return bytes([ATT_READ_BY_TYPE_RSP, 7]) + b"\x02\x00\x12\x03\x00\x37\x2a"
+        return _att_error(req[0], start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+
+    peer = FakePeer(responder)
+    # End at the entry handle so the loop terminates on the range.
+    results = await peer.client.read_by_type(0x0001, 0x0002, b"\x03\x28")
+    assert results == [(0x0002, b"\x12\x03\x00\x37\x2a")]
+    assert len(peer.sent) == 1
+
+
+async def test_find_information_parses_16_bit() -> None:
+    """Descriptor discovery parses 16-bit UUID entries."""
+
+    def responder(req: bytes) -> bytes:
+        start = int.from_bytes(req[1:3], "little")
+        if start <= 0x0004:
+            # format 0x01 (16-bit): handle 0x0004 -> CCCD
+            return bytes([ATT_FIND_INFO_RSP, 0x01]) + b"\x04\x00\x02\x29"
+        return _att_error(req[0], start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+
+    peer = FakePeer(responder)
+    results = await peer.client.find_information(0x0004, 0x0005)
+    assert results == [(0x0004, CCCD_UUID)]
+
+
+# -- full discovery -------------------------------------------------------
+async def test_discover_builds_service_tree() -> None:
+    """
+    discover() walks services, characteristics and descriptors.
+
+    The service has two characteristics: the first owns a CCCD descriptor (so
+    descriptors are fetched) and the second's value handle is the service's last
+    handle (so it has no descriptor range to scan).
+    """
+
+    def responder(req: bytes) -> bytes:
+        opcode = req[0]
+        start = int.from_bytes(req[1:3], "little")
+        if opcode == ATT_READ_BY_GROUP_TYPE_REQ:
+            if start <= 0x0001:
+                # service 0x0001-0x0006, uuid 0x180D
+                return (
+                    bytes([ATT_READ_BY_GROUP_TYPE_RSP, 6]) + b"\x01\x00\x06\x00\x0d\x18"
+                )
+            return _att_error(opcode, start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+        if opcode == ATT_READ_BY_TYPE_REQ:
+            if start <= 0x0002:
+                # two characteristics in one response (each 7 bytes):
+                # A: decl 0x0002, props 0x12, value 0x0003, uuid 0x2A37
+                # B: decl 0x0005, props 0x02, value 0x0006, uuid 0x2A38
+                char_a = b"\x02\x00\x12\x03\x00\x37\x2a"
+                char_b = b"\x05\x00\x02\x06\x00\x38\x2a"
+                return bytes([ATT_READ_BY_TYPE_RSP, 7]) + char_a + char_b
+            return _att_error(opcode, start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+        if opcode == ATT_FIND_INFO_REQ:
+            # Only characteristic A (value 0x0003, end 0x0004) has a descriptor.
+            if start <= 0x0004:
+                return bytes([ATT_FIND_INFO_RSP, 0x01]) + b"\x04\x00\x02\x29"
+            return _att_error(opcode, start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+        msg = f"unexpected opcode {opcode:#x}"
+        raise AssertionError(msg)
+
+    peer = FakePeer(responder)
+    services = await peer.client.discover()
+
+    assert len(services) == 1
+    svc = services[0]
+    assert svc.handle == 0x0001
+    assert svc.end_handle == 0x0006
+    assert svc.uuid == "0000180d-0000-1000-8000-00805f9b34fb"
+
+    assert len(svc.characteristics) == 2
+    char_a, char_b = svc.characteristics
+
+    assert char_a.handle == 0x0002
+    assert char_a.value_handle == 0x0003
+    assert char_a.uuid == "00002a37-0000-1000-8000-00805f9b34fb"
+    assert char_a.properties == 0x12
+    assert char_a.end_handle == 0x0004  # one before the next declaration
+    assert properties_to_strings(char_a.properties) == ["read", "notify"]
+    assert len(char_a.descriptors) == 1
+    assert char_a.descriptors[0].handle == 0x0004
+    assert char_a.descriptors[0].uuid == CCCD_UUID
+
+    # The last characteristic's value handle is the service end, so no
+    # descriptor range remains to scan.
+    assert char_b.handle == 0x0005
+    assert char_b.value_handle == 0x0006
+    assert char_b.uuid == "00002a38-0000-1000-8000-00805f9b34fb"
+    assert char_b.end_handle == 0x0006
+    assert char_b.descriptors == []
+
+
+async def test_read_blob_propagates_other_errors() -> None:
+    """A non-offset error during a long read propagates."""
+    full = bytes(range(22))
+
+    def responder(req: bytes) -> bytes:
+        if req[0] == 0x0A:  # ATT_READ_REQ
+            return bytes([ATT_READ_RSP]) + full
+        return _att_error(req[0], 0x10, ATT_ERR_READ_NOT_PERMITTED)
+
+    peer = FakePeer(responder)
+    with pytest.raises(ATTError):
+        await peer.client.read(0x0010)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda c: c.read_by_group_type(0x0001, 0xFFFF, b"\x00\x28"),
+        lambda c: c.read_by_type(0x0001, 0xFFFF, b"\x03\x28"),
+        lambda c: c.find_information(0x0001, 0xFFFF),
+    ],
+)
+async def test_discovery_propagates_non_not_found_errors(
+    call: Callable[[ATTClient], Awaitable[object]],
+) -> None:
+    """A non-ATTR_NOT_FOUND error aborts discovery instead of ending it."""
+    peer = FakePeer(lambda req: _att_error(req[0], 0x0001, ATT_ERR_READ_NOT_PERMITTED))
+    with pytest.raises(ATTError):
+        await call(peer.client)
+
+
+async def test_read_by_group_type_stops_at_max_handle() -> None:
+    """An end handle of 0xFFFF ends the loop without another request."""
+    peer = FakePeer(
+        lambda _req: (
+            bytes([ATT_READ_BY_GROUP_TYPE_RSP, 6]) + b"\x01\x00\xff\xff\x0d\x18"
+        )
+    )
+    results = await peer.client.read_by_group_type(0x0001, 0xFFFF, b"\x00\x28")
+    assert results == [(0x0001, 0xFFFF, b"\x0d\x18")]
+    assert len(peer.sent) == 1
+
+
+async def test_read_by_type_stops_at_max_handle() -> None:
+    """A handle of 0xFFFF ends the loop without another request."""
+    peer = FakePeer(
+        lambda _req: bytes([ATT_READ_BY_TYPE_RSP, 7]) + b"\xff\xff\x12\x03\x00\x37\x2a"
+    )
+    results = await peer.client.read_by_type(0x0001, 0xFFFF, b"\x03\x28")
+    assert results[0][0] == 0xFFFF
+    assert len(peer.sent) == 1
+
+
+async def test_find_information_128_bit_and_max_handle() -> None:
+    """find_information parses 128-bit UUIDs and stops at the max handle."""
+    uuid128 = bytes.fromhex("fb349b5f8000008000100000661a0a05")
+    peer = FakePeer(
+        lambda _req: bytes([ATT_FIND_INFO_RSP, 0x02]) + b"\xff\xff" + uuid128
+    )
+    results = await peer.client.find_information(0x0001, 0xFFFF)
+    assert results == [(0xFFFF, "050a1a66-0000-1000-8000-00805f9b34fb")]
+    assert len(peer.sent) == 1
+
+
+async def test_no_pending_request_paths() -> None:
+    """A stray response and a bare connection loss are handled safely."""
+    peer = FakePeer()
+    # A response with no in-flight request is ignored.
+    peer.client.data_received(bytes([ATT_WRITE_RSP]))
+    # Connection loss with no pending request and no callback does not raise.
+    peer.client.connection_lost(None)
+
+
+# -- wire robustness on malformed input -----------------------------------
+async def test_uuid_from_bytes_rejects_invalid_length() -> None:
+    """A UUID that is neither 2 nor 16 bytes is rejected, not mis-formatted."""
+    with pytest.raises(BleakError, match="invalid ATT UUID length"):
+        uuid_from_bytes(b"\x01\x02\x03\x04")
+
+
+async def test_read_by_group_type_rejects_malformed_length() -> None:
+    """A zero/short length byte raises instead of crashing range()."""
+    peer = FakePeer(lambda _req: bytes([ATT_READ_BY_GROUP_TYPE_RSP, 0]))
+    with pytest.raises(BleakError, match="malformed read-by-group-type"):
+        await peer.client.read_by_group_type(0x0001, 0xFFFF, b"\x00\x28")
+
+
+async def test_read_by_type_rejects_malformed_length() -> None:
+    """A zero/short length byte raises instead of crashing range()."""
+    peer = FakePeer(lambda _req: bytes([ATT_READ_BY_TYPE_RSP, 0]))
+    with pytest.raises(BleakError, match="malformed read-by-type"):
+        await peer.client.read_by_type(0x0001, 0xFFFF, b"\x03\x28")
+
+
+async def test_find_information_rejects_invalid_format() -> None:
+    """A format byte other than 0x01/0x02 raises rather than mis-parsing."""
+    peer = FakePeer(lambda _req: bytes([ATT_FIND_INFO_RSP, 0x03]) + b"\x04\x00")
+    with pytest.raises(BleakError, match="invalid find-information format"):
+        await peer.client.find_information(0x0004, 0xFFFF)
+
+
+async def test_indication_confirm_failure_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed indication confirmation is logged, not raised as a task error."""
+
+    async def send(data: bytes) -> None:
+        if data == bytes([ATT_HANDLE_VALUE_CFM]):
+            msg = "send failed"
+            raise OSError(msg)
+
+    client = ATTClient(send)
+    client.set_notify_handler(0x0005, lambda _v: None)
+    with caplog.at_level("DEBUG", logger="habluetooth.channels.att"):
+        client.data_received(
+            bytes([ATT_HANDLE_VALUE_IND]) + (0x0005).to_bytes(2, "little") + b"\x99"
+        )
+        # Let the confirm task run and its done-callback fire.
+        for _ in range(3):
+            await asyncio.sleep(0)
+    assert "Failed to confirm ATT indication" in caplog.text
+
+
+async def test_request_rejects_truncated_error_response() -> None:
+    """A truncated ATT error response raises BleakError, not struct.error."""
+    # ATT_ERROR_RSP needs 5 bytes; return only 2.
+    peer = FakePeer(lambda _req: bytes([ATT_ERROR_RSP, 0x0A]))
+    with pytest.raises(BleakError, match="truncated ATT error response"):
+        await peer.client.read(0x0010)
+
+
+async def test_discover_rejects_malformed_characteristic_declaration() -> None:
+    """A characteristic declaration shorter than 5 bytes raises BleakError."""
+
+    def responder(req: bytes) -> bytes:
+        opcode = req[0]
+        start = int.from_bytes(req[1:3], "little")
+        if opcode == ATT_READ_BY_GROUP_TYPE_REQ:
+            if start <= 0x0001:
+                return (
+                    bytes([ATT_READ_BY_GROUP_TYPE_RSP, 6]) + b"\x01\x00\x05\x00\x0d\x18"
+                )
+            return _att_error(opcode, start, ATT_ERR_ATTRIBUTE_NOT_FOUND)
+        if opcode == ATT_READ_BY_TYPE_REQ:
+            # length 2 survives read_by_type's guard but leaves an empty value.
+            return bytes([ATT_READ_BY_TYPE_RSP, 2]) + b"\x02\x00"
+        msg = f"unexpected opcode {opcode:#x}"
+        raise AssertionError(msg)
+
+    peer = FakePeer(responder)
+    with pytest.raises(BleakError, match="malformed characteristic declaration"):
+        await peer.client.discover()
+
+
+async def test_request_timeout_raises_bleak_error() -> None:
+    """A request with no reply times out as a BleakError, not TimeoutError."""
+    peer = FakePeer()  # no responder: the future never resolves
+    with (
+        patch("habluetooth.channels.att.ATT_TIMEOUT", 0.01),
+        pytest.raises(BleakError, match="ATT request timed out"),
+    ):
+        await peer.client.read(0x0010)
+
+
+async def test_notification_handler_exception_is_isolated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising notification handler is logged, not propagated to data_received."""
+
+    def bad_handler(_value: bytearray) -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    peer = FakePeer()
+    peer.client.set_notify_handler(0x0003, bad_handler)
+    with caplog.at_level("ERROR", logger="habluetooth.channels.att"):
+        # Must not raise out of data_received.
+        peer.client.data_received(
+            bytes([ATT_HANDLE_VALUE_NTF]) + (0x0003).to_bytes(2, "little") + b"\x10"
+        )
+    assert "Error in notification handler" in caplog.text
+
+
+async def test_indication_handler_exception_still_confirms() -> None:
+    """A raising indication handler does not block the confirmation."""
+
+    def bad_handler(_value: bytearray) -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    peer = FakePeer()
+    peer.client.set_notify_handler(0x0005, bad_handler)
+    peer.client.data_received(
+        bytes([ATT_HANDLE_VALUE_IND]) + (0x0005).to_bytes(2, "little") + b"\x99"
+    )
+    await asyncio.sleep(0)
+    assert peer.sent == [bytes([ATT_HANDLE_VALUE_CFM])]
+
+
+@pytest.mark.parametrize(
+    ("call", "empty_response"),
+    [
+        (
+            lambda c: c.read_by_group_type(0x0001, 0xFFFF, b"\x00\x28"),
+            bytes([ATT_READ_BY_GROUP_TYPE_RSP, 6]),  # valid stride, no entries
+        ),
+        (
+            lambda c: c.read_by_type(0x0001, 0xFFFF, b"\x03\x28"),
+            bytes([ATT_READ_BY_TYPE_RSP, 7]),
+        ),
+        (
+            lambda c: c.find_information(0x0001, 0xFFFF),
+            bytes([ATT_FIND_INFO_RSP, 0x01]),
+        ),
+    ],
+)
+async def test_discovery_rejects_entryless_response(
+    call: Callable[[ATTClient], Awaitable[list[object]]],
+    empty_response: bytes,
+) -> None:
+    """An entry-less response is rejected, not treated as a silent partial stop."""
+    peer = FakePeer(lambda _req: empty_response)
+    with pytest.raises(BleakError, match="truncated entries"):
+        await call(peer.client)
+    # Exactly one request; the loop neither re-requests nor returns partial data.
+    assert len(peer.sent) == 1
+
+
+@pytest.mark.parametrize(
+    ("call", "partial_response"),
+    [
+        (
+            lambda c: c.read_by_group_type(0x0001, 0xFFFF, b"\x00\x28"),
+            # stride 6: one full entry plus a 2 byte trailing partial.
+            bytes([ATT_READ_BY_GROUP_TYPE_RSP, 6])
+            + b"\x01\x00\x05\x00\x0f\x18"
+            + b"\x06\x00",
+        ),
+        (
+            lambda c: c.read_by_type(0x0001, 0xFFFF, b"\x03\x28"),
+            # stride 7: one full entry plus a 3 byte trailing partial.
+            bytes([ATT_READ_BY_TYPE_RSP, 7])
+            + b"\x02\x00\x02\x03\x00\x0f\x18"
+            + b"\x04\x00\x02",
+        ),
+        (
+            lambda c: c.find_information(0x0001, 0xFFFF),
+            # entry size 4: one full entry plus a 2 byte trailing partial.
+            bytes([ATT_FIND_INFO_RSP, 0x01]) + b"\x04\x00\x02\x29" + b"\x05\x00",
+        ),
+    ],
+)
+async def test_discovery_rejects_trailing_partial_entry(
+    call: Callable[[ATTClient], Awaitable[list[object]]],
+    partial_response: bytes,
+) -> None:
+    """A body that is not a whole multiple of the stride is rejected."""
+    peer = FakePeer(lambda _req: partial_response)
+    with pytest.raises(BleakError, match="truncated entries"):
+        await call(peer.client)
+    assert len(peer.sent) == 1
+
+
+async def test_exchange_mtu_rejects_truncated_response() -> None:
+    """A truncated MTU response raises rather than negotiating off a stray byte."""
+    peer = FakePeer(lambda _req: bytes([ATT_EXCHANGE_MTU_RSP, 0x10]))  # 2 bytes
+    with pytest.raises(BleakError, match="truncated ATT MTU response"):
+        await peer.client.exchange_mtu(247)
+
+
+async def test_timeout_poisons_channel() -> None:
+    """A request timeout closes the channel so a late response can't desync it."""
+    disconnects: list[Exception | None] = []
+    peer = FakePeer()  # no responder: the request times out
+    client = ATTClient(peer.send, on_disconnect=disconnects.append)
+    with (
+        patch("habluetooth.channels.att.ATT_TIMEOUT", 0.01),
+        pytest.raises(BleakError, match="timed out"),
+    ):
+        await client.read(0x0010)
+    assert len(disconnects) == 1
+
+    # The channel is poisoned: requests and write commands fail fast without
+    # sending, so a write command does not hand a PDU to a dead socket.
+    sent_before = len(peer.sent)
+    with pytest.raises(BleakError, match="ATT channel closed"):
+        await client.read(0x0011)
+    with pytest.raises(BleakError, match="ATT channel closed"):
+        await client.write_command(0x0011, b"\x01")
+    assert len(peer.sent) == sent_before
+
+    # A subsequent connection_lost does not notify a second time.
+    client.connection_lost(None)
+    assert len(disconnects) == 1
+
+
+async def test_poisoned_channel_drops_inbound_pdus() -> None:
+    """A poisoned channel drops late notifications and skips indication confirms."""
+    received: list[bytearray] = []
+    peer = FakePeer()  # no responder: the request times out
+    peer.client.set_notify_handler(0x0005, received.append)
+    with (
+        patch("habluetooth.channels.att.ATT_TIMEOUT", 0.01),
+        pytest.raises(BleakError, match="timed out"),
+    ):
+        await peer.client.read(0x0010)
+
+    sent_before = len(peer.sent)
+    # A late notification is not delivered to the subscriber.
+    peer.client.data_received(bytes([ATT_HANDLE_VALUE_NTF, 0x05, 0x00, 0xAB]))
+    assert received == []
+    # A late indication is dropped without scheduling a confirmation send.
+    peer.client.data_received(bytes([ATT_HANDLE_VALUE_IND, 0x05, 0x00, 0xAB]))
+    await asyncio.sleep(0)
+    assert received == []
+    assert len(peer.sent) == sent_before
+
+
+async def test_write_rejects_oversized_value() -> None:
+    """A write larger than mtu - 3 is rejected (no long-write support)."""
+    peer = FakePeer()
+    with pytest.raises(BleakError, match="value too long"):
+        await peer.client.write(0x0011, bytes(21))  # default mtu 23 -> max 20
+    assert peer.sent == []
+
+
+async def test_write_command_rejects_oversized_value() -> None:
+    """A write command larger than mtu - 3 is rejected."""
+    peer = FakePeer()
+    with pytest.raises(BleakError, match="value too long"):
+        await peer.client.write_command(0x0011, bytes(21))
+    assert peer.sent == []
+
+
+async def test_read_caps_value_at_offset_range() -> None:
+    """An always-full long read is capped instead of overflowing the offset."""
+    full = bytes(range(22))  # a full chunk (mtu - 1) every time, never terminating
+
+    def responder(req: bytes) -> bytes:
+        if req[0] == 0x0A:  # ATT_READ_REQ
+            return bytes([ATT_READ_RSP]) + full
+        return bytes([ATT_READ_BLOB_RSP]) + full
+
+    peer = FakePeer(responder)
+    with pytest.raises(BleakError, match="exceeds the 16-bit"):
+        await peer.client.read(0x0010)
+
+
+async def test_truncated_notification_is_dropped() -> None:
+    """A notification PDU too short to carry a handle is dropped, not fabricated."""
+    peer = FakePeer()
+    received: list[bytearray] = []
+    peer.client.set_notify_handler(0x0005, received.append)
+    # opcode + a single handle byte: too short to carry a 2-byte handle.
+    peer.client.data_received(bytes([ATT_HANDLE_VALUE_NTF, 0x05]))
+    assert received == []
+
+
+async def test_truncated_indication_is_dropped() -> None:
+    """A truncated indication is dropped and not confirmed."""
+    peer = FakePeer()
+    peer.client.data_received(bytes([ATT_HANDLE_VALUE_IND, 0x05]))
+    await asyncio.sleep(0)
+    assert peer.sent == []  # no CFM sent for a malformed PDU


### PR DESCRIPTION
Part of the dbus free local backend; this is the pure ATT/GATT codec the L2CAP GATT client will sit on top of.

channels/att.py is a transport agnostic ATT client and GATT discovery codec for the central subset: MTU exchange, primary service, characteristic and descriptor discovery, reads with long read continuation, writes with and without response, and notification and indication handling. Outbound PDUs go through an injected send coroutine and inbound PDUs arrive via data_received, so nothing opens a socket and the whole module is unit tested off Linux with a fake peer.

Nothing imports it yet; the L2CAP socket that feeds it and the bleak client that drives it land in follow ups. Kept pure python for clean coverage; it can be cythonized later if the notification path needs it.

100% line and branch coverage on the new module, green pure python and compiled suites, and no behavior change for existing code.