### PR TITLE
feat: add mgmt-based local scanner and factory

### DIFF
--- a/src/habluetooth/__init__.py
+++ b/src/habluetooth/__init__.py
@@ -30,6 +30,7 @@ from .models import (
 )
 from .scanner_bleak import BluetoothScanningMode, HaScanner, ScannerStartError
 from .scanner_device import BluetoothScannerDevice
+from .scanner_mgmt import HaScannerMgmt, create_local_scanner
 from .storage import (
     DiscoveredDeviceAdvertisementData,
     DiscoveredDeviceAdvertisementDataDict,
@@ -66,11 +67,13 @@ __all__ = [
     "HaBluetoothSlotAllocations",
     "HaScanner",
     "HaScannerDetails",
+    "HaScannerMgmt",
     "HaScannerModeChange",
     "HaScannerRegistration",
     "HaScannerRegistrationEvent",
     "HaScannerType",
     "ScannerStartError",
+    "create_local_scanner",
     "discovered_device_advertisement_data_from_dict",
     "discovered_device_advertisement_data_to_dict",
     "expire_stale_scanner_discovered_device_advertisement_data",

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -157,7 +157,14 @@ class HaMgmtClient(BaseBleakClient):
         self.services = self._build_services(services)
         self._connected = True
         if self._register_connection is not None:
-            self._register_connection(self.address)
+            # Slot bookkeeping is best-effort; a failure must not undo a
+            # connection that is already established.
+            try:
+                self._register_connection(self.address)
+            except Exception:
+                _LOGGER.exception(
+                    "%s: connection slot register callback failed", self.address
+                )
 
     async def disconnect(self) -> None:
         """
@@ -194,7 +201,15 @@ class HaMgmtClient(BaseBleakClient):
             self._sock = None
         if was_connected:
             if self._unregister_connection is not None:
-                self._unregister_connection(self.address)
+                # Best-effort: a bookkeeping failure must not stop the
+                # disconnected callback from firing.
+                try:
+                    self._unregister_connection(self.address)
+                except Exception:
+                    _LOGGER.exception(
+                        "%s: connection slot unregister callback failed",
+                        self.address,
+                    )
             if self._disconnected_callback is not None:
                 self._disconnected_callback()
 

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -76,6 +76,11 @@ class MgmtClientData:
 
     adapter_address: str  # local adapter BD_ADDR the L2CAP socket binds/sends from
     scanner: SupportsConnecting  # provides connecting() to pause scanning
+    # Optional slot bookkeeping: the mgmt scanner tracks live connections itself
+    # (BleakSlotManager is DBus-path based and cannot see L2CAP connections), so
+    # the client reports connect/disconnect by peer address here.
+    register_connection: Callable[[str], None] | None = None
+    unregister_connection: Callable[[str], None] | None = None
 
 
 class HaMgmtClient(BaseBleakClient):
@@ -93,6 +98,8 @@ class HaMgmtClient(BaseBleakClient):
         super().__init__(address_or_ble_device, *args, **kwargs)
         self._adapter_address = client_data.adapter_address
         self._scanner = client_data.scanner
+        self._register_connection = client_data.register_connection
+        self._unregister_connection = client_data.unregister_connection
         details = getattr(address_or_ble_device, "details", None) or {}
         if "address_type" in details:
             self._address_type: int = details["address_type"]
@@ -149,6 +156,8 @@ class HaMgmtClient(BaseBleakClient):
             raise
         self.services = self._build_services(services)
         self._connected = True
+        if self._register_connection is not None:
+            self._register_connection(self.address)
 
     async def disconnect(self) -> None:
         """
@@ -183,8 +192,11 @@ class HaMgmtClient(BaseBleakClient):
             # timeout poisons the codec without closing, so close it here.
             self._sock.close()
             self._sock = None
-        if was_connected and self._disconnected_callback is not None:
-            self._disconnected_callback()
+        if was_connected:
+            if self._unregister_connection is not None:
+                self._unregister_connection(self.address)
+            if self._disconnected_callback is not None:
+                self._disconnected_callback()
 
     # -- GATT model --------------------------------------------------------
     def _build_services(

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -40,7 +40,6 @@ from bluetooth_adapters import DEFAULT_ADDRESS
 from .base_scanner import BaseHaScanner
 from .central_manager import get_manager
 from .client_mgmt import HaMgmtClient, MgmtClientData
-from .const import SOURCE_LOCAL
 from .models import BluetoothScanningMode, HaBluetoothConnector
 from .scanner_bleak import IS_LINUX, HaScanner, ScannerStartError, _resolve_radio_mode
 
@@ -74,8 +73,15 @@ class HaScannerMgmt(BaseHaScanner):
 
     def __init__(self, mode: BluetoothScanningMode, adapter: str, address: str) -> None:
         """Set up the scanner and wire connections to the mgmt GATT client."""
+        if address == DEFAULT_ADDRESS:
+            # The L2CAP connect path binds to this address to pin connections to
+            # the discovering adapter; without a real BD_ADDR it would bind to
+            # BDADDR_ANY and route through the wrong radio. Fail fast rather than
+            # mis-route (the factory already guards against this).
+            msg = "HaScannerMgmt requires a real adapter address, not DEFAULT_ADDRESS"
+            raise ValueError(msg)
         self.mac_address = address
-        source = address if address != DEFAULT_ADDRESS else adapter or SOURCE_LOCAL
+        source = address
         connector = HaBluetoothConnector(
             # partial-bind the per-connection data; the wrapper calls
             # connector.client(device, ...) like any backend class.
@@ -241,7 +247,9 @@ class HaScannerMgmt(BaseHaScanner):
             # Clamp at 0: a TOCTOU overshoot past the advisory gate must not
             # report negative free slots.
             max(0, slots - len(self._connections)),
-            list(self._connections),
+            # Sorted for stable output (the set order is arbitrary), so repeated
+            # reads do not look like allocation changes.
+            sorted(self._connections),
         )
 
     # -- discovered-device read-out ---------------------------------------
@@ -291,6 +299,10 @@ def create_local_scanner(
     A real ``address`` is required because the L2CAP connect path binds to it to
     pin connections to the adapter that discovered the device; a missing address
     would bind to ``BDADDR_ANY`` and let the kernel pick a different radio.
+
+    AUTO mode falls back to :class:`HaScanner`: the mgmt scanner does not yet
+    implement active-window promotion (``async_request_active_window``), so it
+    cannot satisfy AUTO's on-demand switch to active scanning.
     """
     manager = get_manager()
     mgmt = manager.get_bluez_mgmt_ctl()
@@ -300,6 +312,7 @@ def create_local_scanner(
         and mgmt.can_discover
         and adapter.startswith("hci")
         and address != DEFAULT_ADDRESS
+        and mode is not BluetoothScanningMode.AUTO
     ):
         return HaScannerMgmt(mode, adapter, address)
     return HaScanner(mode, adapter, address)

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -198,6 +198,16 @@ class HaScannerMgmt(BaseHaScanner):
         """Stop and start discovery again under the start/stop lock."""
         async with self._start_stop_lock:
             await self._async_stop_discovery()
+            if self._monitor_handle is not None:
+                # The passive monitor could not be removed; do not re-add one or
+                # we would stack (and leak) a second kernel monitor over the
+                # still-registered handle. The watchdog re-fires next tick to
+                # retry the removal.
+                _LOGGER.debug(
+                    "%s: monitor removal pending, deferring discovery restart",
+                    self.name,
+                )
+                return
             try:
                 await self._async_start()
             except ScannerStartError:

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -207,7 +207,15 @@ class HaScannerMgmt(BaseHaScanner):
         """Run a coroutine, keeping a reference so it is not GC'd mid-flight."""
         task = asyncio.create_task(coro)
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        task.add_done_callback(self._on_background_task_done)
+
+    def _on_background_task_done(self, task: asyncio.Task[None]) -> None:
+        """Drop the task reference and surface any escaped exception in logs."""
+        self._background_tasks.discard(task)
+        if not task.cancelled() and (exc := task.exception()) is not None:
+            # Otherwise this only shows up as asyncio's "Task exception was
+            # never retrieved" at GC time, which is easy to miss.
+            _LOGGER.error("%s: background task failed", self.name, exc_info=exc)
 
     # -- connection slots --------------------------------------------------
     def _can_connect(self) -> bool:

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -45,10 +45,12 @@ from .models import BluetoothScanningMode, HaBluetoothConnector
 from .scanner_bleak import IS_LINUX, HaScanner, ScannerStartError, _resolve_radio_mode
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine
+    from collections.abc import Coroutine, Iterable
     from typing import Any
 
     from bleak.backends.client import BaseBleakClient
+    from bleak.backends.device import BLEDevice
+    from bleak.backends.scanner import AdvertisementData
 
     from .const import CALLBACK_TYPE
 
@@ -139,12 +141,24 @@ class HaScannerMgmt(BaseHaScanner):
         idx = self.adapter_idx
         mgmt = get_manager().get_bluez_mgmt_ctl()
         if idx is None or mgmt is None:
+            # The controller went away with discovery possibly still running in
+            # the kernel; log so the orphaned state is observable.
+            _LOGGER.debug(
+                "%s: cannot stop discovery, mgmt controller unavailable", self.name
+            )
             return
         if self._monitor_handle is not None:
-            await mgmt.remove_adv_monitor(idx, self._monitor_handle)
-            self._monitor_handle = None
-        else:
-            await mgmt.stop_discovery(idx)
+            if await mgmt.remove_adv_monitor(idx, self._monitor_handle):
+                self._monitor_handle = None
+            else:
+                # Keep the handle so a later stop can retry rather than leak it.
+                _LOGGER.warning(
+                    "%s: failed to remove advertisement monitor %s",
+                    self.name,
+                    self._monitor_handle,
+                )
+        elif not await mgmt.stop_discovery(idx):
+            _LOGGER.warning("%s: failed to stop mgmt discovery", self.name)
 
     def _async_scanner_watchdog(self) -> None:
         """Restart discovery if the adapter has gone quiet."""
@@ -177,7 +191,14 @@ class HaScannerMgmt(BaseHaScanner):
 
     # -- connection slots --------------------------------------------------
     def _can_connect(self) -> bool:
-        """Whether a new connection fits within the adapter's slot budget."""
+        """
+        Whether a new connection fits within the adapter's slot budget.
+
+        This is an advisory gate, not a reservation: the slot is only recorded
+        once the client connects, so two attempts that both pass here before
+        either registers can overshoot the budget by one. The bleak slot path
+        has the same shape; it bounds, it does not strictly serialize.
+        """
         if not self.connectable:
             return False
         slots = self._slot_limit()
@@ -207,6 +228,39 @@ class HaScannerMgmt(BaseHaScanner):
             list(self._connections),
         )
 
+    # -- discovered-device read-out ---------------------------------------
+    # BaseHaScanner leaves these abstract; only remote scanners implement them.
+    # They are served from _previous_service_info (populated by the inherited
+    # ingestion path) so the manager's unavailable tracking, connect path, and
+    # diagnostics work once this scanner is registered.
+    @property
+    def discovered_devices(self) -> list[BLEDevice]:
+        """Return the devices seen so far."""
+        return [info.device for info in self._previous_service_info.values()]
+
+    @property
+    def discovered_devices_and_advertisement_data(
+        self,
+    ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
+        """Return each discovered device with its latest advertisement."""
+        return {
+            address: (info.device, info.advertisement)
+            for address, info in self._previous_service_info.items()
+        }
+
+    @property
+    def discovered_addresses(self) -> Iterable[str]:
+        """Return the addresses seen so far."""
+        return self._previous_service_info
+
+    def get_discovered_device_advertisement_data(
+        self, address: str
+    ) -> tuple[BLEDevice, AdvertisementData] | None:
+        """Return the device and advertisement for a discovered address."""
+        if (info := self._previous_service_info.get(address)) is not None:
+            return info.device, info.advertisement
+        return None
+
 
 def create_local_scanner(
     mode: BluetoothScanningMode, adapter: str, address: str
@@ -215,8 +269,12 @@ def create_local_scanner(
     Build the best local scanner for an adapter.
 
     Returns :class:`HaScannerMgmt` when mgmt discovery is available (Linux with a
-    usable management socket and an ``hciN`` adapter), otherwise the bleak-backed
-    :class:`HaScanner`.
+    usable management socket, an ``hciN`` adapter, and a real adapter BD_ADDR),
+    otherwise the bleak-backed :class:`HaScanner`.
+
+    A real ``address`` is required because the L2CAP connect path binds to it to
+    pin connections to the adapter that discovered the device; a missing address
+    would bind to ``BDADDR_ANY`` and let the kernel pick a different radio.
     """
     manager = get_manager()
     mgmt = manager.get_bluez_mgmt_ctl()
@@ -225,6 +283,7 @@ def create_local_scanner(
         and mgmt is not None
         and mgmt.can_discover
         and adapter.startswith("hci")
+        and address != DEFAULT_ADDRESS
     ):
         return HaScannerMgmt(mode, adapter, address)
     return HaScanner(mode, adapter, address)

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -57,6 +57,18 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+class _MgmtClientFactory(partial):  # type: ignore[type-arg]
+    """A functools.partial that binds per-connection data into HaMgmtClient."""
+
+
+# The connect path derives the backend id from
+# ``type(scanner.connector.client).__name__`` (wrappers.py); a bare partial
+# reads as the generic "partial", so name this factory after the client it
+# builds for clear connect diagnostics.
+_MgmtClientFactory.__name__ = "HaMgmtClient"
+_MgmtClientFactory.__qualname__ = "HaMgmtClient"
+
+
 class HaScannerMgmt(BaseHaScanner):
     """A local scanner that discovers and connects over the BlueZ mgmt socket."""
 
@@ -69,7 +81,7 @@ class HaScannerMgmt(BaseHaScanner):
             # connector.client(device, ...) like any backend class.
             client=cast(
                 "type[BaseBleakClient]",
-                partial(
+                _MgmtClientFactory(
                     HaMgmtClient,
                     client_data=MgmtClientData(
                         adapter_address=address,
@@ -124,7 +136,9 @@ class HaScannerMgmt(BaseHaScanner):
                 msg = f"{self.name}: failed to add advertisement monitor"
                 raise ScannerStartError(msg)
             self._monitor_handle = handle
-        self.current_mode = mode
+        # Use the setter so mode-change subscribers are notified, matching
+        # HaScanner.
+        self.set_current_mode(mode)
         self.scanning = True
         self._async_setup_scanner_watchdog()
         self._on_start_success()
@@ -224,7 +238,9 @@ class HaScannerMgmt(BaseHaScanner):
         return Allocations(
             self.adapter,
             slots,
-            slots - len(self._connections),
+            # Clamp at 0: a TOCTOU overshoot past the advisory gate must not
+            # report negative free slots.
+            max(0, slots - len(self._connections)),
             list(self._connections),
         )
 

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -1,0 +1,230 @@
+"""
+Local scanner driven entirely by the BlueZ management socket.
+
+EXPERIMENTAL: this module and its public names (``HaScannerMgmt`` and
+``create_local_scanner``) are a work in progress. The API is not stable and is
+likely to change or be renamed; nothing in Home Assistant selects this scanner
+yet, so do not depend on it.
+
+``HaScannerMgmt`` is the DBus-free counterpart to :class:`HaScanner`: it drives
+discovery through the kernel management socket (active discovery or a passive
+advertisement monitor) and routes connections through :class:`HaMgmtClient`
+over a raw L2CAP ATT channel. Advertisements arrive via the shared mgmt side
+channel, which the manager points at this scanner once it is registered (keyed
+by ``adapter_idx``), so the hot advert path is inherited unchanged from
+:class:`BaseHaScanner`.
+
+Connection slots are tracked here rather than in ``BleakSlotManager``: that
+manager counts connections by BlueZ DBus path, which an L2CAP connection never
+creates, so it cannot see mgmt connections. This scanner keeps its own set of
+live peer addresses and gates ``can_connect`` against the configured slot count
+(read from the slot manager purely as the limit).
+
+``create_local_scanner`` is the factory Home Assistant will call instead of
+constructing a scanner directly; it returns this scanner when mgmt discovery is
+available and falls back to the bleak-backed :class:`HaScanner` otherwise. Home
+Assistant is not wired to the factory yet, so nothing selects this scanner in
+production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from functools import partial
+from typing import TYPE_CHECKING, cast
+
+from bleak_retry_connector import Allocations
+from bluetooth_adapters import DEFAULT_ADDRESS
+
+from .base_scanner import BaseHaScanner
+from .central_manager import get_manager
+from .client_mgmt import HaMgmtClient, MgmtClientData
+from .const import SOURCE_LOCAL
+from .models import BluetoothScanningMode, HaBluetoothConnector
+from .scanner_bleak import IS_LINUX, HaScanner, ScannerStartError, _resolve_radio_mode
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from typing import Any
+
+    from bleak.backends.client import BaseBleakClient
+
+    from .const import CALLBACK_TYPE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HaScannerMgmt(BaseHaScanner):
+    """A local scanner that discovers and connects over the BlueZ mgmt socket."""
+
+    def __init__(self, mode: BluetoothScanningMode, adapter: str, address: str) -> None:
+        """Set up the scanner and wire connections to the mgmt GATT client."""
+        self.mac_address = address
+        source = address if address != DEFAULT_ADDRESS else adapter or SOURCE_LOCAL
+        connector = HaBluetoothConnector(
+            # partial-bind the per-connection data; the wrapper calls
+            # connector.client(device, ...) like any backend class.
+            client=cast(
+                "type[BaseBleakClient]",
+                partial(
+                    HaMgmtClient,
+                    client_data=MgmtClientData(
+                        adapter_address=address,
+                        scanner=self,
+                        register_connection=self._register_connection,
+                        unregister_connection=self._unregister_connection,
+                    ),
+                ),
+            ),
+            source=source,
+            can_connect=self._can_connect,
+        )
+        super().__init__(source, adapter, connector=connector, requested_mode=mode)
+        self.connectable = True
+        self.scanning = False
+        self._start_stop_lock = asyncio.Lock()
+        self._monitor_handle: int | None = None
+        self._connections: set[str] = set()
+        self._background_tasks: set[asyncio.Task[Any]] = set()
+
+    # -- lifecycle ---------------------------------------------------------
+    def async_setup(self) -> CALLBACK_TYPE:
+        """Set up the scanner and return the teardown callback."""
+        super().async_setup()
+        return self._unsetup
+
+    def _unsetup(self) -> None:
+        """Tear down the expiry timer and the watchdog."""
+        super()._unsetup()
+        self._async_stop_scanner_watchdog()
+
+    async def async_start(self) -> None:
+        """Start mgmt discovery for this adapter."""
+        async with self._start_stop_lock:
+            await self._async_start()
+
+    async def _async_start(self) -> None:
+        """Issue the discovery/monitor command and arm the watchdog."""
+        idx = self.adapter_idx
+        mgmt = self._manager.get_bluez_mgmt_ctl() if self._manager else None
+        if idx is None or mgmt is None or not mgmt.can_discover:
+            msg = f"{self.name}: mgmt discovery is not available"
+            raise ScannerStartError(msg)
+        mode = _resolve_radio_mode(self.requested_mode or BluetoothScanningMode.PASSIVE)
+        if mode is BluetoothScanningMode.ACTIVE:
+            if not await mgmt.start_discovery(idx):
+                msg = f"{self.name}: failed to start mgmt discovery"
+                raise ScannerStartError(msg)
+        else:
+            handle = await mgmt.add_adv_pattern_monitor(idx)
+            if handle is None:
+                msg = f"{self.name}: failed to add advertisement monitor"
+                raise ScannerStartError(msg)
+            self._monitor_handle = handle
+        self.current_mode = mode
+        self.scanning = True
+        self._async_setup_scanner_watchdog()
+        self._on_start_success()
+
+    async def async_stop(self) -> None:
+        """Stop mgmt discovery and the watchdog."""
+        async with self._start_stop_lock:
+            self._async_stop_scanner_watchdog()
+            await self._async_stop_discovery()
+            self.scanning = False
+
+    async def _async_stop_discovery(self) -> None:
+        """Stop the active discovery or remove the passive monitor."""
+        idx = self.adapter_idx
+        mgmt = self._manager.get_bluez_mgmt_ctl() if self._manager else None
+        if idx is None or mgmt is None:
+            return
+        if self._monitor_handle is not None:
+            await mgmt.remove_adv_monitor(idx, self._monitor_handle)
+            self._monitor_handle = None
+        else:
+            await mgmt.stop_discovery(idx)
+
+    def _async_scanner_watchdog(self) -> None:
+        """Restart discovery if the adapter has gone quiet."""
+        if not self._async_watchdog_triggered():
+            return
+        if self._start_stop_lock.locked():
+            return
+        _LOGGER.debug(
+            "%s: mgmt scanner quiet for %ss, restarting discovery",
+            self.name,
+            self.time_since_last_detection(),
+        )
+        self.scanning = False
+        self._create_background_task(self._async_restart())
+
+    async def _async_restart(self) -> None:
+        """Stop and start discovery again under the start/stop lock."""
+        async with self._start_stop_lock:
+            await self._async_stop_discovery()
+            try:
+                await self._async_start()
+            except ScannerStartError:
+                _LOGGER.exception("%s: failed to restart mgmt discovery", self.name)
+
+    def _create_background_task(self, coro: Coroutine[Any, Any, None]) -> None:
+        """Run a coroutine, keeping a reference so it is not GC'd mid-flight."""
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    # -- connection slots --------------------------------------------------
+    def _can_connect(self) -> bool:
+        """Whether a new connection fits within the adapter's slot budget."""
+        if not self.connectable:
+            return False
+        slots = self._slot_limit()
+        return slots == 0 or len(self._connections) < slots
+
+    def _slot_limit(self) -> int:
+        """Configured connection-slot count for this adapter (0 if unregistered)."""
+        return self._manager.slot_manager.get_allocations(self.adapter).slots
+
+    def _register_connection(self, address: str) -> None:
+        """Record a live connection (called by the client on connect)."""
+        self._connections.add(address)
+
+    def _unregister_connection(self, address: str) -> None:
+        """Drop a connection (called by the client on disconnect)."""
+        self._connections.discard(address)
+
+    def get_allocations(self) -> Allocations | None:
+        """Report slot usage from this scanner's own connection tracking."""
+        slots = self._slot_limit()
+        if not slots:
+            return None
+        return Allocations(
+            self.adapter,
+            slots,
+            slots - len(self._connections),
+            list(self._connections),
+        )
+
+
+def create_local_scanner(
+    mode: BluetoothScanningMode, adapter: str, address: str
+) -> BaseHaScanner:
+    """
+    Build the best local scanner for an adapter.
+
+    Returns :class:`HaScannerMgmt` when mgmt discovery is available (Linux with a
+    usable management socket and an ``hciN`` adapter), otherwise the bleak-backed
+    :class:`HaScanner`.
+    """
+    manager = get_manager()
+    mgmt = manager.get_bluez_mgmt_ctl()
+    if (
+        IS_LINUX
+        and mgmt is not None
+        and mgmt.can_discover
+        and adapter.startswith("hci")
+    ):
+        return HaScannerMgmt(mode, adapter, address)
+    return HaScanner(mode, adapter, address)

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -107,7 +107,7 @@ class HaScannerMgmt(BaseHaScanner):
     async def _async_start(self) -> None:
         """Issue the discovery/monitor command and arm the watchdog."""
         idx = self.adapter_idx
-        mgmt = self._manager.get_bluez_mgmt_ctl() if self._manager else None
+        mgmt = get_manager().get_bluez_mgmt_ctl()
         if idx is None or mgmt is None or not mgmt.can_discover:
             msg = f"{self.name}: mgmt discovery is not available"
             raise ScannerStartError(msg)
@@ -137,7 +137,7 @@ class HaScannerMgmt(BaseHaScanner):
     async def _async_stop_discovery(self) -> None:
         """Stop the active discovery or remove the passive monitor."""
         idx = self.adapter_idx
-        mgmt = self._manager.get_bluez_mgmt_ctl() if self._manager else None
+        mgmt = get_manager().get_bluez_mgmt_ctl()
         if idx is None or mgmt is None:
             return
         if self._monitor_handle is not None:
@@ -185,7 +185,7 @@ class HaScannerMgmt(BaseHaScanner):
 
     def _slot_limit(self) -> int:
         """Configured connection-slot count for this adapter (0 if unregistered)."""
-        return self._manager.slot_manager.get_allocations(self.adapter).slots
+        return get_manager().slot_manager.get_allocations(self.adapter).slots
 
     def _register_connection(self, address: str) -> None:
         """Record a live connection (called by the client on connect)."""

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -391,6 +391,29 @@ async def test_disconnect_closes_transport() -> None:
     assert client.is_connected is False
 
 
+async def test_connection_register_callbacks_fire() -> None:
+    """The client reports connect/disconnect to the scanner's slot callbacks."""
+    holder: dict[str, FakeTransport] = {}
+    registered: list[str] = []
+    unregistered: list[str] = []
+    client = HaMgmtClient(
+        _ble_device(),
+        client_data=MgmtClientData(
+            adapter_address=_ADAPTER,
+            scanner=FakeScanner(),
+            register_connection=registered.append,
+            unregister_connection=unregistered.append,
+        ),
+        timeout=5.0,
+    )
+    with _patch_transport(make_responder(), holder):
+        await client.connect(False)
+    assert registered == [_PEER]
+    assert unregistered == []
+    await client.disconnect()
+    assert unregistered == [_PEER]
+
+
 async def test_disconnect_fires_disconnected_callback() -> None:
     """A deliberate disconnect fires the callback, matching the BlueZ backend."""
     holder: dict[str, FakeTransport] = {}

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -414,6 +414,54 @@ async def test_connection_register_callbacks_fire() -> None:
     assert unregistered == [_PEER]
 
 
+async def test_register_callback_failure_does_not_break_connect() -> None:
+    """A raising slot register callback is swallowed; the connection survives."""
+    holder: dict[str, FakeTransport] = {}
+
+    def boom(_address: str) -> None:
+        msg = "bookkeeping broke"
+        raise RuntimeError(msg)
+
+    client = HaMgmtClient(
+        _ble_device(),
+        client_data=MgmtClientData(
+            adapter_address=_ADAPTER,
+            scanner=FakeScanner(),
+            register_connection=boom,
+        ),
+        timeout=5.0,
+    )
+    with _patch_transport(make_responder(), holder):
+        await client.connect(False)
+    assert client.is_connected is True
+
+
+async def test_unregister_callback_failure_still_fires_disconnect() -> None:
+    """A raising slot unregister callback does not block the disconnect callback."""
+    holder: dict[str, FakeTransport] = {}
+    fired: list[bool] = []
+
+    def boom(_address: str) -> None:
+        msg = "bookkeeping broke"
+        raise RuntimeError(msg)
+
+    client = HaMgmtClient(
+        _ble_device(),
+        client_data=MgmtClientData(
+            adapter_address=_ADAPTER,
+            scanner=FakeScanner(),
+            unregister_connection=boom,
+        ),
+        timeout=5.0,
+        disconnected_callback=lambda: fired.append(True),
+    )
+    with _patch_transport(make_responder(), holder):
+        await client.connect(False)
+    holder["transport"].drop(OSError("reset"))
+    assert fired == [True]
+    assert client.is_connected is False
+
+
 async def test_disconnect_fires_disconnected_callback() -> None:
     """A deliberate disconnect fires the callback, matching the BlueZ backend."""
     holder: dict[str, FakeTransport] = {}

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -128,6 +128,9 @@ async def test_init_is_connectable_with_connector() -> None:
     assert scanner.connector is not None
     assert scanner.connector.source == _ADDRESS
     assert scanner.connector.can_connect == scanner._can_connect
+    # The connect path derives the backend id from this; it should read as the
+    # client, not the generic "partial".
+    assert type(scanner.connector.client).__name__ == "HaMgmtClient"
 
 
 # -- discovery lifecycle --------------------------------------------------
@@ -139,6 +142,16 @@ async def test_async_start_active_uses_start_discovery(use_mgmt: FakeMgmt) -> No
     assert use_mgmt.started == [_ADAPTER_IDX]
     assert scanner.scanning is True
     assert scanner.current_mode is BluetoothScanningMode.ACTIVE
+    await scanner.async_stop()
+
+
+async def test_start_notifies_mode_change(use_mgmt: FakeMgmt) -> None:
+    """Starting sets the radio mode through the manager notification path."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    with patch.object(get_manager(), "scanner_mode_changed") as notify:
+        await scanner.async_start()
+    notify.assert_called_once_with(scanner)
     await scanner.async_stop()
 
 
@@ -240,6 +253,17 @@ async def test_get_allocations_reflects_tracked_connections() -> None:
     assert allocations.slots == 3
     assert allocations.free == 2
     assert allocations.allocated == [_PEER]
+
+
+async def test_get_allocations_clamps_free_at_zero() -> None:
+    """An overshoot past the advisory gate reports zero free, never negative."""
+    scanner = _scanner()
+    get_manager().slot_manager.register_adapter(_ADAPTER, 1)
+    scanner._register_connection(_PEER)
+    scanner._register_connection("11:22:33:44:55:66")  # overshoot the 1 slot
+    allocations = scanner.get_allocations()
+    assert allocations is not None
+    assert allocations.free == 0
 
 
 # -- watchdog -------------------------------------------------------------

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from bluetooth_adapters import DEFAULT_ADDRESS
+from bluetooth_data_tools import monotonic_time_coarse
 
 from habluetooth import (
     BluetoothScanningMode,
@@ -37,6 +39,8 @@ class FakeMgmt:
         self.monitors_added: list[int] = []
         self.monitors_removed: list[tuple[int, int]] = []
         self.start_ok = True
+        self.stop_ok = True
+        self.remove_ok = True
         self.monitor_handle: int | None = 7
 
     async def start_discovery(self, idx: int) -> bool:
@@ -45,7 +49,7 @@ class FakeMgmt:
 
     async def stop_discovery(self, idx: int) -> bool:
         self.stopped.append(idx)
-        return True
+        return self.stop_ok
 
     async def add_adv_pattern_monitor(self, idx: int) -> int | None:
         self.monitors_added.append(idx)
@@ -53,7 +57,7 @@ class FakeMgmt:
 
     async def remove_adv_monitor(self, idx: int, handle: int) -> bool:
         self.monitors_removed.append((idx, handle))
-        return True
+        return self.remove_ok
 
 
 @pytest.fixture
@@ -94,6 +98,15 @@ async def test_factory_falls_back_for_non_hci_adapter(use_mgmt: FakeMgmt) -> Non
     with patch("habluetooth.scanner_mgmt.IS_LINUX", True):
         scanner = create_local_scanner(
             BluetoothScanningMode.ACTIVE, "CoreBluetooth", _ADDRESS
+        )
+    assert type(scanner) is HaScanner
+
+
+async def test_factory_falls_back_without_real_address(use_mgmt: FakeMgmt) -> None:
+    """Without a real adapter BD_ADDR the mgmt scanner cannot pin connects."""
+    with patch("habluetooth.scanner_mgmt.IS_LINUX", True):
+        scanner = create_local_scanner(
+            BluetoothScanningMode.ACTIVE, _ADAPTER, DEFAULT_ADDRESS
         )
     assert type(scanner) is HaScanner
 
@@ -307,6 +320,59 @@ async def test_stop_discovery_noop_without_mgmt() -> None:
     scanner = _scanner()
     with patch.object(get_manager(), "get_bluez_mgmt_ctl", return_value=None):
         await scanner._async_stop_discovery()  # does not raise
+
+
+async def test_stop_active_warns_on_failure(
+    use_mgmt: FakeMgmt, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed stop_discovery is logged and the scanner still stops scanning."""
+    use_mgmt.stop_ok = False
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    with caplog.at_level("WARNING", logger="habluetooth.scanner_mgmt"):
+        await scanner.async_stop()
+    assert "failed to stop mgmt discovery" in caplog.text
+    assert scanner.scanning is False
+
+
+async def test_stop_passive_keeps_handle_on_failed_removal(
+    use_mgmt: FakeMgmt, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed monitor removal keeps the handle so a later stop can retry."""
+    use_mgmt.remove_ok = False
+    scanner = _scanner(BluetoothScanningMode.PASSIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    with caplog.at_level("WARNING", logger="habluetooth.scanner_mgmt"):
+        await scanner.async_stop()
+    assert "failed to remove advertisement monitor" in caplog.text
+    assert scanner._monitor_handle == 7  # not cleared, so a retry is possible
+
+
+async def test_registered_scanner_reports_discovered_devices(
+    use_mgmt: FakeMgmt,
+) -> None:
+    """Once registered, the inherited ingestion feeds the read-out overrides."""
+    scanner = _scanner()
+    scanner.async_setup()
+    unregister = get_manager().async_register_scanner(scanner)
+    try:
+        assert list(scanner.discovered_addresses) == []
+        assert scanner.discovered_devices == []
+        assert scanner.discovered_devices_and_advertisement_data == {}
+        assert scanner.get_discovered_device_advertisement_data(_PEER) is None
+        scanner._async_on_advertisement(
+            _PEER, -60, "dev", [], {}, {}, None, {}, monotonic_time_coarse()
+        )
+        assert _PEER in scanner.discovered_addresses
+        assert _PEER in scanner.discovered_devices_and_advertisement_data
+        result = scanner.get_discovered_device_advertisement_data(_PEER)
+        assert result is not None
+        assert result[0].address == _PEER
+        assert scanner.discovered_devices[0].address == _PEER
+    finally:
+        unregister()
 
 
 async def test_slot_limit_zero_when_adapter_unregistered() -> None:

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -1,0 +1,316 @@
+"""Tests for the mgmt-based local scanner and the create_local_scanner factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from habluetooth import (
+    BluetoothScanningMode,
+    HaScanner,
+    HaScannerMgmt,
+    create_local_scanner,
+    get_manager,
+)
+from habluetooth.scanner_bleak import ScannerStartError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytestmark = pytest.mark.asyncio
+
+_ADAPTER = "hci0"
+_ADAPTER_IDX = 0
+_ADDRESS = "00:11:22:33:44:55"
+_PEER = "AA:BB:CC:DD:EE:FF"
+
+
+class FakeMgmt:
+    """Stand-in for MGMTBluetoothCtl recording the discovery calls made."""
+
+    def __init__(self, *, can_discover: bool = True) -> None:
+        self.can_discover = can_discover
+        self.started: list[int] = []
+        self.stopped: list[int] = []
+        self.monitors_added: list[int] = []
+        self.monitors_removed: list[tuple[int, int]] = []
+        self.start_ok = True
+        self.monitor_handle: int | None = 7
+
+    async def start_discovery(self, idx: int) -> bool:
+        self.started.append(idx)
+        return self.start_ok
+
+    async def stop_discovery(self, idx: int) -> bool:
+        self.stopped.append(idx)
+        return True
+
+    async def add_adv_pattern_monitor(self, idx: int) -> int | None:
+        self.monitors_added.append(idx)
+        return self.monitor_handle
+
+    async def remove_adv_monitor(self, idx: int, handle: int) -> bool:
+        self.monitors_removed.append((idx, handle))
+        return True
+
+
+@pytest.fixture
+def use_mgmt() -> Iterator[FakeMgmt]:
+    """Point the manager at a fake mgmt controller that can discover."""
+    fake = FakeMgmt()
+    with patch.object(get_manager(), "get_bluez_mgmt_ctl", return_value=fake):
+        yield fake
+
+
+def _scanner(
+    mode: BluetoothScanningMode = BluetoothScanningMode.ACTIVE,
+) -> HaScannerMgmt:
+    return HaScannerMgmt(mode, _ADAPTER, _ADDRESS)
+
+
+# -- factory --------------------------------------------------------------
+async def test_factory_falls_back_without_mgmt() -> None:
+    """With no mgmt controller, the factory returns the bleak scanner."""
+    with patch.object(get_manager(), "get_bluez_mgmt_ctl", return_value=None):
+        scanner = create_local_scanner(BluetoothScanningMode.ACTIVE, _ADAPTER, _ADDRESS)
+    assert type(scanner) is HaScanner
+
+
+async def test_factory_falls_back_when_cannot_discover() -> None:
+    """A mgmt controller without discovery capability still uses bleak."""
+    fake = FakeMgmt(can_discover=False)
+    with (
+        patch("habluetooth.scanner_mgmt.IS_LINUX", True),
+        patch.object(get_manager(), "get_bluez_mgmt_ctl", return_value=fake),
+    ):
+        scanner = create_local_scanner(BluetoothScanningMode.ACTIVE, _ADAPTER, _ADDRESS)
+    assert type(scanner) is HaScanner
+
+
+async def test_factory_falls_back_for_non_hci_adapter(use_mgmt: FakeMgmt) -> None:
+    """A non-hci adapter has no controller index, so it uses bleak."""
+    with patch("habluetooth.scanner_mgmt.IS_LINUX", True):
+        scanner = create_local_scanner(
+            BluetoothScanningMode.ACTIVE, "CoreBluetooth", _ADDRESS
+        )
+    assert type(scanner) is HaScanner
+
+
+async def test_factory_returns_mgmt_scanner_when_available(
+    use_mgmt: FakeMgmt,
+) -> None:
+    """On Linux with a discovering mgmt socket and an hci adapter, use mgmt."""
+    with patch("habluetooth.scanner_mgmt.IS_LINUX", True):
+        scanner = create_local_scanner(BluetoothScanningMode.ACTIVE, _ADAPTER, _ADDRESS)
+    assert type(scanner) is HaScannerMgmt
+
+
+# -- construction ---------------------------------------------------------
+async def test_init_is_connectable_with_connector() -> None:
+    """The scanner is connectable and routes through a mgmt connector."""
+    scanner = _scanner()
+    assert scanner.connectable is True
+    assert scanner.connector is not None
+    assert scanner.connector.source == _ADDRESS
+    assert scanner.connector.can_connect == scanner._can_connect
+
+
+# -- discovery lifecycle --------------------------------------------------
+async def test_async_start_active_uses_start_discovery(use_mgmt: FakeMgmt) -> None:
+    """Active mode starts kernel discovery and marks the scanner scanning."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    assert use_mgmt.started == [_ADAPTER_IDX]
+    assert scanner.scanning is True
+    assert scanner.current_mode is BluetoothScanningMode.ACTIVE
+    await scanner.async_stop()
+
+
+async def test_async_start_passive_uses_monitor(use_mgmt: FakeMgmt) -> None:
+    """Passive mode adds an advertisement monitor and records its handle."""
+    scanner = _scanner(BluetoothScanningMode.PASSIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    assert use_mgmt.monitors_added == [_ADAPTER_IDX]
+    assert scanner._monitor_handle == 7
+    assert scanner.scanning is True
+    await scanner.async_stop()
+
+
+async def test_async_start_raises_when_unavailable() -> None:
+    """Starting without mgmt discovery raises ScannerStartError."""
+    scanner = _scanner()
+    scanner.async_setup()
+    with (
+        patch.object(get_manager(), "get_bluez_mgmt_ctl", return_value=None),
+        pytest.raises(ScannerStartError, match="not available"),
+    ):
+        await scanner.async_start()
+
+
+async def test_async_start_raises_when_discovery_fails(use_mgmt: FakeMgmt) -> None:
+    """A rejected start_discovery surfaces as ScannerStartError."""
+    use_mgmt.start_ok = False
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    with pytest.raises(ScannerStartError, match="failed to start"):
+        await scanner.async_start()
+
+
+async def test_async_start_raises_when_monitor_fails(use_mgmt: FakeMgmt) -> None:
+    """A rejected monitor registration surfaces as ScannerStartError."""
+    use_mgmt.monitor_handle = None
+    scanner = _scanner(BluetoothScanningMode.PASSIVE)
+    scanner.async_setup()
+    with pytest.raises(ScannerStartError, match="advertisement monitor"):
+        await scanner.async_start()
+
+
+async def test_async_stop_active_stops_discovery(use_mgmt: FakeMgmt) -> None:
+    """Stopping an active scanner stops kernel discovery."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    await scanner.async_stop()
+    assert use_mgmt.stopped == [_ADAPTER_IDX]
+    assert scanner.scanning is False
+
+
+async def test_async_stop_passive_removes_monitor(use_mgmt: FakeMgmt) -> None:
+    """Stopping a passive scanner removes its advertisement monitor."""
+    scanner = _scanner(BluetoothScanningMode.PASSIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    await scanner.async_stop()
+    assert use_mgmt.monitors_removed == [(_ADAPTER_IDX, 7)]
+    assert scanner._monitor_handle is None
+
+
+# -- connection slots -----------------------------------------------------
+async def test_can_connect_respects_slot_limit() -> None:
+    """can_connect tracks live connections against the configured slot count."""
+    scanner = _scanner()
+    get_manager().slot_manager.register_adapter(_ADAPTER, 1)
+    assert scanner._can_connect() is True
+    scanner._register_connection(_PEER)
+    assert scanner._can_connect() is False
+    scanner._unregister_connection(_PEER)
+    assert scanner._can_connect() is True
+
+
+async def test_can_connect_unlimited_without_registered_slots() -> None:
+    """With no slot count registered, connections are not slot-gated."""
+    scanner = _scanner()
+    assert scanner._can_connect() is True
+    scanner._register_connection(_PEER)
+    assert scanner._can_connect() is True
+
+
+async def test_can_connect_false_when_not_connectable() -> None:
+    """A non-connectable scanner never reports it can connect."""
+    scanner = _scanner()
+    scanner.connectable = False
+    assert scanner._can_connect() is False
+
+
+async def test_get_allocations_reflects_tracked_connections() -> None:
+    """get_allocations reports free/allocated from the scanner's own tracking."""
+    scanner = _scanner()
+    assert scanner.get_allocations() is None  # no slots registered yet
+    get_manager().slot_manager.register_adapter(_ADAPTER, 3)
+    scanner._register_connection(_PEER)
+    allocations = scanner.get_allocations()
+    assert allocations is not None
+    assert allocations.slots == 3
+    assert allocations.free == 2
+    assert allocations.allocated == [_PEER]
+
+
+# -- watchdog -------------------------------------------------------------
+async def test_watchdog_restarts_discovery_when_quiet(use_mgmt: FakeMgmt) -> None:
+    """The watchdog restarts discovery after the adapter goes quiet."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    assert use_mgmt.started == [_ADAPTER_IDX]
+    with patch.object(scanner, "_async_watchdog_triggered", return_value=True):
+        scanner._async_scanner_watchdog()
+        assert scanner.scanning is False
+        # Let the restart background task run to completion.
+        for task in list(scanner._background_tasks):
+            await task
+    assert use_mgmt.stopped == [_ADAPTER_IDX]  # stopped during restart
+    assert use_mgmt.started == [_ADAPTER_IDX, _ADAPTER_IDX]  # then started again
+    await scanner.async_stop()
+
+
+async def test_watchdog_noop_when_not_triggered(use_mgmt: FakeMgmt) -> None:
+    """The watchdog does nothing while advertisements are still arriving."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    with patch.object(scanner, "_async_watchdog_triggered", return_value=False):
+        scanner._async_scanner_watchdog()
+    assert use_mgmt.stopped == []
+    assert use_mgmt.started == [_ADAPTER_IDX]
+    await scanner.async_stop()
+
+
+async def test_watchdog_skips_when_restart_in_progress(use_mgmt: FakeMgmt) -> None:
+    """A triggered watchdog does not stack a second restart on the lock."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    async with scanner._start_stop_lock:
+        with patch.object(scanner, "_async_watchdog_triggered", return_value=True):
+            scanner._async_scanner_watchdog()
+        assert scanner._background_tasks == set()  # no restart scheduled
+    await scanner.async_stop()
+
+
+async def test_watchdog_restart_logs_on_failure(
+    use_mgmt: FakeMgmt, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed restart is logged, not raised out of the background task."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    use_mgmt.start_ok = False  # the restart's start_discovery will fail
+    with (
+        patch.object(scanner, "_async_watchdog_triggered", return_value=True),
+        caplog.at_level("ERROR", logger="habluetooth.scanner_mgmt"),
+    ):
+        scanner._async_scanner_watchdog()
+        for task in list(scanner._background_tasks):
+            await task
+    assert "failed to restart" in caplog.text
+    await scanner.async_stop()
+
+
+async def test_unsetup_stops_watchdog(use_mgmt: FakeMgmt) -> None:
+    """The teardown callback cancels the watchdog timer."""
+    scanner = _scanner(BluetoothScanningMode.ACTIVE)
+    unsetup = scanner.async_setup()
+    await scanner.async_start()
+    armed = scanner._cancel_watchdog  # capture before asserting to avoid narrowing
+    assert armed is not None  # armed by the start
+    unsetup()
+    assert scanner._cancel_watchdog is None
+    await scanner.async_stop()
+
+
+async def test_stop_discovery_noop_without_mgmt() -> None:
+    """Stopping with no mgmt controller is a safe no-op."""
+    scanner = _scanner()
+    with patch.object(get_manager(), "get_bluez_mgmt_ctl", return_value=None):
+        await scanner._async_stop_discovery()  # does not raise
+
+
+async def test_slot_limit_zero_when_adapter_unregistered() -> None:
+    """An adapter with no registered slot count reports 0 (unlimited)."""
+    scanner = _scanner()
+    assert scanner._slot_limit() == 0
+    assert scanner._can_connect() is True

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -354,6 +355,25 @@ async def test_watchdog_restart_logs_on_failure(
             await task
     assert "failed to restart" in caplog.text
     await scanner.async_stop()
+
+
+async def test_background_task_failure_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An exception escaping a background task is logged, not lost at GC."""
+    scanner = _scanner()
+
+    async def boom() -> None:
+        msg = "kaboom"
+        raise RuntimeError(msg)
+
+    with caplog.at_level("ERROR", logger="habluetooth.scanner_mgmt"):
+        scanner._create_background_task(boom())
+        task = next(iter(scanner._background_tasks))
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)  # let the done-callback run
+    assert "background task failed" in caplog.text
+    assert scanner._background_tasks == set()  # reference dropped
 
 
 async def test_unsetup_stops_watchdog(use_mgmt: FakeMgmt) -> None:

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -111,6 +111,13 @@ async def test_factory_falls_back_without_real_address(use_mgmt: FakeMgmt) -> No
     assert type(scanner) is HaScanner
 
 
+async def test_factory_falls_back_for_auto_mode(use_mgmt: FakeMgmt) -> None:
+    """AUTO needs active-window promotion the mgmt scanner lacks, so use bleak."""
+    with patch("habluetooth.scanner_mgmt.IS_LINUX", True):
+        scanner = create_local_scanner(BluetoothScanningMode.AUTO, _ADAPTER, _ADDRESS)
+    assert type(scanner) is HaScanner
+
+
 async def test_factory_returns_mgmt_scanner_when_available(
     use_mgmt: FakeMgmt,
 ) -> None:
@@ -118,6 +125,12 @@ async def test_factory_returns_mgmt_scanner_when_available(
     with patch("habluetooth.scanner_mgmt.IS_LINUX", True):
         scanner = create_local_scanner(BluetoothScanningMode.ACTIVE, _ADAPTER, _ADDRESS)
     assert type(scanner) is HaScannerMgmt
+
+
+async def test_init_rejects_default_address() -> None:
+    """Direct construction without a real BD_ADDR fails fast."""
+    with pytest.raises(ValueError, match="real adapter address"):
+        HaScannerMgmt(BluetoothScanningMode.ACTIVE, _ADAPTER, DEFAULT_ADDRESS)
 
 
 # -- construction ---------------------------------------------------------
@@ -264,6 +277,22 @@ async def test_get_allocations_clamps_free_at_zero() -> None:
     allocations = scanner.get_allocations()
     assert allocations is not None
     assert allocations.free == 0
+
+
+async def test_get_allocations_sorts_allocated() -> None:
+    """Allocated addresses are reported in a stable sorted order."""
+    scanner = _scanner()
+    get_manager().slot_manager.register_adapter(_ADAPTER, 5)
+    scanner._register_connection("CC:CC:CC:CC:CC:CC")
+    scanner._register_connection("AA:AA:AA:AA:AA:AA")
+    scanner._register_connection("BB:BB:BB:BB:BB:BB")
+    allocations = scanner.get_allocations()
+    assert allocations is not None
+    assert allocations.allocated == [
+        "AA:AA:AA:AA:AA:AA",
+        "BB:BB:BB:BB:BB:BB",
+        "CC:CC:CC:CC:CC:CC",
+    ]
 
 
 # -- watchdog -------------------------------------------------------------

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -357,6 +357,26 @@ async def test_watchdog_restart_logs_on_failure(
     await scanner.async_stop()
 
 
+async def test_restart_does_not_stack_monitor_on_failed_removal(
+    use_mgmt: FakeMgmt,
+) -> None:
+    """If a passive monitor cannot be removed, the restart does not add another."""
+    use_mgmt.remove_ok = False
+    scanner = _scanner(BluetoothScanningMode.PASSIVE)
+    scanner.async_setup()
+    await scanner.async_start()
+    assert use_mgmt.monitors_added == [_ADAPTER_IDX]
+    with patch.object(scanner, "_async_watchdog_triggered", return_value=True):
+        scanner._async_scanner_watchdog()
+        for task in list(scanner._background_tasks):
+            await task
+    # Removal failed, so no second monitor was registered (no stacking/leak),
+    # and the handle is preserved for a retry on the next tick.
+    assert use_mgmt.monitors_added == [_ADAPTER_IDX]
+    assert scanner._monitor_handle == 7
+    await scanner.async_stop()
+
+
 async def test_background_task_failure_is_logged(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Adds scanner_mgmt.py with HaScannerMgmt, a local scanner that drives discovery over the BlueZ management socket (active discovery or a passive advertisement monitor) and routes connections through the L2CAP HaMgmtClient, no DBus. Advertisements arrive over the existing mgmt side channel, which the manager points at this scanner once it is registered by adapter index, so the hot advert path is inherited unchanged from BaseHaScanner. Also adds create_local_scanner(mode, adapter, address), the factory that returns the mgmt scanner when mgmt discovery is available and falls back to the bleak backed HaScanner otherwise.

Marked experimental at the top of the module; the public names are likely to change or be renamed. Nothing in Home Assistant selects this scanner, the factory is not wired into core yet, so there is no behavior change; HA keeps using HaScanner and the bleak platform client. Verified the 26 habluetooth symbols HA imports all still resolve.

Connection slots are tracked by the scanner itself rather than BleakSlotManager; that manager counts connections by BlueZ DBus path, which an L2CAP connection never creates, so it cannot see mgmt connections. The scanner keeps its own set of live peer addresses, reads only the configured slot count from the slot manager as the limit, and the client reports connect and disconnect through two callbacks on MgmtClientData (additive, the existing client behavior is unchanged when they are absent).

Tested the factory selection, active and passive start, start failures, stop, the quiet watchdog restart and its skip and failure paths, teardown, and the slot counting and gating; scanner_mgmt and client_mgmt both at 100 percent line and branch, full suite green.