### PR TITLE
feat: add l2cap att socket transport

### DIFF
--- a/src/habluetooth/channels/l2cap.py
+++ b/src/habluetooth/channels/l2cap.py
@@ -192,10 +192,14 @@ class L2CAPSocket:
         one fd (a second backpressured call would replace the first's writer and
         stall it). SEQPACKET keeps each write framed as one PDU.
         """
-        if self._closed:
-            msg = "L2CAP socket is closed"
-            raise BleakError(msg)
         async with self._write_lock:
+            # Re-check under the lock: close() may have run while we were parked
+            # on it (e.g. a peer disconnect tearing the socket down), and writing
+            # to the closed fd must raise the documented BleakError, not an
+            # incidental OSError from sock_sendall.
+            if self._closed:
+                msg = "L2CAP socket is closed"
+                raise BleakError(msg)
             await self._loop.sock_sendall(self._sock, data)
 
     def _read_ready(self) -> None:

--- a/src/habluetooth/channels/l2cap.py
+++ b/src/habluetooth/channels/l2cap.py
@@ -144,6 +144,7 @@ class L2CAPSocket:
         self._on_data = on_data
         self._on_close = on_close
         self._closed = False
+        self._write_lock = asyncio.Lock()
         loop.add_reader(sock.fileno(), self._read_ready)
 
     @classmethod
@@ -182,11 +183,20 @@ class L2CAPSocket:
         return cls(sock, loop, on_data, on_close)
 
     async def send(self, data: bytes) -> None:
-        """Write one ATT PDU, awaiting socket writability under backpressure."""
+        """
+        Write one ATT PDU, awaiting socket writability under backpressure.
+
+        Serialized with a lock: ATTClient may call this concurrently (e.g. an
+        indication confirmation or a write-without-response alongside a pending
+        request), and ``loop.sock_sendall`` is not safe to run concurrently on
+        one fd (a second backpressured call would replace the first's writer and
+        stall it). SEQPACKET keeps each write framed as one PDU.
+        """
         if self._closed:
             msg = "L2CAP socket is closed"
             raise BleakError(msg)
-        await self._loop.sock_sendall(self._sock, data)
+        async with self._write_lock:
+            await self._loop.sock_sendall(self._sock, data)
 
     def _read_ready(self) -> None:
         """Read one inbound PDU and hand it to ``on_data`` (reader callback)."""

--- a/src/habluetooth/channels/l2cap.py
+++ b/src/habluetooth/channels/l2cap.py
@@ -200,7 +200,15 @@ class L2CAPSocket:
             if self._closed:
                 msg = "L2CAP socket is closed"
                 raise BleakError(msg)
-            await self._loop.sock_sendall(self._sock, data)
+            try:
+                await self._loop.sock_sendall(self._sock, data)
+            except OSError as exc:
+                # Mirror the read path: a write-side transport failure tears the
+                # channel down and notifies on_close once before surfacing to
+                # the caller, rather than leaving it half-open until a read event
+                # happens to detect the loss.
+                self._fail(exc)
+                raise
 
     def _read_ready(self) -> None:
         """Read one inbound PDU and hand it to ``on_data`` (reader callback)."""

--- a/src/habluetooth/channels/l2cap.py
+++ b/src/habluetooth/channels/l2cap.py
@@ -33,11 +33,13 @@ import struct
 from typing import TYPE_CHECKING
 
 from bleak import BleakError
+from bluetooth_data_tools import mac_to_int
 
 from ..const import BDADDR_LE_PUBLIC
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import NoReturn
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,13 +80,9 @@ def str_to_bdaddr(address: str) -> bytes:
     Pack ``AA:BB:CC:DD:EE:FF`` into the 6 little-endian bytes the kernel wants.
 
     BD_ADDRs go on the wire least-significant-octet first, so the textual
-    address is reversed.
+    address is reversed. Raises ``ValueError`` for a malformed address.
     """
-    parts = address.split(":")
-    if len(parts) != 6:
-        msg = f"invalid Bluetooth address: {address!r}"
-        raise ValueError(msg)
-    return bytes(int(part, 16) for part in reversed(parts))
+    return mac_to_int(address).to_bytes(6, "little")
 
 
 def make_sockaddr_l2(address: str, cid: int, bdaddr_type: int) -> _SockaddrL2:
@@ -127,6 +125,10 @@ class L2CAPSocket:
     disconnect, socket error) is reported once to ``on_close``. Outbound PDUs go
     through :meth:`send`, which is backpressure aware. ``on_data`` runs in the
     event loop read callback, so it must not block.
+
+    The loop's reader holds a reference to this socket (and thus to the
+    callbacks), so the owner must call :meth:`close` to release it; a peer
+    disconnect or read error closes it automatically.
     """
 
     def __init__(
@@ -172,53 +174,12 @@ class L2CAPSocket:
             sock.setblocking(False)
             if security_level:
                 _set_bt_security(sock, security_level)
-            cls._bind(sock, source)
-            await cls._connect(sock, address, address_type, loop, timeout)
+            _bind(sock, source)
+            await _connect(sock, address, address_type, loop, timeout)
         except BaseException:
             sock.close()
             raise
         return cls(sock, loop, on_data, on_close)
-
-    @staticmethod
-    def _bind(sock: socket.socket, source: str) -> None:
-        """Bind the socket to the local adapter so the route is deterministic."""
-        addr = make_sockaddr_l2(source, ATT_CID, BDADDR_LE_PUBLIC)
-        if (err := _bind_fd(sock.fileno(), addr)) != 0:
-            raise OSError(err, os.strerror(err))
-
-    @staticmethod
-    async def _connect(
-        sock: socket.socket,
-        address: str,
-        address_type: int,
-        loop: asyncio.AbstractEventLoop,
-        timeout: float,
-    ) -> None:
-        """Issue the non-blocking connect and await the result via SO_ERROR."""
-        addr = make_sockaddr_l2(address, ATT_CID, address_type)
-        err = _connect_fd(sock.fileno(), addr)
-        if err in (errno.EINPROGRESS, errno.EALREADY, errno.EAGAIN):
-            await L2CAPSocket._wait_connected(sock, loop, timeout)
-        elif err != 0:
-            raise OSError(err, os.strerror(err))
-
-    @staticmethod
-    async def _wait_connected(
-        sock: socket.socket,
-        loop: asyncio.AbstractEventLoop,
-        timeout: float,
-    ) -> None:
-        """Wait for the in-progress connect to settle, then check SO_ERROR."""
-        fut: asyncio.Future[None] = loop.create_future()
-        fd = sock.fileno()
-        loop.add_writer(fd, _set_result_if_pending, fut)
-        try:
-            async with asyncio.timeout(timeout):
-                await fut
-        finally:
-            loop.remove_writer(fd)
-        if (err := _so_error(sock)) != 0:
-            raise OSError(err, os.strerror(err))
 
     async def send(self, data: bytes) -> None:
         """Write one ATT PDU, awaiting socket writability under backpressure."""
@@ -256,6 +217,52 @@ class L2CAPSocket:
         self._closed = True
         self._loop.remove_reader(self._sock.fileno())
         self._sock.close()
+
+
+def _bind(sock: socket.socket, source: str) -> None:
+    """Bind the socket to the local adapter so the route is deterministic."""
+    addr = make_sockaddr_l2(source, ATT_CID, BDADDR_LE_PUBLIC)
+    if (err := _bind_fd(sock.fileno(), addr)) != 0:
+        _raise_errno(err)
+
+
+async def _connect(
+    sock: socket.socket,
+    address: str,
+    address_type: int,
+    loop: asyncio.AbstractEventLoop,
+    timeout: float,
+) -> None:
+    """Issue the non-blocking connect and await the result via SO_ERROR."""
+    addr = make_sockaddr_l2(address, ATT_CID, address_type)
+    err = _connect_fd(sock.fileno(), addr)
+    if err in (errno.EINPROGRESS, errno.EALREADY, errno.EAGAIN):
+        await _wait_connected(sock, loop, timeout)
+    elif err != 0:
+        _raise_errno(err)
+
+
+async def _wait_connected(
+    sock: socket.socket,
+    loop: asyncio.AbstractEventLoop,
+    timeout: float,
+) -> None:
+    """Wait for the in-progress connect to settle, then check SO_ERROR."""
+    fut: asyncio.Future[None] = loop.create_future()
+    fd = sock.fileno()
+    loop.add_writer(fd, _set_result_if_pending, fut)
+    try:
+        async with asyncio.timeout(timeout):
+            await fut
+    finally:
+        loop.remove_writer(fd)
+    if (err := _so_error(sock)) != 0:
+        _raise_errno(err)
+
+
+def _raise_errno(err: int) -> NoReturn:
+    """Raise an ``OSError`` carrying ``err`` and its platform message."""
+    raise OSError(err, os.strerror(err))
 
 
 def _set_bt_security(  # pragma: no cover - BT-only setsockopt

--- a/src/habluetooth/channels/l2cap.py
+++ b/src/habluetooth/channels/l2cap.py
@@ -1,0 +1,276 @@
+"""
+L2CAP ATT socket transport for the kernel/L2CAP backend.
+
+This opens a raw L2CAP connection-oriented socket to a peripheral on the ATT
+fixed channel (CID ``0x0004``) and exposes it as an asyncio push transport: one
+SEQPACKET datagram in, one ATT PDU out. It is the thing that feeds
+:class:`habluetooth.channels.att.ATTClient` once a peer is connected.
+
+CPython's :mod:`socket` cannot express the Bluetooth ``sockaddr_l2`` (it has no
+field for ``l2_cid`` or ``l2_bdaddr_type``), so the address is packed by hand
+and ``bind``/``connect`` are issued through libc via :mod:`ctypes` on the raw
+file descriptor; everything after the connect handshake is ordinary asyncio
+(:meth:`~asyncio.loop.add_reader` for the inbound stream,
+:meth:`~asyncio.loop.sock_sendall` for backpressured writes).
+
+``SOCK_SEQPACKET`` preserves datagram boundaries, so each ``recv`` yields
+exactly one ATT PDU and the codec never has to reframe the stream. The libc
+``bind``/``connect`` shims are the only Linux/Bluetooth specific lines; the
+orchestration around them is exercised over an ordinary socket pair, so the
+module is unit-testable without Bluetooth hardware.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import errno
+import functools
+import logging
+import os
+import socket
+import struct
+from typing import TYPE_CHECKING
+
+from bleak import BleakError
+
+from ..const import BDADDR_LE_PUBLIC
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_LOGGER = logging.getLogger(__name__)
+
+# -- Bluetooth socket constants -------------------------------------------
+# CPython exposes these on Linux only (and not at all on python-build-standalone
+# builds without the bluetooth headers), so they are pinned here as literals
+# rather than read from the socket module.
+AF_BLUETOOTH = 31
+BTPROTO_L2CAP = 0
+ATT_CID = 0x0004
+
+# setsockopt(SOL_BLUETOOTH, BT_SECURITY, struct bt_security{level, key_size})
+SOL_BLUETOOTH = 274
+BT_SECURITY = 4
+BT_SECURITY_LOW = 1
+BT_SECURITY_MEDIUM = 2
+BT_SECURITY_HIGH = 3
+
+# One SEQPACKET recv yields one ATT PDU; the largest legal ATT MTU is 517, so a
+# 1024 byte buffer cannot truncate a PDU.
+_RECV_BUFSIZE = 1024
+
+
+class _SockaddrL2(ctypes.Structure):
+    """The Linux ``struct sockaddr_l2`` (see ``include/net/bluetooth/l2cap.h``)."""
+
+    _fields_ = (
+        ("l2_family", ctypes.c_ushort),
+        ("l2_psm", ctypes.c_ushort),
+        ("l2_bdaddr", ctypes.c_ubyte * 6),
+        ("l2_cid", ctypes.c_ushort),
+        ("l2_bdaddr_type", ctypes.c_ubyte),
+    )
+
+
+def str_to_bdaddr(address: str) -> bytes:
+    """
+    Pack ``AA:BB:CC:DD:EE:FF`` into the 6 little-endian bytes the kernel wants.
+
+    BD_ADDRs go on the wire least-significant-octet first, so the textual
+    address is reversed.
+    """
+    parts = address.split(":")
+    if len(parts) != 6:
+        msg = f"invalid Bluetooth address: {address!r}"
+        raise ValueError(msg)
+    return bytes(int(part, 16) for part in reversed(parts))
+
+
+def make_sockaddr_l2(address: str, cid: int, bdaddr_type: int) -> _SockaddrL2:
+    """Build a ``sockaddr_l2`` for ``address`` on the given fixed channel."""
+    addr = _SockaddrL2()
+    addr.l2_family = AF_BLUETOOTH
+    addr.l2_psm = 0
+    addr.l2_bdaddr = (ctypes.c_ubyte * 6)(*str_to_bdaddr(address))
+    addr.l2_cid = cid
+    addr.l2_bdaddr_type = bdaddr_type
+    return addr
+
+
+@functools.cache
+def _get_libc() -> ctypes.CDLL:  # pragma: no cover - libc load is platform glue
+    """Return a cached errno-aware libc handle for the raw bind/connect calls."""
+    return ctypes.CDLL(None, use_errno=True)
+
+
+def _bind_fd(fd: int, addr: _SockaddrL2) -> int:  # pragma: no cover - syscall shim
+    """``bind(2)`` the raw fd; return 0 on success or the errno on failure."""
+    if _get_libc().bind(fd, ctypes.byref(addr), ctypes.sizeof(addr)) != 0:
+        return ctypes.get_errno()
+    return 0
+
+
+def _connect_fd(fd: int, addr: _SockaddrL2) -> int:  # pragma: no cover - syscall
+    """``connect(2)`` the raw fd; return 0, EINPROGRESS, or the errno."""
+    if _get_libc().connect(fd, ctypes.byref(addr), ctypes.sizeof(addr)) != 0:
+        return ctypes.get_errno()
+    return 0
+
+
+class L2CAPSocket:
+    """
+    An open L2CAP ATT channel to a single peer, driven by asyncio.
+
+    Construct one with :meth:`create_connection`; it registers a reader so that
+    every inbound PDU is handed to ``on_data`` and a transport failure (peer
+    disconnect, socket error) is reported once to ``on_close``. Outbound PDUs go
+    through :meth:`send`, which is backpressure aware. ``on_data`` runs in the
+    event loop read callback, so it must not block.
+    """
+
+    def __init__(
+        self,
+        sock: socket.socket,
+        loop: asyncio.AbstractEventLoop,
+        on_data: Callable[[bytes], None],
+        on_close: Callable[[Exception | None], None],
+    ) -> None:
+        """Wrap an already-connected socket and start reading from it."""
+        self._sock = sock
+        self._loop = loop
+        self._on_data = on_data
+        self._on_close = on_close
+        self._closed = False
+        loop.add_reader(sock.fileno(), self._read_ready)
+
+    @classmethod
+    async def create_connection(
+        cls,
+        *,
+        source: str,
+        address: str,
+        address_type: int,
+        on_data: Callable[[bytes], None],
+        on_close: Callable[[Exception | None], None],
+        timeout: float,
+        security_level: int = BT_SECURITY_MEDIUM,
+        sock: socket.socket | None = None,
+    ) -> L2CAPSocket:
+        """
+        Open an L2CAP ATT channel from adapter ``source`` to ``address``.
+
+        ``source`` is the local adapter's public BD_ADDR (it selects which
+        adapter the connection goes out of); ``address``/``address_type`` are the
+        peer. ``security_level`` requests kernel-driven LE encryption when bonded
+        keys exist; pass 0 to leave it unset. ``sock`` is injectable for testing.
+        """
+        loop = asyncio.get_running_loop()
+        if sock is None:  # pragma: no cover - real socket needs a Linux adapter
+            sock = socket.socket(AF_BLUETOOTH, socket.SOCK_SEQPACKET, BTPROTO_L2CAP)
+        try:
+            sock.setblocking(False)
+            if security_level:
+                _set_bt_security(sock, security_level)
+            cls._bind(sock, source)
+            await cls._connect(sock, address, address_type, loop, timeout)
+        except BaseException:
+            sock.close()
+            raise
+        return cls(sock, loop, on_data, on_close)
+
+    @staticmethod
+    def _bind(sock: socket.socket, source: str) -> None:
+        """Bind the socket to the local adapter so the route is deterministic."""
+        addr = make_sockaddr_l2(source, ATT_CID, BDADDR_LE_PUBLIC)
+        if (err := _bind_fd(sock.fileno(), addr)) != 0:
+            raise OSError(err, os.strerror(err))
+
+    @staticmethod
+    async def _connect(
+        sock: socket.socket,
+        address: str,
+        address_type: int,
+        loop: asyncio.AbstractEventLoop,
+        timeout: float,
+    ) -> None:
+        """Issue the non-blocking connect and await the result via SO_ERROR."""
+        addr = make_sockaddr_l2(address, ATT_CID, address_type)
+        err = _connect_fd(sock.fileno(), addr)
+        if err in (errno.EINPROGRESS, errno.EALREADY, errno.EAGAIN):
+            await L2CAPSocket._wait_connected(sock, loop, timeout)
+        elif err != 0:
+            raise OSError(err, os.strerror(err))
+
+    @staticmethod
+    async def _wait_connected(
+        sock: socket.socket,
+        loop: asyncio.AbstractEventLoop,
+        timeout: float,
+    ) -> None:
+        """Wait for the in-progress connect to settle, then check SO_ERROR."""
+        fut: asyncio.Future[None] = loop.create_future()
+        fd = sock.fileno()
+        loop.add_writer(fd, _set_result_if_pending, fut)
+        try:
+            async with asyncio.timeout(timeout):
+                await fut
+        finally:
+            loop.remove_writer(fd)
+        if (err := _so_error(sock)) != 0:
+            raise OSError(err, os.strerror(err))
+
+    async def send(self, data: bytes) -> None:
+        """Write one ATT PDU, awaiting socket writability under backpressure."""
+        if self._closed:
+            msg = "L2CAP socket is closed"
+            raise BleakError(msg)
+        await self._loop.sock_sendall(self._sock, data)
+
+    def _read_ready(self) -> None:
+        """Read one inbound PDU and hand it to ``on_data`` (reader callback)."""
+        try:
+            data = self._sock.recv(_RECV_BUFSIZE)
+        except (BlockingIOError, InterruptedError):
+            return
+        except OSError as exc:
+            self._fail(exc)
+            return
+        if not data:
+            # A zero-length SEQPACKET read means the peer hung up.
+            self._fail(None)
+            return
+        self._on_data(data)
+
+    def _fail(self, exc: Exception | None) -> None:
+        """Tear down once and report the loss to ``on_close`` exactly once."""
+        if self._closed:
+            return
+        self.close()
+        self._on_close(exc)
+
+    def close(self) -> None:
+        """Stop reading and close the socket; idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        self._loop.remove_reader(self._sock.fileno())
+        self._sock.close()
+
+
+def _set_bt_security(  # pragma: no cover - BT-only setsockopt
+    sock: socket.socket, level: int
+) -> None:
+    """Request a kernel-driven LE security level on the socket."""
+    sock.setsockopt(SOL_BLUETOOTH, BT_SECURITY, struct.pack("BB", level, 0))
+
+
+def _so_error(sock: socket.socket) -> int:
+    """Return the socket's pending error (``SO_ERROR``), 0 if none."""
+    return sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+
+
+def _set_result_if_pending(fut: asyncio.Future[None]) -> None:
+    """Resolve ``fut`` if it has not already completed (writer callback)."""
+    if not fut.done():
+        fut.set_result(None)

--- a/tests/channels/test_l2cap.py
+++ b/tests/channels/test_l2cap.py
@@ -309,6 +309,27 @@ async def test_send_rechecks_closed_after_acquiring_lock(
             await second
 
 
+async def test_send_error_tears_down_channel(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """A write-side socket error closes the channel and notifies on_close once."""
+    left, _right = pair
+    closed: list[Exception | None] = []
+    sock = await _connect(left, on_data=lambda _d: None, on_close=closed.append)
+    boom = OSError("epipe")
+
+    async def fake_sendall(_sock: socket.socket, _data: bytes) -> None:
+        raise boom
+
+    with (
+        patch.object(sock._loop, "sock_sendall", fake_sendall),
+        pytest.raises(OSError, match="epipe"),
+    ):
+        await sock.send(b"A")
+    assert sock._closed is True
+    assert closed == [boom]
+
+
 async def test_send_after_close_raises(
     pair: tuple[socket.socket, socket.socket],
 ) -> None:

--- a/tests/channels/test_l2cap.py
+++ b/tests/channels/test_l2cap.py
@@ -18,18 +18,30 @@ from habluetooth.channels.l2cap import (
     ATT_CID,
     L2CAPSocket,
     _set_result_if_pending,
+    _wait_connected,
     make_sockaddr_l2,
     str_to_bdaddr,
 )
 from habluetooth.const import BDADDR_LE_RANDOM
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
 pytestmark = pytest.mark.asyncio
 
 _SOURCE = "00:11:22:33:44:55"
 _PEER = "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.fixture
+def pair() -> Iterator[tuple[socket.socket, socket.socket]]:
+    """Yield a connected socket pair and close both ends on teardown."""
+    left, right = socket.socketpair()
+    try:
+        yield left, right
+    finally:
+        left.close()
+        right.close()
 
 
 async def _connect(
@@ -74,7 +86,7 @@ async def test_str_to_bdaddr_reverses_octets() -> None:
 @pytest.mark.parametrize("bad", ["AA:BB:CC", "", "AA:BB:CC:DD:EE:FF:00"])
 async def test_str_to_bdaddr_rejects_malformed(bad: str) -> None:
     """An address without exactly six octets is rejected."""
-    with pytest.raises(ValueError, match="invalid Bluetooth address"):
+    with pytest.raises(ValueError, match="Invalid MAC address"):
         str_to_bdaddr(bad)
 
 
@@ -94,10 +106,12 @@ async def test_make_sockaddr_l2_layout() -> None:
     [(2, 1), (0, 0)],
 )
 async def test_create_connection_security_level(
-    security_level: int, expected_calls: int
+    pair: tuple[socket.socket, socket.socket],
+    security_level: int,
+    expected_calls: int,
 ) -> None:
     """A non-zero security level requests kernel LE security; zero skips it."""
-    left, right = socket.socketpair()
+    left, _right = pair
     with (
         patch("habluetooth.channels.l2cap._set_bt_security") as set_security,
         patch("habluetooth.channels.l2cap._bind_fd", return_value=0),
@@ -113,16 +127,15 @@ async def test_create_connection_security_level(
             security_level=security_level,
             sock=left,
         )
-    try:
-        assert set_security.call_count == expected_calls
-    finally:
-        sock.close()
-        right.close()
+    sock.close()
+    assert set_security.call_count == expected_calls
 
 
-async def test_create_connection_immediate_success() -> None:
+async def test_create_connection_immediate_success(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """A connect that succeeds at once yields a live, readable socket."""
-    left, right = socket.socketpair()
+    left, right = pair
     received: list[bytes] = []
     closed: list[Exception | None] = []
     got = asyncio.Event()
@@ -132,35 +145,33 @@ async def test_create_connection_immediate_success() -> None:
         got.set()
 
     sock = await _connect(left, on_data=on_data, on_close=closed.append)
-    try:
-        right.send(b"\x1b\x05\x00\xab")
-        await got.wait()
-        assert received == [b"\x1b\x05\x00\xab"]
-        assert closed == []
-    finally:
-        sock.close()
-        right.close()
+    right.send(b"\x1b\x05\x00\xab")
+    await got.wait()
+    assert received == [b"\x1b\x05\x00\xab"]
+    assert closed == []
+    sock.close()
 
 
-async def test_create_connection_in_progress_then_writable() -> None:
+async def test_create_connection_in_progress_then_writable(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """An EINPROGRESS connect completes once the socket reports writable."""
-    left, right = socket.socketpair()
+    left, _right = pair
     sock = await _connect(
         left,
         on_data=lambda _d: None,
         on_close=lambda _e: None,
         connect_result=errno.EINPROGRESS,
     )
-    try:
-        assert sock._closed is False
-    finally:
-        sock.close()
-        right.close()
+    assert sock._closed is False
+    sock.close()
 
 
-async def test_create_connection_so_error_fails_and_closes() -> None:
+async def test_create_connection_so_error_fails_and_closes(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """A non-zero SO_ERROR after connect surfaces and closes the socket."""
-    left, right = socket.socketpair()
+    left, _right = pair
     with (
         patch(
             "habluetooth.channels.l2cap._so_error",
@@ -176,80 +187,74 @@ async def test_create_connection_so_error_fails_and_closes() -> None:
         )
     assert exc_info.value.errno == errno.EHOSTUNREACH
     assert left.fileno() == -1  # the injected socket was closed on failure
-    right.close()
 
 
-async def test_create_connection_immediate_error_closes() -> None:
-    """A hard connect error is raised and the socket is closed."""
-    left, right = socket.socketpair()
-    with pytest.raises(OSError, match=_strerror(errno.EHOSTUNREACH)) as exc_info:
+@pytest.mark.parametrize(
+    ("connect_kwargs", "expected_errno"),
+    [
+        ({"connect_result": errno.EHOSTUNREACH}, errno.EHOSTUNREACH),
+        ({"bind_result": errno.EPERM}, errno.EPERM),
+    ],
+)
+async def test_create_connection_syscall_error_closes(
+    pair: tuple[socket.socket, socket.socket],
+    connect_kwargs: dict[str, int],
+    expected_errno: int,
+) -> None:
+    """A hard bind/connect error is raised and the socket is closed."""
+    left, _right = pair
+    with pytest.raises(OSError, match=_strerror(expected_errno)) as exc_info:
         await _connect(
             left,
             on_data=lambda _d: None,
             on_close=lambda _e: None,
-            connect_result=errno.EHOSTUNREACH,
+            **connect_kwargs,
         )
-    assert exc_info.value.errno == errno.EHOSTUNREACH
+    assert exc_info.value.errno == expected_errno
     assert left.fileno() == -1
-    right.close()
 
 
-async def test_create_connection_bind_error_closes() -> None:
-    """A bind failure is raised and the socket is closed."""
-    left, right = socket.socketpair()
-    with pytest.raises(OSError, match=_strerror(errno.EPERM)) as exc_info:
-        await _connect(
-            left,
-            on_data=lambda _d: None,
-            on_close=lambda _e: None,
-            bind_result=errno.EPERM,
-        )
-    assert exc_info.value.errno == errno.EPERM
-    assert left.fileno() == -1
-    right.close()
-
-
-async def test_wait_connected_times_out() -> None:
+async def test_wait_connected_times_out(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """If the socket never reports writable, the connect times out."""
     loop = asyncio.get_running_loop()
-    left, right = socket.socketpair()
-    try:
-        with (
-            patch.object(loop, "add_writer"),
-            pytest.raises(TimeoutError),
-        ):
-            await L2CAPSocket._wait_connected(left, loop, 0.01)
-    finally:
-        left.close()
-        right.close()
+    left, _right = pair
+    with (
+        patch.object(loop, "add_writer"),
+        pytest.raises(TimeoutError),
+    ):
+        await _wait_connected(left, loop, 0.01)
 
 
 # -- send / receive / teardown -------------------------------------------
-async def test_send_writes_one_pdu() -> None:
+async def test_send_writes_one_pdu(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """Send writes the PDU to the peer end of the channel."""
-    left, right = socket.socketpair()
+    left, right = pair
     sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
-    try:
-        await sock.send(b"\x02\x17\x00")
-        assert right.recv(64) == b"\x02\x17\x00"
-    finally:
-        sock.close()
-        right.close()
+    await sock.send(b"\x02\x17\x00")
+    assert right.recv(64) == b"\x02\x17\x00"
+    sock.close()
 
 
-async def test_send_after_close_raises() -> None:
+async def test_send_after_close_raises(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """Writing to a closed channel raises rather than touching the socket."""
-    left, right = socket.socketpair()
+    left, _right = pair
     sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
     sock.close()
     with pytest.raises(BleakError, match="closed"):
         await sock.send(b"\x02\x17\x00")
-    right.close()
 
 
-async def test_peer_disconnect_reports_close_once() -> None:
+async def test_peer_disconnect_reports_close_once(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """A peer hangup is reported to on_close exactly once with no error."""
-    left, right = socket.socketpair()
+    left, right = pair
     closed: list[Exception | None] = []
     hung_up = asyncio.Event()
 
@@ -264,26 +269,26 @@ async def test_peer_disconnect_reports_close_once() -> None:
     assert sock._closed is True
 
 
-async def test_read_ready_ignores_would_block() -> None:
+async def test_read_ready_ignores_would_block(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """A spurious wakeup with no data is a no-op, not a disconnect."""
-    left, right = socket.socketpair()
+    left, _right = pair
     received: list[bytes] = []
     closed: list[Exception | None] = []
     sock = await _connect(left, on_data=received.append, on_close=closed.append)
-    try:
-        sock._sock = Mock(recv=Mock(side_effect=BlockingIOError))
-        sock._read_ready()
-        assert received == []
-        assert closed == []
-        assert sock._closed is False
-    finally:
-        left.close()
-        right.close()
+    sock._sock = Mock(recv=Mock(side_effect=BlockingIOError))
+    sock._read_ready()
+    assert received == []
+    assert closed == []
+    assert sock._closed is False
 
 
-async def test_read_ready_reports_socket_error() -> None:
+async def test_read_ready_reports_socket_error(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """A read error tears the channel down and reports the exception once."""
-    left, right = socket.socketpair()
+    left, _right = pair
     closed: list[Exception | None] = []
     sock = await _connect(left, on_data=lambda _d: None, on_close=closed.append)
     fd = sock._sock.fileno()
@@ -292,13 +297,13 @@ async def test_read_ready_reports_socket_error() -> None:
     sock._read_ready()
     assert closed == [boom]
     assert sock._closed is True
-    left.close()
-    right.close()
 
 
-async def test_close_is_idempotent() -> None:
+async def test_close_is_idempotent(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
     """Closing twice is safe and does not double-report."""
-    left, right = socket.socketpair()
+    left, _right = pair
     closed: list[Exception | None] = []
     sock = await _connect(left, on_data=lambda _d: None, on_close=closed.append)
     sock.close()
@@ -306,7 +311,6 @@ async def test_close_is_idempotent() -> None:
     # A subsequent failure does not call on_close again.
     sock._fail(None)
     assert closed == []
-    right.close()
 
 
 async def test_set_result_if_pending_is_idempotent() -> None:

--- a/tests/channels/test_l2cap.py
+++ b/tests/channels/test_l2cap.py
@@ -7,6 +7,7 @@ import errno
 import os
 import re
 import socket
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
@@ -27,7 +28,16 @@ from habluetooth.const import BDADDR_LE_RANDOM
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    # L2CAP is Linux only; the transport drives the socket with add_reader /
+    # add_writer / sock_sendall, which the Windows proactor event loop does not
+    # implement. The selector loops on Linux and macOS run these fine.
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="L2CAP transport needs a selector event loop (Linux/macOS)",
+    ),
+]
 
 _SOURCE = "00:11:22:33:44:55"
 _PEER = "AA:BB:CC:DD:EE:FF"
@@ -236,6 +246,41 @@ async def test_send_writes_one_pdu(
     sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
     await sock.send(b"\x02\x17\x00")
     assert right.recv(64) == b"\x02\x17\x00"
+    sock.close()
+
+
+async def test_send_serializes_concurrent_writes(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """Concurrent sends are serialized so one cannot stall another mid-write."""
+    left, _right = pair
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    order: list[tuple[str, bytes]] = []
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def fake_sendall(_sock: socket.socket, data: bytes) -> None:
+        order.append(("enter", data))
+        if data == b"A":
+            first_entered.set()
+            await release_first.wait()
+        order.append(("exit", data))
+
+    with patch.object(sock._loop, "sock_sendall", fake_sendall):
+        first = asyncio.create_task(sock.send(b"A"))
+        await first_entered.wait()
+        second = asyncio.create_task(sock.send(b"B"))
+        await asyncio.sleep(0)
+        # The second send is blocked on the lock while the first is in flight.
+        assert order == [("enter", b"A")]
+        release_first.set()
+        await asyncio.gather(first, second)
+    assert order == [
+        ("enter", b"A"),
+        ("exit", b"A"),
+        ("enter", b"B"),
+        ("exit", b"B"),
+    ]
     sock.close()
 
 

--- a/tests/channels/test_l2cap.py
+++ b/tests/channels/test_l2cap.py
@@ -284,6 +284,31 @@ async def test_send_serializes_concurrent_writes(
     sock.close()
 
 
+async def test_send_rechecks_closed_after_acquiring_lock(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """A send parked on the write lock raises BleakError if close() intervenes."""
+    left, _right = pair
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_sendall(_sock: socket.socket, _data: bytes) -> None:
+        in_flight.set()
+        await release.wait()
+
+    with patch.object(sock._loop, "sock_sendall", fake_sendall):
+        first = asyncio.create_task(sock.send(b"A"))
+        await in_flight.wait()
+        second = asyncio.create_task(sock.send(b"B"))
+        await asyncio.sleep(0)  # the second send parks on the held lock
+        sock.close()  # tear down while the second send is waiting
+        release.set()
+        await first  # the first send already passed the closed check
+        with pytest.raises(BleakError, match="closed"):
+            await second
+
+
 async def test_send_after_close_raises(
     pair: tuple[socket.socket, socket.socket],
 ) -> None:

--- a/tests/channels/test_l2cap.py
+++ b/tests/channels/test_l2cap.py
@@ -1,0 +1,318 @@
+"""Tests for the L2CAP ATT socket transport."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import re
+import socket
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
+
+import pytest
+from bleak import BleakError
+
+from habluetooth.channels.l2cap import (
+    AF_BLUETOOTH,
+    ATT_CID,
+    L2CAPSocket,
+    _set_result_if_pending,
+    make_sockaddr_l2,
+    str_to_bdaddr,
+)
+from habluetooth.const import BDADDR_LE_RANDOM
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+pytestmark = pytest.mark.asyncio
+
+_SOURCE = "00:11:22:33:44:55"
+_PEER = "AA:BB:CC:DD:EE:FF"
+
+
+async def _connect(
+    left: socket.socket,
+    *,
+    on_data: Callable[[bytes], None],
+    on_close: Callable[[Exception | None], None],
+    connect_result: int = 0,
+    bind_result: int = 0,
+    timeout: float = 1.0,
+) -> L2CAPSocket:
+    """Drive create_connection over an injected socket with patched syscalls."""
+    with (
+        patch("habluetooth.channels.l2cap._set_bt_security"),
+        patch("habluetooth.channels.l2cap._bind_fd", return_value=bind_result),
+        patch("habluetooth.channels.l2cap._connect_fd", return_value=connect_result),
+    ):
+        return await L2CAPSocket.create_connection(
+            source=_SOURCE,
+            address=_PEER,
+            address_type=BDADDR_LE_RANDOM,
+            on_data=on_data,
+            on_close=on_close,
+            timeout=timeout,
+            sock=left,
+        )
+
+
+def _strerror(err: int) -> str:
+    """Return the platform error string for ``err`` as a regex-safe pattern."""
+    return re.escape(os.strerror(err))
+
+
+# -- address packing ------------------------------------------------------
+async def test_str_to_bdaddr_reverses_octets() -> None:
+    """A textual BD_ADDR is packed least-significant-octet first."""
+    assert str_to_bdaddr("AA:BB:CC:DD:EE:FF") == bytes(
+        [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA]
+    )
+
+
+@pytest.mark.parametrize("bad", ["AA:BB:CC", "", "AA:BB:CC:DD:EE:FF:00"])
+async def test_str_to_bdaddr_rejects_malformed(bad: str) -> None:
+    """An address without exactly six octets is rejected."""
+    with pytest.raises(ValueError, match="invalid Bluetooth address"):
+        str_to_bdaddr(bad)
+
+
+async def test_make_sockaddr_l2_layout() -> None:
+    """The packed sockaddr carries the family, channel, address, and type."""
+    addr = make_sockaddr_l2(_PEER, ATT_CID, BDADDR_LE_RANDOM)
+    assert addr.l2_family == AF_BLUETOOTH
+    assert addr.l2_psm == 0
+    assert bytes(addr.l2_bdaddr) == bytes([0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA])
+    assert addr.l2_cid == ATT_CID
+    assert addr.l2_bdaddr_type == BDADDR_LE_RANDOM
+
+
+# -- connect handshake ----------------------------------------------------
+@pytest.mark.parametrize(
+    ("security_level", "expected_calls"),
+    [(2, 1), (0, 0)],
+)
+async def test_create_connection_security_level(
+    security_level: int, expected_calls: int
+) -> None:
+    """A non-zero security level requests kernel LE security; zero skips it."""
+    left, right = socket.socketpair()
+    with (
+        patch("habluetooth.channels.l2cap._set_bt_security") as set_security,
+        patch("habluetooth.channels.l2cap._bind_fd", return_value=0),
+        patch("habluetooth.channels.l2cap._connect_fd", return_value=0),
+    ):
+        sock = await L2CAPSocket.create_connection(
+            source=_SOURCE,
+            address=_PEER,
+            address_type=BDADDR_LE_RANDOM,
+            on_data=lambda _d: None,
+            on_close=lambda _e: None,
+            timeout=1.0,
+            security_level=security_level,
+            sock=left,
+        )
+    try:
+        assert set_security.call_count == expected_calls
+    finally:
+        sock.close()
+        right.close()
+
+
+async def test_create_connection_immediate_success() -> None:
+    """A connect that succeeds at once yields a live, readable socket."""
+    left, right = socket.socketpair()
+    received: list[bytes] = []
+    closed: list[Exception | None] = []
+    got = asyncio.Event()
+
+    def on_data(data: bytes) -> None:
+        received.append(data)
+        got.set()
+
+    sock = await _connect(left, on_data=on_data, on_close=closed.append)
+    try:
+        right.send(b"\x1b\x05\x00\xab")
+        await got.wait()
+        assert received == [b"\x1b\x05\x00\xab"]
+        assert closed == []
+    finally:
+        sock.close()
+        right.close()
+
+
+async def test_create_connection_in_progress_then_writable() -> None:
+    """An EINPROGRESS connect completes once the socket reports writable."""
+    left, right = socket.socketpair()
+    sock = await _connect(
+        left,
+        on_data=lambda _d: None,
+        on_close=lambda _e: None,
+        connect_result=errno.EINPROGRESS,
+    )
+    try:
+        assert sock._closed is False
+    finally:
+        sock.close()
+        right.close()
+
+
+async def test_create_connection_so_error_fails_and_closes() -> None:
+    """A non-zero SO_ERROR after connect surfaces and closes the socket."""
+    left, right = socket.socketpair()
+    with (
+        patch(
+            "habluetooth.channels.l2cap._so_error",
+            return_value=errno.EHOSTUNREACH,
+        ),
+        pytest.raises(OSError, match=_strerror(errno.EHOSTUNREACH)) as exc_info,
+    ):
+        await _connect(
+            left,
+            on_data=lambda _d: None,
+            on_close=lambda _e: None,
+            connect_result=errno.EINPROGRESS,
+        )
+    assert exc_info.value.errno == errno.EHOSTUNREACH
+    assert left.fileno() == -1  # the injected socket was closed on failure
+    right.close()
+
+
+async def test_create_connection_immediate_error_closes() -> None:
+    """A hard connect error is raised and the socket is closed."""
+    left, right = socket.socketpair()
+    with pytest.raises(OSError, match=_strerror(errno.EHOSTUNREACH)) as exc_info:
+        await _connect(
+            left,
+            on_data=lambda _d: None,
+            on_close=lambda _e: None,
+            connect_result=errno.EHOSTUNREACH,
+        )
+    assert exc_info.value.errno == errno.EHOSTUNREACH
+    assert left.fileno() == -1
+    right.close()
+
+
+async def test_create_connection_bind_error_closes() -> None:
+    """A bind failure is raised and the socket is closed."""
+    left, right = socket.socketpair()
+    with pytest.raises(OSError, match=_strerror(errno.EPERM)) as exc_info:
+        await _connect(
+            left,
+            on_data=lambda _d: None,
+            on_close=lambda _e: None,
+            bind_result=errno.EPERM,
+        )
+    assert exc_info.value.errno == errno.EPERM
+    assert left.fileno() == -1
+    right.close()
+
+
+async def test_wait_connected_times_out() -> None:
+    """If the socket never reports writable, the connect times out."""
+    loop = asyncio.get_running_loop()
+    left, right = socket.socketpair()
+    try:
+        with (
+            patch.object(loop, "add_writer"),
+            pytest.raises(TimeoutError),
+        ):
+            await L2CAPSocket._wait_connected(left, loop, 0.01)
+    finally:
+        left.close()
+        right.close()
+
+
+# -- send / receive / teardown -------------------------------------------
+async def test_send_writes_one_pdu() -> None:
+    """Send writes the PDU to the peer end of the channel."""
+    left, right = socket.socketpair()
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    try:
+        await sock.send(b"\x02\x17\x00")
+        assert right.recv(64) == b"\x02\x17\x00"
+    finally:
+        sock.close()
+        right.close()
+
+
+async def test_send_after_close_raises() -> None:
+    """Writing to a closed channel raises rather than touching the socket."""
+    left, right = socket.socketpair()
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    sock.close()
+    with pytest.raises(BleakError, match="closed"):
+        await sock.send(b"\x02\x17\x00")
+    right.close()
+
+
+async def test_peer_disconnect_reports_close_once() -> None:
+    """A peer hangup is reported to on_close exactly once with no error."""
+    left, right = socket.socketpair()
+    closed: list[Exception | None] = []
+    hung_up = asyncio.Event()
+
+    def on_close(exc: Exception | None) -> None:
+        closed.append(exc)
+        hung_up.set()
+
+    sock = await _connect(left, on_data=lambda _d: None, on_close=on_close)
+    right.close()
+    await hung_up.wait()
+    assert closed == [None]
+    assert sock._closed is True
+
+
+async def test_read_ready_ignores_would_block() -> None:
+    """A spurious wakeup with no data is a no-op, not a disconnect."""
+    left, right = socket.socketpair()
+    received: list[bytes] = []
+    closed: list[Exception | None] = []
+    sock = await _connect(left, on_data=received.append, on_close=closed.append)
+    try:
+        sock._sock = Mock(recv=Mock(side_effect=BlockingIOError))
+        sock._read_ready()
+        assert received == []
+        assert closed == []
+        assert sock._closed is False
+    finally:
+        left.close()
+        right.close()
+
+
+async def test_read_ready_reports_socket_error() -> None:
+    """A read error tears the channel down and reports the exception once."""
+    left, right = socket.socketpair()
+    closed: list[Exception | None] = []
+    sock = await _connect(left, on_data=lambda _d: None, on_close=closed.append)
+    fd = sock._sock.fileno()
+    boom = OSError("boom")
+    sock._sock = Mock(recv=Mock(side_effect=boom), fileno=Mock(return_value=fd))
+    sock._read_ready()
+    assert closed == [boom]
+    assert sock._closed is True
+    left.close()
+    right.close()
+
+
+async def test_close_is_idempotent() -> None:
+    """Closing twice is safe and does not double-report."""
+    left, right = socket.socketpair()
+    closed: list[Exception | None] = []
+    sock = await _connect(left, on_data=lambda _d: None, on_close=closed.append)
+    sock.close()
+    sock.close()
+    # A subsequent failure does not call on_close again.
+    sock._fail(None)
+    assert closed == []
+    right.close()
+
+
+async def test_set_result_if_pending_is_idempotent() -> None:
+    """Resolving an already-finished future is a no-op."""
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future[None] = loop.create_future()
+    _set_result_if_pending(fut)
+    _set_result_if_pending(fut)
+    assert fut.result() is None


### PR DESCRIPTION
Adds channels/l2cap.py, the raw L2CAP ATT socket transport for the kernel backend; it opens a connection oriented L2CAP socket to a peer on the ATT fixed channel (CID 0x0004) and exposes it as an asyncio push transport, one SEQPACKET datagram in, one ATT PDU out, which is what feeds the ATTClient codec.

CPython's socket module cannot express sockaddr_l2 (no l2_cid or l2_bdaddr_type), so the address is packed by hand and bind/connect go through libc via ctypes on the raw fd; everything after the connect handshake is ordinary asyncio, add_reader for the inbound stream and sock_sendall for backpressured writes. BT_SECURITY is requested before connect so the kernel drives LE encryption when bonded keys exist; pass security_level 0 to skip it.

Nothing imports this yet; it lands ahead of the GATT client. The libc bind/connect and the BT_SECURITY setsockopt are the only Bluetooth specific lines, marked as platform glue; the orchestration around them is exercised over an ordinary socket pair so the module is unit tested without hardware at 100 percent coverage.