### PR TITLE
feat(auto-scheduler): add last active window timing to diagnostics

### DIFF
--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -32,6 +32,8 @@ cdef class _ScannerWorker:
     cdef public object _task
     cdef public double _window_end
     cdef public double _sweep_last_completed
+    cdef public double _last_window_at
+    cdef public double _last_window_duration
     cdef public bint _failed_window
     cdef public bint _warned_no_fallback
     cdef public dict _owned_due_at
@@ -93,6 +95,7 @@ cdef class AutoScanScheduler:
     cdef public dict _requests_by_address
     cdef public _ScanSchedule _schedule
     cdef public dict _workers
+    cdef public dict _last_window_by_address
     cdef public object _loop
     cdef public bint _running
     cdef public object _on_demand_sweep_future

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -231,6 +231,8 @@ class _ScannerWorker:
 
     __slots__ = (
         "_failed_window",
+        "_last_window_at",
+        "_last_window_duration",
         "_manager",
         "_owned_due_at",
         "_scanner",
@@ -257,6 +259,11 @@ class _ScannerWorker:
         self._sweep_last_completed: float = 0.0
         self._failed_window: bool = False
         self._warned_no_fallback: bool = False
+        # When this worker last opened (or was delegated) an active
+        # window, and that window's duration. Diagnostics-only; 0.0
+        # means "never". Set at dispatch (pre-await), like _window_end.
+        self._last_window_at: float = 0.0
+        self._last_window_duration: float = 0.0
         # Subset of _due_at owned by this worker; inner dicts aliased so
         # in-place advances stay visible. Mutated only via _attach_owned
         # / _detach_owned / _clear_owned, driven by _ScanSchedule.
@@ -338,6 +345,8 @@ class _ScannerWorker:
             self._window_end = window_end
         if self._sweep_last_completed < now:
             self._sweep_last_completed = now
+        self._last_window_at = now
+        self._last_window_duration = window_end - now
 
     def _next_event_at(self, now: float) -> float:
         """
@@ -426,7 +435,10 @@ class _ScannerWorker:
         Called before the scanner await so a mid-window ownership
         flip can't let a new owner double-fire.
         """
+        last_window_by_address = self._scheduler._last_window_by_address
+        source = self._scanner.source
         for _address, entries, due in due_buckets:
+            last_window_by_address[_address] = (from_time, source)
             for request in due:
                 entries[request] = from_time + request.scan_interval
 
@@ -472,6 +484,8 @@ class _ScannerWorker:
             if sweep_due and duration < _AUTO_REDISCOVERY_SWEEP_DURATION:
                 duration = _AUTO_REDISCOVERY_SWEEP_DURATION
             self._window_end = now + duration
+            self._last_window_at = now
+            self._last_window_duration = duration
             # Advance pre-await: a new owner that wakes mid-window
             # must see the entries already advanced, otherwise an
             # RSSI flip would let the new owner fire a duplicate
@@ -555,6 +569,10 @@ class _ScannerWorker:
                 continue
             for request in due:
                 entries[request] = now + request.scan_interval
+            self._scheduler._last_window_by_address[address] = (
+                now,
+                fallback.source if fallback is not None else None,
+            )
             had_any_progress = True
             if fallback is None:
                 continue
@@ -715,6 +733,7 @@ class AutoScanScheduler:
     """Coordinates on-demand active windows across AUTO-mode scanners."""
 
     __slots__ = (
+        "_last_window_by_address",
         "_loop",
         "_manager",
         "_on_demand_sweep_end",
@@ -731,6 +750,13 @@ class AutoScanScheduler:
         self._requests_by_address: dict[str, set[ActiveScanRequest]] = {}
         self._workers: dict[str, _ScannerWorker] = {}
         self._schedule = _ScanSchedule(self._workers)
+        # address -> (loop.time(), source) of the last active window that
+        # covered it. ``source`` is the scanner that ran the window (the
+        # owner on the normal path, the fallback when delegated, or None
+        # when another ACTIVE scanner already covered it). Compare source
+        # to the current owner to see if the right scanner scanned it.
+        # Diagnostics-only; pruned with requests.
+        self._last_window_by_address: dict[str, tuple[float, str | None]] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._running = False
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
@@ -792,6 +818,7 @@ class AutoScanScheduler:
             worker.stop()
         self._schedule.clear()
         self._workers.clear()
+        self._last_window_by_address.clear()
         # done() guard mirrors the leader's finally for symmetry;
         # a future left non-None after completion would otherwise
         # raise InvalidStateError here.
@@ -881,6 +908,7 @@ class AutoScanScheduler:
             bucket.discard(request)
             if not bucket:
                 del self._requests_by_address[request.address]
+                self._last_window_by_address.pop(request.address, None)
         self._schedule.drop(request.address, request)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
@@ -1180,6 +1208,17 @@ class AutoScanScheduler:
         ``loop.time()`` values so callers can compute deltas; before
         ``start()`` (or after ``stop()``) ``_loop`` is None and these
         are reported as 0.0.
+
+        ``last_window_at`` / ``last_window_duration`` (per worker) and
+        ``last_active_window`` (per request address) record when an
+        active window last opened, recorded at dispatch (pre-await),
+        so a window the scanner then failed to open still shows here;
+        pair with ``failed_window`` to tell the two apart. 0.0 / None
+        means no active window has fired for that worker / address.
+        ``last_active_window_source`` is the scanner that ran that
+        window (None if another ACTIVE scanner covered it); compare it
+        to ``owner_source`` to see whether the device's current owner
+        is the one actually active-scanning it.
         """
         loop = self._loop
         now = loop.time() if loop is not None else 0.0
@@ -1188,6 +1227,8 @@ class AutoScanScheduler:
             workers[source] = {
                 "name": worker._scanner.name,
                 "window_end": worker._window_end,
+                "last_window_at": worker._last_window_at,
+                "last_window_duration": worker._last_window_duration,
                 "sweep_last_completed": worker._sweep_last_completed,
                 "next_sweep_at": (
                     worker._sweep_last_completed + _AUTO_REDISCOVERY_INTERVAL
@@ -1204,12 +1245,19 @@ class AutoScanScheduler:
             entries = self._schedule._due_at.get(address, {})
             history = last_service_info(address, False)
             owner_source = history.source if history is not None else None
+            last_window = self._last_window_by_address.get(address)
+            last_active_window = last_window[0] if last_window is not None else None
+            last_active_window_source = (
+                last_window[1] if last_window is not None else None
+            )
             requests[address] = [
                 {
                     "scan_interval": request.scan_interval,
                     "scan_duration": request.scan_duration,
                     "next_due": entries.get(request),
                     "owner_source": owner_source,
+                    "last_active_window": last_active_window,
+                    "last_active_window_source": last_active_window_source,
                 }
                 for request in bucket
             ]

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -346,7 +346,10 @@ class _ScannerWorker:
         if self._sweep_last_completed < now:
             self._sweep_last_completed = now
         self._last_window_at = now
-        self._last_window_duration = window_end - now
+        # Use the post-max _window_end so the (last_window_at,
+        # last_window_duration) pair stays consistent with the window
+        # end actually in effect when a longer one was already open.
+        self._last_window_duration = self._window_end - now
 
     def _next_event_at(self, now: float) -> float:
         """
@@ -569,12 +572,12 @@ class _ScannerWorker:
                 continue
             for request in due:
                 entries[request] = now + request.scan_interval
-            self._scheduler._last_window_by_address[address] = (
-                now,
-                fallback.source if fallback is not None else None,
-            )
             had_any_progress = True
             if fallback is None:
+                # Covered by another ACTIVE scanner: no later dispatch
+                # here, so the tick time is the window start. Delegated
+                # addresses are recorded below at their dispatch time.
+                self._scheduler._last_window_by_address[address] = (now, None)
                 continue
             existing = fallback_groups.get(fallback.source)
             if existing is None:
@@ -614,19 +617,22 @@ class _ScannerWorker:
         if TYPE_CHECKING:
             assert loop is not None
         workers = self._scheduler._workers
+        last_window_by_address = self._scheduler._last_window_by_address
         fb_worker: _ScannerWorker | None
         for fb, fb_due in fallback_groups.values():
             duration = self._scheduler._coalesce_duration(fb_due)
+            # Sample loop.time() per iteration: each prior
+            # ``async_request_active_window`` await can take seconds
+            # (scanner stop/restart on Linux), so the owner's tick-start
+            # ``now`` is stale for later fallbacks. Using it would put
+            # ``_window_end`` in the past (leaving the fallback worker's
+            # tick suppression off during the delegated window) and
+            # under-report ``last_active_window`` for these addresses.
+            dispatch_now = loop.time()
+            for request in fb_due:
+                last_window_by_address[request.address] = (dispatch_now, fb.source)
             fb_worker = workers.get(fb.source)
             if fb_worker is not None:
-                # Sample loop.time() per iteration: each prior
-                # ``async_request_active_window`` await can take
-                # seconds (scanner stop/restart on Linux), so the
-                # owner's tick-start ``now`` is stale for later
-                # fallbacks and would put ``_window_end`` in the
-                # past — leaving the fallback worker's tick
-                # suppression off during the delegated window.
-                dispatch_now = loop.time()
                 fb_worker.note_window_dispatched(dispatch_now + duration, dispatch_now)
             try:
                 await fb.async_request_active_window(duration)

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -2534,6 +2534,11 @@ async def test_worker_tick_delegates_to_fallback_when_owner_is_connecting() -> N
         # Owner can't service the flip; fallback gets the call.
         assert owner.active_window_calls == []
         assert fallback.active_window_calls == [7.0]
+        # The delegated window is recorded against the fallback that ran
+        # it, not the connecting owner.
+        entry = sched.async_diagnostics()["requests"][address][0]
+        assert entry["last_active_window_source"] == fallback.source
+        assert entry["last_active_window"] is not None
     finally:
         owner._finished_connecting(address, connected=False)
         cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4576,6 +4576,8 @@ async def test_async_diagnostics() -> None:
         worker_diag = workers[scanner.source]
         assert worker_diag["name"] == scanner.name
         assert worker_diag["window_end"] == 0.0
+        assert worker_diag["last_window_at"] == 0.0
+        assert worker_diag["last_window_duration"] == 0.0
         assert worker_diag["failed_window"] is False
         assert worker_diag["warned_no_fallback"] is False
         assert worker_diag["next_sweep_at"] == pytest.approx(
@@ -4594,6 +4596,8 @@ async def test_async_diagnostics() -> None:
             assert entry["owner_source"] == scanner.source
             assert entry["next_due"] is not None
             assert entry["next_due"] > loop.time()
+            assert entry["last_active_window"] is None
+            assert entry["last_active_window_source"] is None
     finally:
         cancel1()
         cancel2()
@@ -4601,6 +4605,40 @@ async def test_async_diagnostics() -> None:
     # After cancellation the address falls out of both indexes.
     post = sched.async_diagnostics()
     assert post["requests"] == {}
+
+
+@pytest.mark.asyncio
+async def test_async_diagnostics_last_active_window() -> None:
+    """A fired window populates per-worker and per-address last-window timing."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    loop = asyncio.get_running_loop()
+    address = "11:22:33:44:55:66"
+    cancel = manager.async_register_active_scan(
+        address, scan_interval=120.0, scan_duration=5.0
+    )
+    scanner = _RecordingAutoScanner("AA:BB:CC:DD:EE:00", BluetoothScanningMode.AUTO)
+    register_cancel = manager.async_register_scanner(scanner)
+    try:
+        _inject(scanner, address)
+        entries = sched._schedule._due_at[address]
+        request = next(iter(entries))
+        entries[request] = loop.time() - 1.0
+        tick_at = loop.time()
+        await _run_worker_tick(sched, scanner.source)
+        assert scanner.active_window_calls == [5.0]
+        diagnostics = sched.async_diagnostics()
+        worker_diag = diagnostics["workers"][scanner.source]
+        assert worker_diag["last_window_at"] == pytest.approx(tick_at, abs=0.5)
+        assert worker_diag["last_window_duration"] == 5.0
+        entry = diagnostics["requests"][address][0]
+        assert entry["last_active_window"] == pytest.approx(tick_at, abs=0.5)
+        assert entry["last_active_window_source"] == scanner.source
+    finally:
+        cancel()
+        register_cancel()
+    # Pruned with the request so the map cannot grow without bound.
+    assert sched._last_window_by_address == {}
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
Snapshot diagnostics could show active scans running and slots filled, but not whether the device's owning scanner actually ran a window on time; this fills that gap.

Per worker it adds last_window_at and last_window_duration. Per request address it adds last_active_window and last_active_window_source, so the scanning source can be compared against owner_source to tell whether the right scanner is active scanning the device, and how recently versus its scan_interval.

Motivated by home-assistant/core#174169, where scan response only Inkbird sensors update rarely behind multiple proxies; a single diagnostics snapshot could not confirm whether the owning scanner was active scanning on cadence.