### PR TITLE
feat: add mgmt pair, unpair, and disconnect commands

### DIFF
--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -41,12 +41,19 @@ DEVICE_FOUND = 0x0012
 ADV_MONITOR_DEVICE_FOUND = 0x002F
 
 # Management commands
+MGMT_OP_DISCONNECT = 0x0014
 MGMT_OP_GET_CONNECTIONS = 0x0015
+MGMT_OP_PAIR_DEVICE = 0x0019
+MGMT_OP_UNPAIR_DEVICE = 0x001B
 MGMT_OP_START_DISCOVERY = 0x0023
 MGMT_OP_STOP_DISCOVERY = 0x0024
 MGMT_OP_LOAD_CONN_PARAM = 0x0035
 MGMT_OP_ADD_ADV_PATTERNS_MONITOR = 0x0052
 MGMT_OP_REMOVE_ADV_MONITOR = 0x0053
+
+# IO capability for pairing; NoInputNoOutput selects "Just Works" (no PIN or
+# passkey prompt), which is what a headless host can satisfy.
+IO_CAPABILITY_NO_INPUT_NO_OUTPUT = 0x03
 
 # Management events
 MGMT_EV_CMD_COMPLETE = 0x0001
@@ -75,6 +82,15 @@ DISCOVERY_PACK = DISCOVERY_STRUCT.pack
 MONITOR_HANDLE_STRUCT = Struct("<H")
 MONITOR_HANDLE_PACK = MONITOR_HANDLE_STRUCT.pack
 MONITOR_HANDLE_UNPACK = MONITOR_HANDLE_STRUCT.unpack
+# DISCONNECT carries bdaddr (6) + address type (1).
+DISCONNECT_STRUCT = Struct("<6sB")
+DISCONNECT_PACK = DISCONNECT_STRUCT.pack
+# PAIR_DEVICE carries bdaddr (6) + address type (1) + IO capability (1).
+PAIR_DEVICE_STRUCT = Struct("<6sBB")
+PAIR_DEVICE_PACK = PAIR_DEVICE_STRUCT.pack
+# UNPAIR_DEVICE carries bdaddr (6) + address type (1) + disconnect flag (1).
+UNPAIR_DEVICE_STRUCT = Struct("<6sBB")
+UNPAIR_DEVICE_PACK = UNPAIR_DEVICE_STRUCT.pack
 
 CONNECTION_ERRORS = (
     BluetoothSocketError,
@@ -88,6 +104,22 @@ def _set_future_if_not_done(future: asyncio.Future[None] | None) -> None:
     """Set the future result if not done."""
     if future is not None and not future.done():
         future.set_result(None)
+
+
+def _mgmt_address_bytes(address: str) -> bytes | None:
+    """
+    Pack ``AA:BB:CC:DD:EE:FF`` into the 6 little-endian bytes mgmt expects.
+
+    Returns ``None`` for a malformed address (the caller treats that as a soft
+    failure rather than raising into the mgmt command path).
+    """
+    try:
+        addr_bytes = bytes.fromhex(address.replace(":", ""))
+    except ValueError:
+        return None
+    if len(addr_bytes) != 6:
+        return None
+    return addr_bytes[::-1]
 
 
 @lru_cache(maxsize=512)
@@ -619,6 +651,90 @@ class MGMTBluetoothCtl:
             "hci%u: failed to remove advertisement monitor %u: %s",
             adapter_idx,
             handle,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def pair_device(
+        self,
+        adapter_idx: int,
+        address: str,
+        address_type: int,
+        io_capability: int = IO_CAPABILITY_NO_INPUT_NO_OUTPUT,
+    ) -> bool:
+        """
+        Pair (bond) with a device over the management socket.
+
+        ``io_capability`` defaults to NoInputNoOutput, which drives "Just Works"
+        pairing; the kernel performs SMP and stores the keys. Returns True when
+        the controller reports the pairing completed.
+        """
+        addr = _mgmt_address_bytes(address)
+        if addr is None:
+            _LOGGER.error("hci%u: invalid address to pair: %s", adapter_idx, address)
+            return False
+        result = await self._send_command_await(
+            MGMT_OP_PAIR_DEVICE,
+            adapter_idx,
+            PAIR_DEVICE_PACK(addr, address_type, io_capability),
+        )
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        _LOGGER.warning(
+            "hci%u: failed to pair with %s: %s",
+            adapter_idx,
+            address,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def unpair_device(
+        self,
+        adapter_idx: int,
+        address: str,
+        address_type: int,
+        *,
+        disconnect: bool = True,
+    ) -> bool:
+        """Remove the bond for a device (and disconnect it by default)."""
+        addr = _mgmt_address_bytes(address)
+        if addr is None:
+            _LOGGER.error("hci%u: invalid address to unpair: %s", adapter_idx, address)
+            return False
+        result = await self._send_command_await(
+            MGMT_OP_UNPAIR_DEVICE,
+            adapter_idx,
+            UNPAIR_DEVICE_PACK(addr, address_type, 1 if disconnect else 0),
+        )
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        _LOGGER.warning(
+            "hci%u: failed to unpair %s: %s",
+            adapter_idx,
+            address,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def disconnect_device(
+        self, adapter_idx: int, address: str, address_type: int
+    ) -> bool:
+        """Force-disconnect a device at the controller over the mgmt socket."""
+        addr = _mgmt_address_bytes(address)
+        if addr is None:
+            _LOGGER.error(
+                "hci%u: invalid address to disconnect: %s", adapter_idx, address
+            )
+            return False
+        result = await self._send_command_await(
+            MGMT_OP_DISCONNECT, adapter_idx, DISCONNECT_PACK(addr, address_type)
+        )
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        _LOGGER.warning(
+            "hci%u: failed to disconnect %s: %s",
+            adapter_idx,
+            address,
             "no response" if result is None else f"status={result[0]:#x}",
         )
         return False

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -11,10 +11,14 @@ import pytest
 from btsocket.btmgmt_socket import BluetoothSocketError
 
 from habluetooth.channels.bluez import (
+    IO_CAPABILITY_NO_INPUT_NO_OUTPUT,
     MGMT_OP_ADD_ADV_PATTERNS_MONITOR,
+    MGMT_OP_DISCONNECT,
+    MGMT_OP_PAIR_DEVICE,
     MGMT_OP_REMOVE_ADV_MONITOR,
     MGMT_OP_START_DISCOVERY,
     MGMT_OP_STOP_DISCOVERY,
+    MGMT_OP_UNPAIR_DEVICE,
     SCAN_TYPE_LE,
     BluetoothMGMTProtocol,
     MGMTBluetoothCtl,
@@ -1918,3 +1922,117 @@ def test_make_bluez_details() -> None:
         "path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
         "props": {"Adapter": "/org/bluez/hci0"},
     }
+
+
+# -- pairing / disconnect commands ----------------------------------------
+@pytest.mark.asyncio
+async def test_pair_device_success() -> None:
+    """pair_device sends bdaddr + type + IO capability and returns True."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert await mgmt_ctl.pair_device(0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_RANDOM) is True
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_PAIR_DEVICE.to_bytes(2, "little")
+    assert sent[2:4] == b"\x00\x00"  # controller idx
+    assert sent[6:12] == bytes([0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA])  # reversed
+    assert sent[12] == BDADDR_LE_RANDOM
+    assert sent[13] == IO_CAPABILITY_NO_INPUT_NO_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_pair_device_failure() -> None:
+    """pair_device returns False on a non-success status."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x03)
+    assert await mgmt_ctl.pair_device(0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC) is False
+
+
+@pytest.mark.asyncio
+async def test_unpair_device_success() -> None:
+    """unpair_device sends bdaddr + type + disconnect flag and returns True."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert (
+        await mgmt_ctl.unpair_device(0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC) is True
+    )
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_UNPAIR_DEVICE.to_bytes(2, "little")
+    assert sent[6:12] == bytes([0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA])
+    assert sent[12] == BDADDR_LE_PUBLIC
+    assert sent[13] == 1  # disconnect default
+
+
+@pytest.mark.asyncio
+async def test_unpair_device_without_disconnect() -> None:
+    """unpair_device(disconnect=False) clears the disconnect flag."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert (
+        await mgmt_ctl.unpair_device(
+            0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC, disconnect=False
+        )
+        is True
+    )
+    assert mock_protocol._write_to_socket.call_args[0][0][13] == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_device_success() -> None:
+    """disconnect_device sends bdaddr + type and returns True."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert (
+        await mgmt_ctl.disconnect_device(0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_RANDOM)
+        is True
+    )
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_DISCONNECT.to_bytes(2, "little")
+    assert sent[6:12] == bytes([0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA])
+    assert sent[12] == BDADDR_LE_RANDOM
+
+
+@pytest.mark.asyncio
+async def test_disconnect_device_no_response() -> None:
+    """A command with no response (timeout) returns False."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.transport = None  # no connection -> _send_command_await None
+    assert (
+        await mgmt_ctl.disconnect_device(0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC)
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_unpair_device_failure() -> None:
+    """unpair_device returns False on a non-success status."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x03)
+    assert (
+        await mgmt_ctl.unpair_device(0, "AA:BB:CC:DD:EE:FF", BDADDR_LE_PUBLIC) is False
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    ["pair_device", "unpair_device", "disconnect_device"],
+)
+@pytest.mark.parametrize(
+    "bad_address",
+    ["AA:BB", "ZZ:BB:CC:DD:EE:FF"],  # too short, and non-hex
+)
+async def test_pairing_commands_reject_invalid_address(
+    command: str, bad_address: str
+) -> None:
+    """A malformed address is a soft failure, not an exception."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert await getattr(mgmt_ctl, command)(0, bad_address, BDADDR_LE_PUBLIC) is False
+    mock_protocol._write_to_socket.assert_not_called()


### PR DESCRIPTION
Adds three management socket command senders to the bluez channel; pair_device (bond with a peer, NoInputNoOutput IO capability so the kernel runs Just Works pairing and stores the keys), unpair_device (remove the bond, disconnecting by default), and disconnect_device (force-disconnect at the controller). Each follows the existing start_discovery / load_conn_params pattern, encodes the mgmt_addr_info layout (bdaddr reversed to little endian plus address type), awaits the command-complete status, and returns a bool.

Opcodes and the request struct layouts were taken from the installed btsocket btmgmt_protocol (PAIR_DEVICE 0x0019, UNPAIR_DEVICE 0x001B, DISCONNECT 0x0014; pair is addr+type+io_capability, unpair is addr+type+disconnect, disconnect is addr+type). A small helper packs and validates the address and treats a malformed address as a soft failure rather than raising into the command path.

This is the command sending half of the pairing work and unblocks HaMgmtClient.pair and unpair later; nothing calls these yet. The event side (NEW_LONG_TERM_KEY capture, AUTH_FAILED, key restore via LOAD_LONG_TERM_KEYS) and the passkey/confirmation interactive replies are follow ups. No behavior change.

Tested the encoded command bytes for each, success and failure status, the no response path, the unpair disconnect flag, and that a too short or non hex address is rejected without sending; the new code is fully covered.