### PR TITLE
feat: raise the maximum auto active scan window to 35s

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -65,7 +65,7 @@ AUTO_REDISCOVERY_SWEEP_DURATION: Final = 15.0
 # matches the validation in async_register_active_scan; the ceiling is
 # the longest single ACTIVE flip we'll ever do for one device tick.
 AUTO_WINDOW_MIN_DURATION: Final = 5.0
-AUTO_WINDOW_MAX_DURATION: Final = 30.0
+AUTO_WINDOW_MAX_DURATION: Final = 35.0
 
 # Per-device entries due within AUTO_COALESCE_LOOKAHEAD of now are
 # pulled into the current window so staggered registrations sync up

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1251,7 +1251,7 @@ class BluetoothManager:
         DEFAULT_ACTIVE_SCAN_DURATION (10s); pass smaller values to
         get a tighter cadence. The effective window is clamped to
         [AUTO_WINDOW_MIN_DURATION, AUTO_WINDOW_MAX_DURATION]
-        (5s..30s) and coalesced with other due requests for the
+        (5s..35s) and coalesced with other due requests for the
         scanner; very large ``scan_duration`` values are capped.
         ``scan_interval`` is measured between window starts (not
         between successive windows). ACTIVE / PASSIVE scanners

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -1868,6 +1868,30 @@ async def test_coalesce_clamps_oversize_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_window_honors_35s_request() -> None:
+    """A 35s scan_duration is dispatched as-is, not clamped down."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(
+        address, scan_interval=60.0, scan_duration=35.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        entries = sched._schedule._due_at[address]
+        for req in list(entries):
+            entries[req] = loop.time() - 1.0
+        await sched._workers[scanner.source]._tick()
+        assert scanner.active_window_calls == [35.0]
+    finally:
+        cancel()
+        register_cancel()
+
+
+@pytest.mark.asyncio
 async def test_coalesce_only_due_requests_count() -> None:
     """Only the requests that are actually due contribute to coalesced duration."""
     manager = get_manager()


### PR DESCRIPTION
Some scan response only sensors broadcast on a 30s interval (Govee H5074, Inkbird IBS-TH2), so a 30s active window can fall just short of a full interval and miss them. This raises AUTO_WINDOW_MAX_DURATION from 30s to 35s so callers can request a window that spans a 30s interval with margin.

The coalesce lookahead derives from the window max, so it stays ahead of it (now 40s); the invariant that lookahead exceeds the window is preserved.