### PR TITLE
feat: add l2cap gatt client backend

### DIFF
--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -94,7 +94,16 @@ class HaMgmtClient(BaseBleakClient):
         self._adapter_address = client_data.adapter_address
         self._scanner = client_data.scanner
         details = getattr(address_or_ble_device, "details", None) or {}
-        self._address_type: int = details.get("address_type", BDADDR_LE_PUBLIC)
+        if "address_type" in details:
+            self._address_type: int = details["address_type"]
+        else:
+            # Adverts always carry the peer address type, so the scanner should
+            # populate it; fall back to public but log so a missing field is not
+            # only visible as an opaque L2CAP connect timeout later.
+            self._address_type = BDADDR_LE_PUBLIC
+            _LOGGER.debug(
+                "%s: no address_type in details; assuming LE public", self.address
+            )
         self._att: ATTClient | None = None
         self._sock: L2CAPSocket | None = None
         self._connected = False

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -170,6 +170,11 @@ class HaMgmtClient(BaseBleakClient):
 
     def _handle_disconnect(self, exc: Exception | None) -> None:
         """Tear the channel down once and notify on an unexpected drop."""
+        if exc is not None:
+            # The codec only passes a cause on an unexpected drop; a deliberate
+            # disconnect() passes None and stays silent. bleak's callback takes
+            # no args, so this log is the only place the reason can surface.
+            _LOGGER.debug("%s: L2CAP/ATT channel lost: %s", self.address, exc)
         was_connected = self._connected
         self._connected = False
         self._att = None

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -1,0 +1,290 @@
+"""
+Kernel/L2CAP GATT client backend (bleak ``BaseBleakClient``).
+
+``HaMgmtClient`` is a bleak-compatible client that talks to a peripheral over a
+raw L2CAP ATT channel instead of going through bluetoothd/DBus. It wires the
+:class:`~habluetooth.channels.l2cap.L2CAPSocket` transport to the
+:class:`~habluetooth.channels.att.ATTClient` codec, runs MTU exchange and GATT
+discovery on connect, and translates the discovered tree into bleak's unified
+GATT model so existing integrations can use it unchanged.
+
+It is **not** wired into Home Assistant: the scanner selection still builds the
+DBus-backed ``HaScanner`` and bleak's platform client. This module is the
+connect-side backend that a later mgmt scanner / factory change will route to;
+on its own nothing imports it, so it has no effect on the running system.
+
+Pairing is intentionally out of scope here. ``pair``/``unpair`` raise, and
+``connect`` ignores the ``pair`` flag; the kernel still drives LE encryption
+from bonded keys via the socket's ``BT_SECURITY`` level. Mgmt-driven bonding
+lands in a follow-up alongside the mgmt connect/pairing commands.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from bleak import BleakError
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.client import BaseBleakClient
+from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.backends.service import BleakGATTService, BleakGATTServiceCollection
+
+from .channels.att import (
+    CCCD_UUID,
+    DEFAULT_MTU,
+    PREFERRED_MTU,
+    ATTClient,
+    properties_to_strings,
+)
+from .channels.l2cap import L2CAPSocket
+from .const import BDADDR_LE_PUBLIC
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from contextlib import AbstractContextManager
+
+    from bleak.args import SizedBuffer
+    from bleak.assigned_numbers import CharacteristicPropertyName
+    from bleak.backends.device import BLEDevice
+
+    from .channels.att import GattService
+
+
+class SupportsConnecting(Protocol):
+    """The slice of a scanner the client needs: a scan-pause context manager."""
+
+    def connecting(self) -> AbstractContextManager[None]:
+        """Pause scanning for the duration of a connection attempt."""
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# Fallback connect timeout; the bleak wrapper always supplies ``timeout``.
+DEFAULT_TIMEOUT = 10.0
+
+# Client Characteristic Configuration Descriptor payloads (Core Vol 3 Part G).
+_CCCD_NOTIFY = b"\x01\x00"
+_CCCD_INDICATE = b"\x02\x00"
+_CCCD_OFF = b"\x00\x00"
+
+
+@dataclass(slots=True)
+class MgmtClientData:
+    """Per-connection wiring the mgmt scanner hands to each client instance."""
+
+    adapter_address: str  # local adapter BD_ADDR the L2CAP socket binds/sends from
+    scanner: SupportsConnecting  # provides connecting() to pause scanning
+
+
+class HaMgmtClient(BaseBleakClient):
+    """A bleak client that drives GATT over a raw L2CAP ATT channel."""
+
+    def __init__(
+        self,
+        address_or_ble_device: BLEDevice | str,
+        *args: Any,
+        client_data: MgmtClientData,
+        **kwargs: Any,
+    ) -> None:
+        """Bind the client to its peer address and adapter wiring."""
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+        super().__init__(address_or_ble_device, *args, **kwargs)
+        self._adapter_address = client_data.adapter_address
+        self._scanner = client_data.scanner
+        details = getattr(address_or_ble_device, "details", None) or {}
+        self._address_type: int = details.get("address_type", BDADDR_LE_PUBLIC)
+        self._att: ATTClient | None = None
+        self._sock: L2CAPSocket | None = None
+        self._connected = False
+
+    # -- properties --------------------------------------------------------
+    @property
+    def is_connected(self) -> bool:
+        """Whether the L2CAP/ATT channel is currently up."""
+        return self._connected
+
+    @property
+    def mtu_size(self) -> int:
+        """The negotiated ATT MTU, or the default until it is exchanged."""
+        return self._att.mtu if self._att is not None else DEFAULT_MTU
+
+    # -- connection --------------------------------------------------------
+    async def connect(self, pair: bool, **kwargs: Any) -> None:
+        """Open the L2CAP channel, exchange MTU, and discover services."""
+        if self._connected:
+            msg = "already connected"
+            raise BleakError(msg)
+        if pair:
+            _LOGGER.debug(
+                "%s: mgmt client does not pair on connect; relying on bonded keys",
+                self.address,
+            )
+        att = ATTClient(send=self._send_pdu, on_disconnect=self._handle_disconnect)
+        self._att = att
+        try:
+            with self._scanner.connecting():
+                self._sock = await L2CAPSocket.create_connection(
+                    source=self._adapter_address,
+                    address=self.address,
+                    address_type=self._address_type,
+                    on_data=att.data_received,
+                    on_close=att.connection_lost,
+                    timeout=self._timeout,
+                )
+                await att.exchange_mtu(PREFERRED_MTU)
+                services = await att.discover()
+        except BaseException:
+            self._handle_disconnect(None)
+            raise
+        self.services = self._build_services(services)
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        """Close the channel; idempotent."""
+        self._handle_disconnect(None)
+
+    async def _send_pdu(self, data: bytes) -> None:
+        """Write one ATT PDU through the transport (bound into the codec)."""
+        # _att is created before the socket, but its send is only driven after
+        # create_connection has returned and assigned _sock.
+        if self._sock is None:  # pragma: no cover - send only runs once connected
+            msg = "transport not connected"
+            raise BleakError(msg)
+        await self._sock.send(data)
+
+    def _handle_disconnect(self, exc: Exception | None) -> None:
+        """Tear the channel down once and notify on an unexpected drop."""
+        was_connected = self._connected
+        self._connected = False
+        self._att = None
+        if self._sock is not None:
+            # Idempotent: a transport-level drop already closed it; a request
+            # timeout poisons the codec without closing, so close it here.
+            self._sock.close()
+            self._sock = None
+        if was_connected and self._disconnected_callback is not None:
+            self._disconnected_callback()
+
+    # -- GATT model --------------------------------------------------------
+    def _build_services(
+        self, services: list[GattService]
+    ) -> BleakGATTServiceCollection:
+        """Translate the discovered tree into bleak's GATT collection."""
+        collection = BleakGATTServiceCollection()
+        for svc in services:
+            bleak_service = BleakGATTService(svc, svc.handle, svc.uuid)
+            collection.add_service(bleak_service)
+            for char in svc.characteristics:
+                bleak_char = BleakGATTCharacteristic(
+                    char,
+                    # Reads/writes target the value handle, so that is the
+                    # handle bleak resolves operations against.
+                    char.value_handle,
+                    char.uuid,
+                    cast(
+                        "list[CharacteristicPropertyName]",
+                        properties_to_strings(char.properties),
+                    ),
+                    self._max_write_without_response_size,
+                    bleak_service,
+                )
+                collection.add_characteristic(bleak_char)
+                for desc in char.descriptors:
+                    collection.add_descriptor(
+                        BleakGATTDescriptor(desc, desc.handle, desc.uuid, bleak_char)
+                    )
+        return collection
+
+    def _max_write_without_response_size(self) -> int:
+        """Largest write-without-response payload for the current MTU."""
+        return self.mtu_size - 3
+
+    # -- GATT operations ---------------------------------------------------
+    async def read_gatt_char(
+        self,
+        characteristic: BleakGATTCharacteristic,
+        *,
+        use_cached: bool = False,
+        **kwargs: Any,
+    ) -> bytearray:
+        """Read a characteristic value by its value handle."""
+        return bytearray(await self._codec().read(characteristic.handle))
+
+    async def read_gatt_descriptor(
+        self,
+        descriptor: BleakGATTDescriptor,
+        *,
+        use_cached: bool = False,
+        **kwargs: Any,
+    ) -> bytearray:
+        """Read a descriptor value by its handle."""
+        return bytearray(await self._codec().read(descriptor.handle))
+
+    async def write_gatt_char(
+        self,
+        characteristic: BleakGATTCharacteristic,
+        data: SizedBuffer,
+        response: bool,
+    ) -> None:
+        """Write a characteristic value, with or without a response."""
+        codec = self._codec()
+        if response:
+            await codec.write(characteristic.handle, bytes(data))
+        else:
+            await codec.write_command(characteristic.handle, bytes(data))
+
+    async def write_gatt_descriptor(
+        self, descriptor: BleakGATTDescriptor, data: SizedBuffer
+    ) -> None:
+        """Write a descriptor value with a response."""
+        await self._codec().write(descriptor.handle, bytes(data))
+
+    async def start_notify(
+        self,
+        characteristic: BleakGATTCharacteristic,
+        callback: Callable[[bytearray], None],
+        **kwargs: Any,
+    ) -> None:
+        """Enable notifications/indications by writing the CCCD and routing them."""
+        codec = self._codec()
+        if "notify" in characteristic.properties:
+            cccd_value = _CCCD_NOTIFY
+        elif "indicate" in characteristic.properties:
+            cccd_value = _CCCD_INDICATE
+        else:
+            msg = "characteristic does not support notify or indicate"
+            raise BleakError(msg)
+        cccd = characteristic.get_descriptor(CCCD_UUID)
+        if cccd is None:
+            msg = "characteristic has no client configuration descriptor"
+            raise BleakError(msg)
+        codec.set_notify_handler(characteristic.handle, callback)
+        await codec.write(cccd.handle, cccd_value)
+
+    async def stop_notify(self, characteristic: BleakGATTCharacteristic) -> None:
+        """Disable notifications by clearing the CCCD and dropping the handler."""
+        codec = self._codec()
+        cccd = characteristic.get_descriptor(CCCD_UUID)
+        if cccd is not None:
+            await codec.write(cccd.handle, _CCCD_OFF)
+        codec.remove_notify_handler(characteristic.handle)
+
+    # -- pairing (not yet supported) --------------------------------------
+    async def pair(self, *args: Any, **kwargs: Any) -> None:
+        """Pairing via mgmt is not implemented yet."""
+        msg = "pairing is not supported by the mgmt client yet"
+        raise NotImplementedError(msg)
+
+    async def unpair(self) -> None:
+        """Unpairing via mgmt is not implemented yet."""
+        msg = "unpairing is not supported by the mgmt client yet"
+        raise NotImplementedError(msg)
+
+    def _codec(self) -> ATTClient:
+        """Return the live ATT codec or raise if the channel is down."""
+        if self._att is None or not self._connected:
+            msg = "not connected"
+            raise BleakError(msg)
+        return self._att

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -142,7 +142,12 @@ class HaMgmtClient(BaseBleakClient):
         self._connected = True
 
     async def disconnect(self) -> None:
-        """Close the channel; idempotent."""
+        """
+        Close the channel; idempotent.
+
+        Like the BlueZ backend this replaces (and unlike CoreBluetooth/WinRT),
+        a deliberate disconnect also fires the disconnected callback.
+        """
         self._handle_disconnect(None)
 
     async def _send_pdu(self, data: bytes) -> None:
@@ -260,8 +265,15 @@ class HaMgmtClient(BaseBleakClient):
         if cccd is None:
             msg = "characteristic has no client configuration descriptor"
             raise BleakError(msg)
+        # Register before enabling so a notification racing in right after the
+        # CCCD write is not lost; unwind if the write fails so no handler is left
+        # registered for notifications that were never enabled.
         codec.set_notify_handler(characteristic.handle, callback)
-        await codec.write(cccd.handle, cccd_value)
+        try:
+            await codec.write(cccd.handle, cccd_value)
+        except BaseException:
+            codec.remove_notify_handler(characteristic.handle)
+            raise
 
     async def stop_notify(self, characteristic: BleakGATTCharacteristic) -> None:
         """Disable notifications by clearing the CCCD and dropping the handler."""

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -436,3 +436,15 @@ async def test_mtu_size_default_before_connect() -> None:
     """Before connect the MTU reports the ATT default."""
     client, _scanner = _make_client()
     assert client.mtu_size == 23
+
+
+async def test_address_type_falls_back_to_public_when_missing() -> None:
+    """A device without an address_type in details defaults to LE public."""
+    scanner = FakeScanner()
+    device = BLEDevice(_PEER, "test-device", {"source": _ADAPTER})  # no address_type
+    client = HaMgmtClient(
+        device,
+        client_data=MgmtClientData(adapter_address=_ADAPTER, scanner=scanner),
+        timeout=5.0,
+    )
+    assert client._address_type == 0x01  # BDADDR_LE_PUBLIC

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -1,0 +1,408 @@
+"""Tests for the kernel/L2CAP GATT client backend."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bleak import BleakError
+from bleak.backends.device import BLEDevice
+
+from habluetooth.client_mgmt import HaMgmtClient, MgmtClientData
+from habluetooth.const import BDADDR_LE_RANDOM
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+    from bleak.backends.characteristic import BleakGATTCharacteristic
+
+_CHAR_UUID = "00002a37-0000-1000-8000-00805f9b34fb"
+_SERVICE_UUID = "0000180d-0000-1000-8000-00805f9b34fb"
+_CCCD_DESC_UUID = "00002902-0000-1000-8000-00805f9b34fb"
+
+pytestmark = pytest.mark.asyncio
+
+_ADAPTER = "00:11:22:33:44:55"
+_PEER = "AA:BB:CC:DD:EE:FF"
+
+# Opcodes used to build server responses.
+_ERROR_RSP = 0x01
+_MTU_RSP = 0x03
+_FIND_INFO_RSP = 0x05
+_READ_BY_TYPE_RSP = 0x09
+_READ_RSP = 0x0B
+_READ_BY_GROUP_TYPE_RSP = 0x11
+_WRITE_RSP = 0x13
+_NTF = 0x1B
+_ERR_ATTRIBUTE_NOT_FOUND = 0x0A
+
+# Discovered layout: heart-rate service 0x180D with one characteristic 0x2A37
+# (value handle 0x0003) and, when present, a CCCD at 0x0004.
+_CHAR_READ_NOTIFY = 0x12
+_VALUE = b"\x01\x02\x03"
+
+
+def _error(req_opcode: int, handle: int, code: int) -> bytes:
+    return (
+        bytes([_ERROR_RSP, req_opcode]) + handle.to_bytes(2, "little") + bytes([code])
+    )
+
+
+def make_responder(
+    char_props: int = _CHAR_READ_NOTIFY, *, has_cccd: bool = True
+) -> Callable[[bytes], bytes | None]:
+    """Build a minimal ATT server for one service/characteristic."""
+    svc_end = 0x0004 if has_cccd else 0x0003
+
+    def services(req: bytes) -> bytes:  # READ_BY_GROUP_TYPE_REQ
+        if int.from_bytes(req[1:3], "little") > 0x0001:
+            return _error(0x10, 0x0001, _ERR_ATTRIBUTE_NOT_FOUND)
+        entry = (
+            (0x0001).to_bytes(2, "little")
+            + svc_end.to_bytes(2, "little")
+            + (0x180D).to_bytes(2, "little")
+        )
+        return bytes([_READ_BY_GROUP_TYPE_RSP, len(entry)]) + entry
+
+    def characteristics(req: bytes) -> bytes:  # READ_BY_TYPE_REQ
+        if int.from_bytes(req[1:3], "little") > 0x0002:
+            return _error(0x08, 0x0002, _ERR_ATTRIBUTE_NOT_FOUND)
+        value = (
+            bytes([char_props])
+            + (0x0003).to_bytes(2, "little")
+            + (0x2A37).to_bytes(2, "little")
+        )
+        entry = (0x0002).to_bytes(2, "little") + value
+        return bytes([_READ_BY_TYPE_RSP, len(entry)]) + entry
+
+    def descriptors(req: bytes) -> bytes:  # FIND_INFORMATION_REQ
+        if int.from_bytes(req[1:3], "little") > 0x0004:
+            return _error(0x04, 0x0004, _ERR_ATTRIBUTE_NOT_FOUND)
+        entry = (0x0004).to_bytes(2, "little") + (0x2902).to_bytes(2, "little")
+        return bytes([_FIND_INFO_RSP, 0x01]) + entry
+
+    handlers: dict[int, Callable[[bytes], bytes | None]] = {
+        0x02: lambda _req: bytes([_MTU_RSP]) + (247).to_bytes(2, "little"),
+        0x10: services,
+        0x08: characteristics,
+        0x04: descriptors,
+        0x0A: lambda _req: bytes([_READ_RSP]) + _VALUE,  # READ_REQ
+        0x12: lambda _req: bytes([_WRITE_RSP]),  # WRITE_REQ
+        0x52: lambda _req: None,  # WRITE_CMD (no response)
+    }
+
+    def responder(req: bytes) -> bytes | None:
+        if (handler := handlers.get(req[0])) is None:
+            msg = f"unexpected request opcode 0x{req[0]:02x}"
+            raise AssertionError(msg)
+        return handler(req)
+
+    return responder
+
+
+class FakeTransport:
+    """Stand-in for L2CAPSocket that answers ATT PDUs from a responder."""
+
+    def __init__(
+        self,
+        responder: Callable[[bytes], bytes | None],
+        on_data: Callable[[bytes], None],
+        on_close: Callable[[Exception | None], None],
+    ) -> None:
+        self._responder = responder
+        self._on_data = on_data
+        self._on_close = on_close
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    async def send(self, data: bytes) -> None:
+        self.sent.append(bytes(data))
+        if (resp := self._responder(bytes(data))) is not None:
+            self._on_data(resp)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def inject(self, data: bytes) -> None:
+        """Simulate a server-initiated PDU (e.g. a notification)."""
+        self._on_data(data)
+
+    def drop(self, exc: Exception | None = None) -> None:
+        """Simulate an unexpected transport failure."""
+        self._on_close(exc)
+
+
+class FakeScanner:
+    """Minimal scanner exposing the connecting() pause context manager."""
+
+    def __init__(self) -> None:
+        self.connecting_calls = 0
+
+    @contextmanager
+    def connecting(self) -> Generator[None, None, None]:
+        self.connecting_calls += 1
+        yield
+
+
+def _ble_device() -> BLEDevice:
+    return BLEDevice(
+        _PEER,
+        "test-device",
+        {"source": _ADAPTER, "address_type": BDADDR_LE_RANDOM},
+    )
+
+
+@contextmanager
+def _patch_transport(
+    responder: Callable[[bytes], bytes | None],
+    holder: dict[str, FakeTransport],
+) -> Generator[None, None, None]:
+    async def fake_create_connection(
+        *,
+        on_data: Callable[[bytes], None],
+        on_close: Callable[[Exception | None], None],
+        **_kwargs: object,
+    ) -> FakeTransport:
+        transport = FakeTransport(responder, on_data, on_close)
+        holder["transport"] = transport
+        return transport
+
+    with patch(
+        "habluetooth.client_mgmt.L2CAPSocket.create_connection",
+        fake_create_connection,
+    ):
+        yield
+
+
+def _make_client(
+    disconnected_callback: Callable[[], None] | None = None,
+) -> tuple[HaMgmtClient, FakeScanner]:
+    scanner = FakeScanner()
+    client = HaMgmtClient(
+        _ble_device(),
+        client_data=MgmtClientData(adapter_address=_ADAPTER, scanner=scanner),
+        timeout=5.0,
+        disconnected_callback=disconnected_callback,
+    )
+    return client, scanner
+
+
+async def _connect(
+    holder: dict[str, FakeTransport],
+    responder: Callable[[bytes], bytes | None] | None = None,
+    disconnected_callback: Callable[[], None] | None = None,
+) -> tuple[HaMgmtClient, FakeScanner]:
+    client, scanner = _make_client(disconnected_callback)
+    with _patch_transport(responder or make_responder(), holder):
+        await client.connect(False)
+    return client, scanner
+
+
+def _char(client: HaMgmtClient) -> BleakGATTCharacteristic:
+    """Return the discovered 0x2A37 characteristic (asserts it was discovered)."""
+    assert client.services is not None
+    char = client.services.get_characteristic(_CHAR_UUID)
+    assert char is not None
+    return char
+
+
+# -- connect / discover ---------------------------------------------------
+async def test_connect_discovers_services() -> None:
+    """Connect opens the channel, exchanges MTU, and builds the GATT tree."""
+    holder: dict[str, FakeTransport] = {}
+    client, scanner = await _connect(holder)
+    assert client.is_connected is True
+    assert client.mtu_size == 247
+    assert scanner.connecting_calls == 1
+    services = client.services
+    assert services is not None
+    assert services.get_service(_SERVICE_UUID) is not None
+    char = _char(client)
+    assert char.handle == 0x0003  # value handle drives operations
+    assert "notify" in char.properties
+    assert char.get_descriptor(_CCCD_DESC_UUID) is not None
+    assert char.max_write_without_response_size == 244  # MTU 247 - 3
+
+
+async def test_connect_rejects_when_already_connected() -> None:
+    """A second connect on a live client raises rather than re-linking."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    with pytest.raises(BleakError, match="already connected"):
+        await client.connect(False)
+
+
+async def test_connect_ignores_pair_flag() -> None:
+    """connect(pair=True) still connects; mgmt pairing is deferred."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = _make_client()
+    with _patch_transport(make_responder(), holder):
+        await client.connect(True)
+    assert client.is_connected is True
+
+
+async def test_connect_failure_tears_down() -> None:
+    """A transport failure during connect leaves the client disconnected."""
+    client, _scanner = _make_client()
+
+    async def boom(**_kwargs: object) -> FakeTransport:
+        raise OSError(113, "No route to host")
+
+    with (
+        patch("habluetooth.client_mgmt.L2CAPSocket.create_connection", boom),
+        pytest.raises(OSError, match="No route to host"),
+    ):
+        await client.connect(False)
+    assert client.is_connected is False
+    assert client.mtu_size == 23
+
+
+# -- GATT operations ------------------------------------------------------
+async def test_read_gatt_char() -> None:
+    """Reading a characteristic returns the value as a bytearray."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    assert await client.read_gatt_char(_char(client)) == bytearray(_VALUE)
+
+
+async def test_read_gatt_descriptor() -> None:
+    """Reading a descriptor returns the value as a bytearray."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    cccd = _char(client).get_descriptor(_CCCD_DESC_UUID)
+    assert cccd is not None
+    assert await client.read_gatt_descriptor(cccd) == bytearray(_VALUE)
+
+
+async def test_write_gatt_char_with_response() -> None:
+    """A write with response uses a Write Request."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    await client.write_gatt_char(_char(client), b"\xaa", response=True)
+    assert holder["transport"].sent[-1] == b"\x12\x03\x00\xaa"  # WRITE_REQ
+
+
+async def test_write_gatt_char_without_response() -> None:
+    """A write without response uses a Write Command (no reply expected)."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    await client.write_gatt_char(_char(client), b"\xbb", response=False)
+    assert holder["transport"].sent[-1] == b"\x52\x03\x00\xbb"  # WRITE_CMD
+
+
+async def test_write_gatt_descriptor() -> None:
+    """Writing a descriptor uses a Write Request against its handle."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    cccd = _char(client).get_descriptor(_CCCD_DESC_UUID)
+    assert cccd is not None
+    await client.write_gatt_descriptor(cccd, b"\x01\x00")
+    assert holder["transport"].sent[-1] == b"\x12\x04\x00\x01\x00"
+
+
+# -- notifications --------------------------------------------------------
+async def test_start_notify_writes_cccd_and_routes() -> None:
+    """start_notify writes the notify CCCD and delivers inbound notifications."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    received: list[bytearray] = []
+    await client.start_notify(_char(client), received.append)
+    assert holder["transport"].sent[-1] == b"\x12\x04\x00\x01\x00"  # CCCD notify
+    holder["transport"].inject(bytes([_NTF]) + (0x0003).to_bytes(2, "little") + b"\x09")
+    assert received == [bytearray(b"\x09")]
+
+
+async def test_start_notify_uses_indicate_when_only_indicate() -> None:
+    """An indicate-only characteristic gets the indicate CCCD value."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder, make_responder(0x20))  # indicate only
+    await client.start_notify(_char(client), lambda _d: None)
+    assert holder["transport"].sent[-1] == b"\x12\x04\x00\x02\x00"  # CCCD indicate
+
+
+async def test_start_notify_rejects_unsupported_characteristic() -> None:
+    """A characteristic without notify/indicate cannot be subscribed."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder, make_responder(0x02))  # read only
+    with pytest.raises(BleakError, match="notify or indicate"):
+        await client.start_notify(_char(client), lambda _d: None)
+
+
+async def test_start_notify_rejects_missing_cccd() -> None:
+    """A notifying characteristic with no CCCD descriptor is rejected."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder, make_responder(has_cccd=False))
+    with pytest.raises(BleakError, match="client configuration descriptor"):
+        await client.start_notify(_char(client), lambda _d: None)
+
+
+async def test_stop_notify_clears_cccd_and_handler() -> None:
+    """stop_notify clears the CCCD and stops routing notifications."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    char = _char(client)
+    received: list[bytearray] = []
+    await client.start_notify(char, received.append)
+    await client.stop_notify(char)
+    assert holder["transport"].sent[-1] == b"\x12\x04\x00\x00\x00"  # CCCD off
+    holder["transport"].inject(bytes([_NTF]) + (0x0003).to_bytes(2, "little") + b"\x09")
+    assert received == []  # handler removed, notification dropped
+
+
+async def test_stop_notify_without_cccd_only_drops_handler() -> None:
+    """stop_notify on a characteristic with no CCCD just drops the handler."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder, make_responder(has_cccd=False))
+    char = _char(client)
+    before = len(holder["transport"].sent)
+    await client.stop_notify(char)
+    assert len(holder["transport"].sent) == before  # no CCCD write attempted
+
+
+# -- disconnect / teardown ------------------------------------------------
+async def test_disconnect_closes_transport() -> None:
+    """Disconnect closes the socket and reports not connected."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    await client.disconnect()
+    assert holder["transport"].closed is True
+    assert client.is_connected is False
+
+
+async def test_unexpected_drop_fires_disconnected_callback() -> None:
+    """A transport drop tears down the client and fires the bleak callback."""
+    holder: dict[str, FakeTransport] = {}
+    fired: list[bool] = []
+    client, _scanner = await _connect(
+        holder, disconnected_callback=lambda: fired.append(True)
+    )
+    holder["transport"].drop(OSError("reset"))
+    assert fired == [True]
+    assert client.is_connected is False
+
+
+async def test_operations_raise_after_disconnect() -> None:
+    """GATT operations on a disconnected client raise a BleakError."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder)
+    char = _char(client)
+    await client.disconnect()
+    with pytest.raises(BleakError, match="not connected"):
+        await client.read_gatt_char(char)
+
+
+async def test_pair_and_unpair_not_supported() -> None:
+    """Pairing is not implemented in this client yet."""
+    client, _scanner = _make_client()
+    with pytest.raises(NotImplementedError, match="pairing"):
+        await client.pair()
+    with pytest.raises(NotImplementedError, match="unpairing"):
+        await client.unpair()
+
+
+async def test_mtu_size_default_before_connect() -> None:
+    """Before connect the MTU reports the ATT default."""
+    client, _scanner = _make_client()
+    assert client.mtu_size == 23

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -411,6 +412,18 @@ async def test_unexpected_drop_fires_disconnected_callback() -> None:
     holder["transport"].drop(OSError("reset"))
     assert fired == [True]
     assert client.is_connected is False
+
+
+async def test_unexpected_drop_logs_cause(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unexpected drop logs the originating cause for diagnosability."""
+    holder: dict[str, FakeTransport] = {}
+    _client, _scanner = await _connect(holder)
+    with caplog.at_level(logging.DEBUG, logger="habluetooth.client_mgmt"):
+        holder["transport"].drop(OSError("connection reset by peer"))
+    assert "channel lost" in caplog.text
+    assert "connection reset by peer" in caplog.text
 
 
 async def test_operations_raise_after_disconnect() -> None:

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -51,7 +51,10 @@ def _error(req_opcode: int, handle: int, code: int) -> bytes:
 
 
 def make_responder(
-    char_props: int = _CHAR_READ_NOTIFY, *, has_cccd: bool = True
+    char_props: int = _CHAR_READ_NOTIFY,
+    *,
+    has_cccd: bool = True,
+    fail_write: bool = False,
 ) -> Callable[[bytes], bytes | None]:
     """Build a minimal ATT server for one service/characteristic."""
     svc_end = 0x0004 if has_cccd else 0x0003
@@ -83,13 +86,16 @@ def make_responder(
         entry = (0x0004).to_bytes(2, "little") + (0x2902).to_bytes(2, "little")
         return bytes([_FIND_INFO_RSP, 0x01]) + entry
 
+    write_rsp = (
+        _error(0x12, 0x0004, 0x03) if fail_write else bytes([_WRITE_RSP])
+    )  # WRITE_REQ: an error (write not permitted) or success
     handlers: dict[int, Callable[[bytes], bytes | None]] = {
         0x02: lambda _req: bytes([_MTU_RSP]) + (247).to_bytes(2, "little"),
         0x10: services,
         0x08: characteristics,
         0x04: descriptors,
         0x0A: lambda _req: bytes([_READ_RSP]) + _VALUE,  # READ_REQ
-        0x12: lambda _req: bytes([_WRITE_RSP]),  # WRITE_REQ
+        0x12: lambda _req: write_rsp,
         0x52: lambda _req: None,  # WRITE_CMD (no response)
     }
 
@@ -351,6 +357,19 @@ async def test_stop_notify_clears_cccd_and_handler() -> None:
     assert received == []  # handler removed, notification dropped
 
 
+async def test_start_notify_unwinds_handler_on_cccd_write_failure() -> None:
+    """If the CCCD write fails, no notify handler is left registered."""
+    holder: dict[str, FakeTransport] = {}
+    client, _scanner = await _connect(holder, make_responder(fail_write=True))
+    char = _char(client)
+    received: list[bytearray] = []
+    with pytest.raises(BleakError):
+        await client.start_notify(char, received.append)
+    # The handler was unwound, so a stray notification is not delivered.
+    holder["transport"].inject(bytes([_NTF]) + (0x0003).to_bytes(2, "little") + b"\x09")
+    assert received == []
+
+
 async def test_stop_notify_without_cccd_only_drops_handler() -> None:
     """stop_notify on a characteristic with no CCCD just drops the handler."""
     holder: dict[str, FakeTransport] = {}
@@ -369,6 +388,17 @@ async def test_disconnect_closes_transport() -> None:
     await client.disconnect()
     assert holder["transport"].closed is True
     assert client.is_connected is False
+
+
+async def test_disconnect_fires_disconnected_callback() -> None:
+    """A deliberate disconnect fires the callback, matching the BlueZ backend."""
+    holder: dict[str, FakeTransport] = {}
+    fired: list[bool] = []
+    client, _scanner = await _connect(
+        holder, disconnected_callback=lambda: fired.append(True)
+    )
+    await client.disconnect()
+    assert fired == [True]
 
 
 async def test_unexpected_drop_fires_disconnected_callback() -> None:


### PR DESCRIPTION
Adds client_mgmt.py, HaMgmtClient, a bleak BaseBleakClient that drives GATT over the raw L2CAP ATT channel instead of bluetoothd/DBus. It wires the L2CAPSocket transport to the ATTClient codec, runs MTU exchange and service discovery on connect, and translates the discovered tree into bleak's unified GATT model so existing integrations work unchanged; read, write with and without response, descriptor read/write, and notify/indicate via the CCCD are all implemented.

This is not wired into Home Assistant; scanner selection still builds the DBus backed HaScanner and bleak's platform client, so there is no behavior change. Like the codec and the transport, nothing imports this module yet; it is the connect side backend a later mgmt scanner and factory change will route to.

Pairing is intentionally out of scope here; pair and unpair raise and connect ignores the pair flag, the kernel still drives LE encryption from bonded keys via the socket BT_SECURITY level. Mgmt driven bonding lands in a follow up alongside the mgmt connect and pairing commands. The reconnect GATT cache is deferred to the scanner that owns it.

Tested by driving the real ATTClient against a fake transport wired to a small in memory GATT server, covering connect and discovery, the value handle mapping, read and write paths, notify and indicate subscription and routing, teardown on disconnect and on unexpected drop, and the not connected and pairing guards; 100 percent line and branch coverage, full suite green.