### PR TITLE
feat: capture new long term key and auth failed mgmt events

### DIFF
--- a/src/habluetooth/channels/bluez.pxd
+++ b/src/habluetooth/channels/bluez.pxd
@@ -19,6 +19,7 @@ cdef class BluetoothMGMTProtocol:
     cdef unsigned int _buffer_len
     cdef unsigned int _pos
     cdef dict _scanners
+    cdef dict _pairing_handlers
     cdef object _on_connection_lost
     cdef object _is_shutting_down
     cdef dict _pending_commands

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
     from ..base_scanner import BaseHaScanner
 
+    PairingHandler = Callable[["NewLongTermKey | AuthenticationFailed"], None]
+
 _LOGGER = logging.getLogger(__name__)
 _int = int
 _bytes = bytes
@@ -61,6 +63,8 @@ IO_CAPABILITY_NO_INPUT_NO_OUTPUT = 0x03
 # Management events
 MGMT_EV_CMD_COMPLETE = 0x0001
 MGMT_EV_CMD_STATUS = 0x0002
+MGMT_EV_NEW_LONG_TERM_KEY = 0x000A
+MGMT_EV_AUTH_FAILED = 0x0011
 
 # Discovery address-type bitmask: BR/EDR (0x01) | LE Public (0x02) | LE Random (0x04).
 # We only scan for LE devices, so we combine the two LE bits.
@@ -101,8 +105,14 @@ LTK_COUNT_STRUCT = Struct("<H")
 LTK_COUNT_PACK = LTK_COUNT_STRUCT.pack
 LTK_INFO_STRUCT = Struct("<6sBBBBH8s16s")
 LTK_INFO_PACK = LTK_INFO_STRUCT.pack
+LTK_INFO_UNPACK = LTK_INFO_STRUCT.unpack
+LTK_INFO_SIZE = LTK_INFO_STRUCT.size  # 36
 _LTK_RAND_LEN = 8
 _LTK_VALUE_LEN = 16
+# NEW_LONG_TERM_KEY event = store_hint (1) + an mgmt_ltk_info record.
+_NEW_LTK_EV_SIZE = 1 + LTK_INFO_SIZE
+# AUTH_FAILED event = bdaddr (6) + address type (1) + status (1).
+_AUTH_FAILED_EV_SIZE = 8
 
 CONNECTION_ERRORS = (
     BluetoothSocketError,
@@ -137,6 +147,23 @@ class LongTermKey:
     ediv: int
     rand: bytes
     value: bytes
+
+
+@dataclass(slots=True, frozen=True)
+class NewLongTermKey:
+    """A NEW_LONG_TERM_KEY event: a freshly bonded key to persist."""
+
+    store_hint: int  # non-zero means the kernel suggests persisting the key
+    key: LongTermKey
+
+
+@dataclass(slots=True, frozen=True)
+class AuthenticationFailed:
+    """An AUTHENTICATION_FAILED event: pairing did not complete."""
+
+    address: str
+    address_type: int
+    status: int
 
 
 def _mgmt_address_bytes(address: str) -> bytes | None:
@@ -183,6 +210,7 @@ class BluetoothMGMTProtocol:
         on_connection_lost: Callable[[], None],
         is_shutting_down: Callable[[], bool],
         sock: socket.socket,
+        pairing_handlers: dict[tuple[int, str], PairingHandler],
     ) -> None:
         """Initialize the protocol."""
         self.transport: asyncio.Transport | None = None
@@ -191,6 +219,10 @@ class BluetoothMGMTProtocol:
         self._buffer_len = 0
         self._pos = 0
         self._scanners = scanners
+        # Shared by reference with MGMTBluetoothCtl; keyed by
+        # (controller_idx, peer address) so pairing events route to the client
+        # that registered for them.
+        self._pairing_handlers = pairing_handlers
         self._on_connection_lost = on_connection_lost
         self._is_shutting_down = is_shutting_down
         # Keyed by (opcode, controller_idx) so the same command can be in flight
@@ -341,6 +373,14 @@ class BluetoothMGMTProtocol:
                             future.set_result((status, response_data))
                 self._remove_from_buffer()
                 continue
+            elif event_code == MGMT_EV_NEW_LONG_TERM_KEY:
+                self._handle_new_long_term_key(controller_idx, header[6 : self._pos])
+                self._remove_from_buffer()
+                continue
+            elif event_code == MGMT_EV_AUTH_FAILED:
+                self._handle_auth_failed(controller_idx, header[6 : self._pos])
+                self._remove_from_buffer()
+                continue
             else:
                 self._remove_from_buffer()
                 continue
@@ -367,6 +407,44 @@ class BluetoothMGMTProtocol:
                     make_bluez_details(address_str, scanner.adapter),
                     monotonic_time_coarse(),
                 )
+
+    def _handle_new_long_term_key(self, controller_idx: _int, param: _bytes) -> None:
+        """Decode a NEW_LONG_TERM_KEY event and route it to its handler."""
+        if len(param) < _NEW_LTK_EV_SIZE:
+            _LOGGER.debug("hci%u: truncated NEW_LONG_TERM_KEY event", controller_idx)
+            return
+        store_hint = param[0]
+        addr, addr_type, key_type, central, enc_size, ediv, rand, value = (
+            LTK_INFO_UNPACK(param[1 : 1 + LTK_INFO_SIZE])
+        )
+        address = bytes_mac_to_str(addr)
+        if (handler := self._pairing_handlers.get((controller_idx, address))) is None:
+            return
+        handler(
+            NewLongTermKey(
+                store_hint,
+                LongTermKey(
+                    address,
+                    addr_type,
+                    key_type,
+                    bool(central),
+                    enc_size,
+                    ediv,
+                    rand,
+                    value,
+                ),
+            )
+        )
+
+    def _handle_auth_failed(self, controller_idx: _int, param: _bytes) -> None:
+        """Decode an AUTHENTICATION_FAILED event and route it to its handler."""
+        if len(param) < _AUTH_FAILED_EV_SIZE:
+            _LOGGER.debug("hci%u: truncated AUTH_FAILED event", controller_idx)
+            return
+        address = bytes_mac_to_str(param[0:6])
+        if (handler := self._pairing_handlers.get((controller_idx, address))) is None:
+            return
+        handler(AuthenticationFailed(address, param[6], param[7]))
 
     def _handle_load_conn_param_response(
         self, status: _int, controller_idx: _int
@@ -406,6 +484,10 @@ class MGMTBluetoothCtl:
         self.protocol: BluetoothMGMTProtocol | None = None
         self.sock: socket.socket | None = None
         self.scanners = scanners
+        # Pairing-event handlers keyed by (controller_idx, peer address); shared
+        # by reference with each protocol instance so registrations survive a
+        # socket reconnect.
+        self._pairing_handlers: dict[tuple[int, str], PairingHandler] = {}
         self._reconnect_task: asyncio.Task[None] | None = None
         self._on_connection_lost_future: asyncio.Future[None] | None = None
         self._shutting_down = False
@@ -467,6 +549,7 @@ class MGMTBluetoothCtl:
                         self._on_connection_lost,
                         lambda: self._shutting_down,
                         self.sock,
+                        self._pairing_handlers,
                     ),
                     None,
                     None,
@@ -831,6 +914,25 @@ class MGMTBluetoothCtl:
             "no response" if result is None else f"status={result[0]:#x}",
         )
         return False
+
+    def register_pairing_handler(
+        self, adapter_idx: int, address: str, handler: PairingHandler
+    ) -> Callable[[], None]:
+        """
+        Route NEW_LONG_TERM_KEY / AUTHENTICATION_FAILED events for a peer.
+
+        ``handler`` is called with a :class:`NewLongTermKey` or
+        :class:`AuthenticationFailed` for events on ``adapter_idx`` from
+        ``address``. Returns a callback that unregisters it.
+        """
+        key = (adapter_idx, address.upper())
+        self._pairing_handlers[key] = handler
+
+        def _unregister() -> None:
+            if self._pairing_handlers.get(key) is handler:
+                del self._pairing_handlers[key]
+
+        return _unregister
 
     def load_conn_params(
         self,

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -420,7 +420,8 @@ class BluetoothMGMTProtocol:
         address = bytes_mac_to_str(addr)
         if (handler := self._pairing_handlers.get((controller_idx, address))) is None:
             return
-        handler(
+        self._dispatch_pairing_event(
+            handler,
             NewLongTermKey(
                 store_hint,
                 LongTermKey(
@@ -433,7 +434,7 @@ class BluetoothMGMTProtocol:
                     rand,
                     value,
                 ),
-            )
+            ),
         )
 
     def _handle_auth_failed(self, controller_idx: _int, param: _bytes) -> None:
@@ -444,7 +445,22 @@ class BluetoothMGMTProtocol:
         address = bytes_mac_to_str(param[0:6])
         if (handler := self._pairing_handlers.get((controller_idx, address))) is None:
             return
-        handler(AuthenticationFailed(address, param[6], param[7]))
+        self._dispatch_pairing_event(
+            handler, AuthenticationFailed(address, param[6], param[7])
+        )
+
+    def _dispatch_pairing_event(
+        self,
+        handler: PairingHandler,
+        event: NewLongTermKey | AuthenticationFailed,
+    ) -> None:
+        """Call a pairing handler, isolating it from the socket read loop."""
+        # data_received runs in the read loop, so a raising handler must not tear
+        # down event demux for the whole mgmt connection.
+        try:
+            handler(event)
+        except Exception:
+            _LOGGER.exception("Error in %s handler", type(event).__name__)
 
     def _handle_load_conn_param_response(
         self, status: _int, controller_idx: _int
@@ -924,6 +940,16 @@ class MGMTBluetoothCtl:
         ``handler`` is called with a :class:`NewLongTermKey` or
         :class:`AuthenticationFailed` for events on ``adapter_idx`` from
         ``address``. Returns a callback that unregisters it.
+
+        ``address`` must be the canonical colon-separated form
+        (``AA:BB:CC:DD:EE:FF``); it is upper-cased to match the address the
+        event decoder produces, but any other shape (e.g. no colons) will simply
+        never match and the handler will not fire.
+
+        Registration is last-wins: a second call for the same
+        ``(adapter_idx, address)`` replaces the previous handler, and that
+        previous registration's unregister callback becomes a no-op. Handlers do
+        not stack.
         """
         key = (adapter_idx, address.upper())
         self._pairing_handlers[key] = handler

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -21,9 +21,11 @@ from habluetooth.channels.bluez import (
     MGMT_OP_STOP_DISCOVERY,
     MGMT_OP_UNPAIR_DEVICE,
     SCAN_TYPE_LE,
+    AuthenticationFailed,
     BluetoothMGMTProtocol,
     LongTermKey,
     MGMTBluetoothCtl,
+    NewLongTermKey,
     bytes_mac_to_str,
     make_bluez_details,
 )
@@ -97,7 +99,7 @@ def test_connection_made(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
     protocol.connection_made(mock_transport)
 
@@ -117,7 +119,7 @@ def test_connection_lost(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
     protocol.connection_made(mock_transport)
 
@@ -140,7 +142,7 @@ def test_connection_lost_no_exception(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
     protocol.connection_made(mock_transport)
 
@@ -160,7 +162,7 @@ def test_data_received_device_found(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a DEVICE_FOUND event (event_code 0x0012). Header layout is
@@ -204,7 +206,7 @@ def test_data_received_adv_monitor_device_found(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create an ADV_MONITOR_DEVICE_FOUND event (event_code 0x002F)
@@ -248,7 +250,7 @@ def test_data_received_cmd_complete_success(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_COMPLETE event for LOAD_CONN_PARAM
@@ -276,7 +278,7 @@ def test_data_received_cmd_complete_failure(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_COMPLETE event with failure
@@ -303,7 +305,7 @@ def test_data_received_cmd_status(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_STATUS event
@@ -330,7 +332,7 @@ def test_data_received_partial_data(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a DEVICE_FOUND event but send it in chunks
@@ -361,7 +363,7 @@ def test_data_received_partial_data_split_in_params(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a DEVICE_FOUND event
@@ -399,7 +401,7 @@ def test_data_received_multiple_small_chunks(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a DEVICE_FOUND event
@@ -433,7 +435,7 @@ def test_data_received_multiple_events_in_one_chunk(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create two events: a DEVICE_FOUND and a CMD_COMPLETE
@@ -466,7 +468,7 @@ def test_data_received_partial_then_multiple_events(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # First event (DEVICE_FOUND)
@@ -527,7 +529,7 @@ def test_data_received_cmd_complete_different_opcode(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_COMPLETE event for a different opcode (e.g., 0x0004 - Add UUID)
@@ -555,7 +557,7 @@ def test_data_received_cmd_status_different_opcode(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_STATUS event for a different opcode
@@ -583,7 +585,7 @@ def test_data_received_cmd_complete_short_params(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_COMPLETE event with param_len < 3
@@ -610,7 +612,7 @@ def test_data_received_cmd_status_param_len_1(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_STATUS event with param_len = 1
@@ -637,7 +639,7 @@ def test_data_received_cmd_complete_param_len_0(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a CMD_COMPLETE event with param_len = 0
@@ -660,7 +662,7 @@ def test_data_received_unknown_event(event_loop: asyncio.AbstractEventLoop) -> N
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create an unknown event
@@ -684,7 +686,7 @@ def test_data_received_no_scanner_for_controller(
     is_shutting_down = Mock(return_value=False)
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Create a DEVICE_FOUND event for controller 0
@@ -1027,7 +1029,7 @@ def test_kernel_bug_workaround_send_returns_zero(
     mock_socket = Mock()
     mock_socket.send = Mock(return_value=0)
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_socket
+        future, scanners, on_connection_lost, is_shutting_down, mock_socket, {}
     )
 
     # Send some data
@@ -1053,7 +1055,7 @@ def test_kernel_bug_workaround_send_raises_exception(
     mock_socket = Mock()
     mock_socket.send = Mock(side_effect=OSError("Socket error"))
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_socket
+        future, scanners, on_connection_lost, is_shutting_down, mock_socket, {}
     )
 
     # Send some data and expect the exception to be re-raised
@@ -1253,7 +1255,7 @@ async def test_command_response_context_manager() -> None:
 
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     # Test successful command response
@@ -1292,7 +1294,7 @@ async def test_command_response_cleanup_on_exception() -> None:
 
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
@@ -1321,7 +1323,7 @@ async def test_get_connections_response_handling() -> None:
 
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
@@ -1355,7 +1357,7 @@ async def test_get_connections_response_with_data() -> None:
 
     mock_sock = Mock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, on_connection_lost, is_shutting_down, mock_sock
+        future, scanners, on_connection_lost, is_shutting_down, mock_sock, {}
     )
 
     opcode = 0x0015  # MGMT_OP_GET_CONNECTIONS
@@ -1787,7 +1789,7 @@ async def test_command_response_skips_already_resolved_future() -> None:
     future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
     future.set_result(None)
     protocol = BluetoothMGMTProtocol(
-        future, {}, Mock(), Mock(return_value=False), Mock()
+        future, {}, Mock(), Mock(return_value=False), Mock(), {}
     )
     async with protocol.command_response(MGMT_OP_START_DISCOVERY, 0) as fut:
         # Resolve early, then deliver a late response for the same command.
@@ -1808,7 +1810,7 @@ async def test_command_response_for_unregistered_command_is_ignored() -> None:
     future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
     future.set_result(None)
     protocol = BluetoothMGMTProtocol(
-        future, {}, Mock(), Mock(return_value=False), Mock()
+        future, {}, Mock(), Mock(return_value=False), Mock(), {}
     )
     # No command_response registered for this opcode/controller: must not raise.
     protocol.data_received(
@@ -1891,7 +1893,7 @@ async def test_per_controller_command_response_isolation() -> None:
     future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
     future.set_result(None)
     protocol = BluetoothMGMTProtocol(
-        future, {}, Mock(), Mock(return_value=False), Mock()
+        future, {}, Mock(), Mock(return_value=False), Mock(), {}
     )
 
     async with (
@@ -2132,3 +2134,141 @@ async def test_load_long_term_keys_rejects_out_of_range_field() -> None:
     )  # key_type 300 does not fit in a byte
     assert await mgmt_ctl.load_long_term_keys(0, [bad]) is False
     mock_protocol._write_to_socket.assert_not_called()
+
+
+# -- pairing event capture ------------------------------------------------
+def _new_ltk_frame(
+    *,
+    store_hint: int = 1,
+    address: bytes = b"\xff\xee\xdd\xcc\xbb\xaa",  # little-endian AA:BB:..:FF
+    controller_idx: int = 0,
+) -> bytes:
+    ltk_info = (
+        address
+        + bytes([0x01, 0x05, 0x00, 0x10])  # type, key_type, central, enc_size
+        + (0x1234).to_bytes(2, "little")  # ediv
+        + bytes(range(8))  # rand
+        + bytes(range(16))  # value
+    )
+    param = bytes([store_hint]) + ltk_info
+    header = (
+        (0x000A).to_bytes(2, "little")
+        + controller_idx.to_bytes(2, "little")
+        + len(param).to_bytes(2, "little")
+    )
+    return header + param
+
+
+def _protocol_with_handlers(
+    event_loop: asyncio.AbstractEventLoop,
+    handlers: dict[tuple[int, str], Callable[..., None]],
+) -> BluetoothMGMTProtocol:
+    return BluetoothMGMTProtocol(
+        event_loop.create_future(),
+        {},
+        Mock(),
+        Mock(return_value=False),
+        Mock(),
+        handlers,
+    )
+
+
+def test_data_received_new_long_term_key(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A NEW_LONG_TERM_KEY event is decoded and routed to its handler."""
+    received: list[object] = []
+    handlers = {(0, "AA:BB:CC:DD:EE:FF"): received.append}
+    protocol = _protocol_with_handlers(event_loop, handlers)
+
+    protocol.data_received(_new_ltk_frame())
+
+    assert len(received) == 1
+    event = received[0]
+    assert isinstance(event, NewLongTermKey)
+    assert event.store_hint == 1
+    key = event.key
+    assert key == LongTermKey(
+        address="AA:BB:CC:DD:EE:FF",
+        address_type=0x01,
+        key_type=0x05,
+        central=False,
+        encryption_size=0x10,
+        ediv=0x1234,
+        rand=bytes(range(8)),
+        value=bytes(range(16)),
+    )
+
+
+def test_data_received_auth_failed(event_loop: asyncio.AbstractEventLoop) -> None:
+    """An AUTHENTICATION_FAILED event is decoded and routed to its handler."""
+    received: list[object] = []
+    handlers = {(0, "AA:BB:CC:DD:EE:FF"): received.append}
+    protocol = _protocol_with_handlers(event_loop, handlers)
+
+    param = b"\xff\xee\xdd\xcc\xbb\xaa" + bytes([0x01, 0x05])  # type, status
+    header = (
+        (0x0011).to_bytes(2, "little") + b"\x00\x00" + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)
+
+    assert received == [AuthenticationFailed("AA:BB:CC:DD:EE:FF", 0x01, 0x05)]
+
+
+def test_pairing_event_without_handler_is_dropped(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """An event for an unregistered peer is dropped without error."""
+    protocol = _protocol_with_handlers(event_loop, {})
+    protocol.data_received(_new_ltk_frame())  # no handlers -> no-op
+    auth_param = b"\xff\xee\xdd\xcc\xbb\xaa" + bytes([0x01, 0x05])
+    auth_header = (
+        (0x0011).to_bytes(2, "little")
+        + b"\x00\x00"
+        + len(auth_param).to_bytes(2, "little")
+    )
+    protocol.data_received(auth_header + auth_param)  # no handlers -> no-op
+
+
+def test_truncated_new_long_term_key_is_dropped(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A NEW_LONG_TERM_KEY event too short to hold a key is dropped."""
+    received: list[object] = []
+    handlers = {(0, "AA:BB:CC:DD:EE:FF"): received.append}
+    protocol = _protocol_with_handlers(event_loop, handlers)
+
+    param = b"\x01\xff\xee"  # store_hint + 2 bytes (well short of 1 + 36)
+    header = (
+        (0x000A).to_bytes(2, "little") + b"\x00\x00" + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)
+    assert received == []
+
+
+def test_truncated_auth_failed_is_dropped(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """An AUTHENTICATION_FAILED event shorter than 8 bytes is dropped."""
+    received: list[object] = []
+    handlers = {(0, "AA:BB:CC:DD:EE:FF"): received.append}
+    protocol = _protocol_with_handlers(event_loop, handlers)
+
+    param = b"\xff\xee\xdd"  # 3 bytes, short of 8
+    header = (
+        (0x0011).to_bytes(2, "little") + b"\x00\x00" + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_register_pairing_handler_normalizes_and_unregisters() -> None:
+    """register_pairing_handler normalizes the address and unregisters cleanly."""
+    mgmt_ctl = MGMTBluetoothCtl(timeout=5.0, scanners={})
+    handler = Mock()
+    unregister = mgmt_ctl.register_pairing_handler(0, "aa:bb:cc:dd:ee:ff", handler)
+    assert mgmt_ctl._pairing_handlers[(0, "AA:BB:CC:DD:EE:FF")] is handler
+    unregister()
+    assert (0, "AA:BB:CC:DD:EE:FF") not in mgmt_ctl._pairing_handlers
+    unregister()  # idempotent, does not raise

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -2262,6 +2262,31 @@ def test_truncated_auth_failed_is_dropped(
     assert received == []
 
 
+def test_pairing_handler_exception_is_isolated(
+    event_loop: asyncio.AbstractEventLoop,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising handler is logged, not allowed to break the read loop."""
+
+    def boom(_event: object) -> None:
+        msg = "handler exploded"
+        raise RuntimeError(msg)
+
+    handlers = {(0, "AA:BB:CC:DD:EE:FF"): boom}
+    protocol = _protocol_with_handlers(event_loop, handlers)
+    with caplog.at_level("ERROR", logger="habluetooth.channels.bluez"):
+        # Neither dispatch path should raise out of data_received.
+        protocol.data_received(_new_ltk_frame())
+        auth_param = b"\xff\xee\xdd\xcc\xbb\xaa" + bytes([0x01, 0x05])
+        auth_header = (
+            (0x0011).to_bytes(2, "little")
+            + b"\x00\x00"
+            + len(auth_param).to_bytes(2, "little")
+        )
+        protocol.data_received(auth_header + auth_param)
+    assert caplog.text.count("Error in") == 2  # both handlers logged
+
+
 @pytest.mark.asyncio
 async def test_register_pairing_handler_normalizes_and_unregisters() -> None:
     """register_pairing_handler normalizes the address and unregisters cleanly."""
@@ -2272,3 +2297,16 @@ async def test_register_pairing_handler_normalizes_and_unregisters() -> None:
     unregister()
     assert (0, "AA:BB:CC:DD:EE:FF") not in mgmt_ctl._pairing_handlers
     unregister()  # idempotent, does not raise
+
+
+@pytest.mark.asyncio
+async def test_register_pairing_handler_last_wins() -> None:
+    """A second registration replaces the first; the first's unregister no-ops."""
+    mgmt_ctl = MGMTBluetoothCtl(timeout=5.0, scanners={})
+    first, second = Mock(), Mock()
+    key = (0, "AA:BB:CC:DD:EE:FF")
+    unregister_first = mgmt_ctl.register_pairing_handler(0, "AA:BB:CC:DD:EE:FF", first)
+    mgmt_ctl.register_pairing_handler(0, "AA:BB:CC:DD:EE:FF", second)
+    assert mgmt_ctl._pairing_handlers[key] is second
+    unregister_first()  # must not remove the newer handler
+    assert mgmt_ctl._pairing_handlers[key] is second

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -943,7 +943,7 @@ async def test_inject_100_bluez_raw_end_to_end_unchanged(
     future: asyncio.Future[None] = loop.create_future()
     mock_sock = MagicMock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, lambda: None, lambda: False, mock_sock
+        future, scanners, lambda: None, lambda: False, mock_sock, {}
     )
 
     # Build a DEVICE_FOUND MGMT packet
@@ -994,7 +994,7 @@ async def test_inject_100_bluez_raw_end_to_end_changed(
     future: asyncio.Future[None] = loop.create_future()
     mock_sock = MagicMock()
     protocol = BluetoothMGMTProtocol(
-        future, scanners, lambda: None, lambda: False, mock_sock
+        future, scanners, lambda: None, lambda: False, mock_sock, {}
     )
 
     # Build 100 different DEVICE_FOUND MGMT packets with varying manufacturer data


### PR DESCRIPTION
Adds the receive side of pairing to the bluez channel. The management socket pushes NEW_LONG_TERM_KEY (0x000A) when bonding completes and AUTHENTICATION_FAILED (0x0011) when it does not; data_received now decodes both and routes them to a per peer handler. NEW_LONG_TERM_KEY is decoded into the existing LongTermKey record (so the client can persist it and feed it back via load_long_term_keys on reconnect) wrapped in a NewLongTermKey event with the kernel store hint; AUTHENTICATION_FAILED is decoded into an AuthenticationFailed event with the status.

Handlers are registered via MGMTBluetoothCtl.register_pairing_handler(adapter_idx, address, handler), which returns an unregister callback and normalizes the address. The handler dict is shared by reference with each protocol instance, like the scanners dict, so registrations survive a socket reconnect; the protocol looks up (controller_idx, address) and calls the handler. Event codes and the 36 byte mgmt_ltk_info layout came from the installed btsocket btmgmt_protocol; a truncated event is dropped with a debug log rather than mis-parsed.

This completes the bond persistence pair with the merged load_long_term_keys and unblocks the client capturing keys during pairing. The new event codes stay plain module constants since NEW_LTK and AUTH_FAILED are rare frames matched after the hot DEVICE_FOUND branch; the only pxd change is one cdef dict attribute on the protocol for the shared handler map. Nothing calls this yet, no behavior change.

Tested decode and dispatch of both events field by field, the no handler and truncated cases, and that register_pairing_handler normalizes the address and unregisters idempotently; the new code is fully covered. Verified on a cython build since this touches data_received and the protocol pxd.