### PR TITLE
feat: add mgmt load long term keys for bond restore

### DIFF
--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from asyncio import timeout as asyncio_timeout
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from functools import lru_cache
 from struct import Struct
 from typing import TYPE_CHECKING, Any, cast
@@ -41,6 +42,7 @@ DEVICE_FOUND = 0x0012
 ADV_MONITOR_DEVICE_FOUND = 0x002F
 
 # Management commands
+MGMT_OP_LOAD_LONG_TERM_KEYS = 0x0013
 MGMT_OP_DISCONNECT = 0x0014
 MGMT_OP_GET_CONNECTIONS = 0x0015
 MGMT_OP_PAIR_DEVICE = 0x0019
@@ -91,6 +93,15 @@ PAIR_DEVICE_PACK = PAIR_DEVICE_STRUCT.pack
 # UNPAIR_DEVICE carries bdaddr (6) + address type (1) + disconnect flag (1).
 UNPAIR_DEVICE_STRUCT = Struct("<6sBB")
 UNPAIR_DEVICE_PACK = UNPAIR_DEVICE_STRUCT.pack
+# LOAD_LONG_TERM_KEYS carries a uint16 key count followed by mgmt_ltk_info
+# records: bdaddr (6) + address type (1) + key type (1) + central flag (1) +
+# encryption size (1) + ediv (2) + rand (8) + value (16) = 36 bytes each.
+LTK_COUNT_STRUCT = Struct("<H")
+LTK_COUNT_PACK = LTK_COUNT_STRUCT.pack
+LTK_INFO_STRUCT = Struct("<6sBBBBH8s16s")
+LTK_INFO_PACK = LTK_INFO_STRUCT.pack
+_LTK_RAND_LEN = 8
+_LTK_VALUE_LEN = 16
 
 CONNECTION_ERRORS = (
     BluetoothSocketError,
@@ -104,6 +115,27 @@ def _set_future_if_not_done(future: asyncio.Future[None] | None) -> None:
     """Set the future result if not done."""
     if future is not None and not future.done():
         future.set_result(None)
+
+
+@dataclass(slots=True, frozen=True)
+class LongTermKey:
+    """
+    A bonded LE long-term key (the mgmt ``mgmt_ltk_info`` record).
+
+    These are captured from NEW_LONG_TERM_KEY events when pairing completes and
+    fed back via :meth:`MGMTBluetoothCtl.load_long_term_keys` on reconnect so the
+    kernel re-encrypts the link without re-pairing. ``rand`` is 8 bytes and
+    ``value`` is 16 bytes.
+    """
+
+    address: str
+    address_type: int
+    key_type: int
+    central: bool  # the mgmt API calls this "master"
+    encryption_size: int
+    ediv: int
+    rand: bytes
+    value: bytes
 
 
 def _mgmt_address_bytes(address: str) -> bytes | None:
@@ -735,6 +767,56 @@ class MGMTBluetoothCtl:
             "hci%u: failed to disconnect %s: %s",
             adapter_idx,
             address,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def load_long_term_keys(
+        self, adapter_idx: int, keys: list[LongTermKey]
+    ) -> bool:
+        """
+        Restore bonded long-term keys for an adapter.
+
+        Replaces the controller's LTK list (an empty list clears it) so the
+        kernel can re-encrypt links to already-bonded peers without re-pairing.
+        """
+        records: list[bytes] = []
+        for key in keys:
+            addr = _mgmt_address_bytes(key.address)
+            if addr is None:
+                _LOGGER.error(
+                    "hci%u: invalid address in long-term key: %s",
+                    adapter_idx,
+                    key.address,
+                )
+                return False
+            if len(key.rand) != _LTK_RAND_LEN or len(key.value) != _LTK_VALUE_LEN:
+                _LOGGER.error(
+                    "hci%u: malformed long-term key for %s", adapter_idx, key.address
+                )
+                return False
+            records.append(
+                LTK_INFO_PACK(
+                    addr,
+                    key.address_type,
+                    key.key_type,
+                    1 if key.central else 0,
+                    key.encryption_size,
+                    key.ediv,
+                    key.rand,
+                    key.value,
+                )
+            )
+        cmd_data = LTK_COUNT_PACK(len(keys)) + b"".join(records)
+        result = await self._send_command_await(
+            MGMT_OP_LOAD_LONG_TERM_KEYS, adapter_idx, cmd_data
+        )
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        _LOGGER.warning(
+            "hci%u: failed to load %d long-term key(s): %s",
+            adapter_idx,
+            len(keys),
             "no response" if result is None else f"status={result[0]:#x}",
         )
         return False

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import lru_cache
 from struct import Struct
+from struct import error as struct_error
 from typing import TYPE_CHECKING, Any, cast
 
 from bluetooth_data_tools import monotonic_time_coarse
@@ -795,8 +796,11 @@ class MGMTBluetoothCtl:
                     "hci%u: malformed long-term key for %s", adapter_idx, key.address
                 )
                 return False
-            records.append(
-                LTK_INFO_PACK(
+            try:
+                # Out-of-range integer fields (e.g. a corrupt key_type) raise
+                # struct.error; keep that a soft failure rather than letting it
+                # escape the command path.
+                record = LTK_INFO_PACK(
                     addr,
                     key.address_type,
                     key.key_type,
@@ -806,7 +810,14 @@ class MGMTBluetoothCtl:
                     key.rand,
                     key.value,
                 )
-            )
+            except struct_error:
+                _LOGGER.exception(
+                    "hci%u: out-of-range field in long-term key for %s",
+                    adapter_idx,
+                    key.address,
+                )
+                return False
+            records.append(record)
         cmd_data = LTK_COUNT_PACK(len(keys)) + b"".join(records)
         result = await self._send_command_await(
             MGMT_OP_LOAD_LONG_TERM_KEYS, adapter_idx, cmd_data

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -2120,3 +2120,15 @@ async def test_load_long_term_keys_rejects_malformed_key(key: LongTermKey) -> No
     mock_protocol.command_response = _stub_command_response(0x00)
     assert await mgmt_ctl.load_long_term_keys(0, [key]) is False
     mock_protocol._write_to_socket.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_long_term_keys_rejects_out_of_range_field() -> None:
+    """An out-of-range integer field is a soft failure, not a struct.error."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    bad = LongTermKey(
+        "AA:BB:CC:DD:EE:FF", 1, 300, False, 16, 0, b"\x00" * 8, b"\x00" * 16
+    )  # key_type 300 does not fit in a byte
+    assert await mgmt_ctl.load_long_term_keys(0, [bad]) is False
+    mock_protocol._write_to_socket.assert_not_called()

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -14,6 +14,7 @@ from habluetooth.channels.bluez import (
     IO_CAPABILITY_NO_INPUT_NO_OUTPUT,
     MGMT_OP_ADD_ADV_PATTERNS_MONITOR,
     MGMT_OP_DISCONNECT,
+    MGMT_OP_LOAD_LONG_TERM_KEYS,
     MGMT_OP_PAIR_DEVICE,
     MGMT_OP_REMOVE_ADV_MONITOR,
     MGMT_OP_START_DISCOVERY,
@@ -21,6 +22,7 @@ from habluetooth.channels.bluez import (
     MGMT_OP_UNPAIR_DEVICE,
     SCAN_TYPE_LE,
     BluetoothMGMTProtocol,
+    LongTermKey,
     MGMTBluetoothCtl,
     bytes_mac_to_str,
     make_bluez_details,
@@ -2035,4 +2037,86 @@ async def test_pairing_commands_reject_invalid_address(
     mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
     mock_protocol.command_response = _stub_command_response(0x00)
     assert await getattr(mgmt_ctl, command)(0, bad_address, BDADDR_LE_PUBLIC) is False
+    mock_protocol._write_to_socket.assert_not_called()
+
+
+# -- load long-term keys --------------------------------------------------
+def _ltk(address: str = "AA:BB:CC:DD:EE:FF") -> LongTermKey:
+    return LongTermKey(
+        address=address,
+        address_type=BDADDR_LE_RANDOM,
+        key_type=1,
+        central=False,
+        encryption_size=16,
+        ediv=0x1234,
+        rand=bytes(range(8)),
+        value=bytes(range(16)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_long_term_keys_success() -> None:
+    """load_long_term_keys packs the count and a 36 byte record per key."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert await mgmt_ctl.load_long_term_keys(0, [_ltk()]) is True
+
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_LOAD_LONG_TERM_KEYS.to_bytes(2, "little")
+    assert sent[6:8] == (1).to_bytes(2, "little")  # key_count
+    record = sent[8:]
+    assert len(record) == 36
+    assert record[0:6] == bytes([0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA])  # reversed
+    assert record[6] == BDADDR_LE_RANDOM
+    assert record[7] == 1  # key_type
+    assert record[8] == 0  # central flag (False)
+    assert record[9] == 16  # encryption_size
+    assert record[10:12] == (0x1234).to_bytes(2, "little")  # ediv
+    assert record[12:20] == bytes(range(8))  # rand
+    assert record[20:36] == bytes(range(16))  # value
+
+
+@pytest.mark.asyncio
+async def test_load_long_term_keys_empty_clears() -> None:
+    """An empty key list sends a zero count (clears the controller's keys)."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+
+    assert await mgmt_ctl.load_long_term_keys(0, []) is True
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[6:8] == (0).to_bytes(2, "little")
+    assert len(sent[8:]) == 0
+
+
+@pytest.mark.asyncio
+async def test_load_long_term_keys_failure() -> None:
+    """A non-success status returns False."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x03)
+    assert await mgmt_ctl.load_long_term_keys(0, [_ltk()]) is False
+
+
+@pytest.mark.asyncio
+async def test_load_long_term_keys_rejects_invalid_address() -> None:
+    """A malformed address in a key is a soft failure with nothing sent."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert await mgmt_ctl.load_long_term_keys(0, [_ltk("AA:BB")]) is False
+    mock_protocol._write_to_socket.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key",
+    [
+        LongTermKey("AA:BB:CC:DD:EE:FF", 1, 1, False, 16, 0, b"\x00" * 7, b"\x00" * 16),
+        LongTermKey("AA:BB:CC:DD:EE:FF", 1, 1, False, 16, 0, b"\x00" * 8, b"\x00" * 15),
+    ],
+)
+async def test_load_long_term_keys_rejects_malformed_key(key: LongTermKey) -> None:
+    """A key with the wrong rand/value length is rejected without sending."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert await mgmt_ctl.load_long_term_keys(0, [key]) is False
     mock_protocol._write_to_socket.assert_not_called()


### PR DESCRIPTION
Adds load_long_term_keys to the bluez channel; it sends MGMT_OP_LOAD_LONG_TERM_KEYS (0x0013) with a uint16 key count followed by one 36 byte mgmt_ltk_info record per key, replacing the controller's LTK list so the kernel can re-encrypt links to already bonded peers without re-pairing. An empty list clears the keys.

Also adds the LongTermKey value type (a frozen dataclass for one mgmt_ltk_info: address, address type, key type, central flag, encryption size, ediv, 8 byte rand, 16 byte value) and the packing struct. The opcode and the 36 byte record layout were taken from the installed btsocket btmgmt_protocol; the struct size is asserted at 36 in the tests. The encoder validates each address and the rand/value lengths and treats a malformed key as a soft failure rather than raising into the command path.

This is the bond restore half of key persistence and reuses the same record layout the NEW_LONG_TERM_KEY event capture will decode in a follow up. It is a pure command sender like the pair/unpair/disconnect commands; nothing calls it yet, no behavior change, and there is no hot path or pxd change.

Tested the encoded count and the full 36 byte record field by field, the empty clear case, a failure status, and rejection of an invalid address or a wrong length rand/value with nothing sent; the new code is fully covered.