### PR TITLE
feat(manager): warn when active scan is requested with a passive-only scanner

### DIFF
--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -768,6 +768,11 @@ class AutoScanScheduler:
         self._on_demand_sweep_future: asyncio.Future[None] | None = None
         self._on_demand_sweep_end: float = 0.0
 
+    @property
+    def has_active_requests(self) -> bool:
+        """Return True if any address has a registered active-scan request."""
+        return bool(self._requests_by_address)
+
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         """
         Bind to the event loop and spawn one worker per AUTO scanner.

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -66,6 +66,7 @@ cdef class BluetoothManager:
     cdef public dict _allocations
     cdef public dict _scanner_registration_callbacks
     cdef public dict _scanner_mode_change_callbacks
+    cdef public set _warned_passive_active_scan
     cdef public object _subclass_discover_info
     cdef public bint has_advertising_side_channel
     cdef public dict _side_channel_scanners

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -46,6 +46,7 @@ from .const import (
 )
 from .models import (
     BluetoothReachabilityIntent,
+    BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     HaBluetoothSlotAllocations,
     HaScannerModeChange,
@@ -149,6 +150,7 @@ class BluetoothManager:
         "_sources",
         "_subclass_discover_info",
         "_unavailable_callbacks",
+        "_warned_passive_active_scan",
         "has_advertising_side_channel",
         "shutdown",
         "slot_manager",
@@ -215,6 +217,10 @@ class BluetoothManager:
         self._scanner_mode_change_callbacks: dict[
             str | None, set[Callable[[HaScannerModeChange], None]]
         ] = {}
+        # Sources of passive-only scanners we've already warned about
+        # while active scans are requested; deduped so one passive proxy
+        # behind many devices warns once.
+        self._warned_passive_active_scan: set[str] = set()
         self._subclass_discover_info = self._discover_service_info
         self._mgmt_ctl: MGMTBluetoothCtl | None = None
         self._auto_scheduler = AutoScanScheduler(self)
@@ -1175,6 +1181,7 @@ class BluetoothManager:
         scanners.discard(scanner)
         scanner._clear_connection_history()
         self._sources.pop(scanner.source, None)
+        self._warned_passive_active_scan.discard(scanner.source)
         self._adapter_sources.pop(scanner.adapter, None)
         self._allocations.pop(scanner.source, None)
         if connection_slots:
@@ -1210,6 +1217,9 @@ class BluetoothManager:
                 self.slot_manager.get_allocations(scanner.adapter)
             )
         self._auto_scheduler.add_scanner(scanner)
+        # Covers a scanner registered already in passive mode (no later
+        # set_requested_mode to trigger scanner_mode_changed).
+        self._async_warn_if_passive_with_active_scan(scanner)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.ADDED)
         return partial(
             self._async_unregister_scanner_internal, scanners, scanner, connection_slots
@@ -1286,6 +1296,10 @@ class BluetoothManager:
         normalized = address.upper() if ":" in address else address
         request = ActiveScanRequest(normalized, scan_interval, scan_duration)
         self._auto_scheduler.add_request(request)
+        # An active scan now exists: warn about any passive-only scanner
+        # that could own such a device and silently starve it.
+        for scanner in self._sources.values():
+            self._async_warn_if_passive_with_active_scan(scanner)
         return partial(self._auto_scheduler.remove_request, request)
 
     async def async_request_active_scan(self, duration: float | None = None) -> None:
@@ -1447,6 +1461,7 @@ class BluetoothManager:
 
     def scanner_mode_changed(self, scanner: BaseHaScanner) -> None:
         """Notify callbacks that a scanner's mode has changed."""
+        self._async_warn_if_passive_with_active_scan(scanner)
         self._dispatch_source_callbacks(
             self._scanner_mode_change_callbacks,
             scanner.source,
@@ -1456,4 +1471,34 @@ class BluetoothManager:
                 current_mode=scanner.current_mode,
             ),
             "scanner mode change callback",
+        )
+
+    def _async_warn_if_passive_with_active_scan(self, scanner: BaseHaScanner) -> None:
+        """
+        Warn once if ``scanner`` is passive-only while active scans are wanted.
+
+        A passive-only scanner never runs an active window, so if it
+        becomes the closest scanner for a device that only answers on
+        its scan response (and an integration has asked for active
+        scans on that device) the device's data may be missing. Deduped
+        per source; the entry is dropped on unregister or when the
+        scanner leaves passive mode so a later relapse warns again.
+        """
+        source = scanner.source
+        if scanner.requested_mode is not BluetoothScanningMode.PASSIVE:
+            self._warned_passive_active_scan.discard(source)
+            return
+        if (
+            source in self._warned_passive_active_scan
+            or not self._auto_scheduler._requests_by_address
+        ):
+            return
+        self._warned_passive_active_scan.add(source)
+        _LOGGER.warning(
+            "Scanner %s is in passive-only mode but active scans have been "
+            "requested for one or more devices; if it becomes the closest "
+            "scanner for such a device the device will not be actively "
+            "scanned and its data may be incomplete or missing. Set this "
+            "scanner to active or auto",
+            scanner.name,
         )

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1482,7 +1482,11 @@ class BluetoothManager:
         its scan response (and an integration has asked for active
         scans on that device) the device's data may be missing. Deduped
         per source; the entry is dropped on unregister or when the
-        scanner leaves passive mode so a later relapse warns again.
+        scanner leaves passive mode so a later relapse warns again. It is
+        intentionally not reset when active-scan requests drop to zero:
+        the warning is per-source config advice ("this scanner is
+        passive, fix its mode"), so one warning per source is enough and
+        a later request for a different device need not re-warn.
         """
         source = scanner.source
         if scanner.requested_mode is not BluetoothScanningMode.PASSIVE:
@@ -1490,7 +1494,7 @@ class BluetoothManager:
             return
         if (
             source in self._warned_passive_active_scan
-            or not self._auto_scheduler._requests_by_address
+            or not self._auto_scheduler.has_active_requests
         ):
             return
         self._warned_passive_active_scan.add(source)

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -4646,6 +4646,21 @@ async def test_async_diagnostics_last_active_window() -> None:
     assert sched._last_window_by_address == {}
 
 
+@pytest.mark.asyncio
+async def test_has_active_requests() -> None:
+    """has_active_requests reflects whether any active-scan request exists."""
+    manager = get_manager()
+    sched = manager._auto_scheduler
+    before = sched.has_active_requests
+    cancel = manager.async_register_active_scan("11:22:33:44:55:66")
+    during = sched.has_active_requests
+    cancel()
+    after = sched.has_active_requests
+    assert before is False
+    assert during is True
+    assert after is False
+
+
 @contextlib.asynccontextmanager
 async def _no_real_sleep():
     """

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock, PropertyMock, patch
@@ -547,6 +547,135 @@ async def test_async_register_scanner_mode_change_callback(
     cancel1()
     cancel2()
     cancel3()
+
+
+_PASSIVE_WARNING = "is in passive-only mode"
+
+
+@pytest.mark.asyncio
+async def test_active_scan_warns_about_existing_passive_scanner(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Registering an active scan warns when a passive-only scanner exists."""
+    manager = get_manager()
+    passive = FakeScanner(
+        "AA:BB:CC:DD:EE:01", "hci1", requested_mode=BluetoothScanningMode.PASSIVE
+    )
+    cancel_scanner = manager.async_register_scanner(passive)
+    try:
+        with caplog.at_level(logging.WARNING):
+            cancel_scan = manager.async_register_active_scan("AA:BB:CC:DD:EE:99")
+        assert _PASSIVE_WARNING in caplog.text
+        assert passive.name in caplog.text
+    finally:
+        cancel_scan()
+        cancel_scanner()
+
+
+@pytest.mark.asyncio
+async def test_scanner_going_passive_after_active_scan_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A scanner becoming passive while active scans exist warns once."""
+    manager = get_manager()
+    cancel_scan = manager.async_register_active_scan("AA:BB:CC:DD:EE:99")
+    auto = FakeScanner(
+        "AA:BB:CC:DD:EE:02", "hci2", requested_mode=BluetoothScanningMode.AUTO
+    )
+    cancel_scanner = manager.async_register_scanner(auto)
+    try:
+        with caplog.at_level(logging.WARNING):
+            # Current-mode toggles on an AUTO scanner must not warn.
+            auto.set_current_mode(BluetoothScanningMode.ACTIVE)
+            assert _PASSIVE_WARNING not in caplog.text
+            # Flipping the requested mode to passive warns.
+            auto.set_requested_mode(BluetoothScanningMode.PASSIVE)
+        assert caplog.text.count(_PASSIVE_WARNING) == 1
+        assert auto.name in caplog.text
+    finally:
+        cancel_scanner()
+        cancel_scan()
+
+
+@pytest.mark.asyncio
+async def test_passive_scanner_warning_dedupes_per_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One passive scanner warns once across many active-scan registrations."""
+    manager = get_manager()
+    passive = FakeScanner(
+        "AA:BB:CC:DD:EE:03", "hci3", requested_mode=BluetoothScanningMode.PASSIVE
+    )
+    cancel_scanner = manager.async_register_scanner(passive)
+    cancels: list[Callable[[], None]] = []
+    try:
+        with caplog.at_level(logging.WARNING):
+            cancels.extend(
+                manager.async_register_active_scan(addr)
+                for addr in ("AA:BB:CC:DD:EE:91", "AA:BB:CC:DD:EE:92")
+            )
+        assert caplog.text.count(_PASSIVE_WARNING) == 1
+    finally:
+        for cancel in cancels:
+            cancel()
+        cancel_scanner()
+
+
+@pytest.mark.asyncio
+async def test_active_scan_no_warning_for_auto_or_active_scanner(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning when the only scanners are auto or active."""
+    manager = get_manager()
+    auto = FakeScanner(
+        "AA:BB:CC:DD:EE:04", "hci4", requested_mode=BluetoothScanningMode.AUTO
+    )
+    active = FakeScanner(
+        "AA:BB:CC:DD:EE:05", "hci5", requested_mode=BluetoothScanningMode.ACTIVE
+    )
+    cancel_auto = manager.async_register_scanner(auto)
+    cancel_active = manager.async_register_scanner(active)
+    try:
+        with caplog.at_level(logging.WARNING):
+            cancel_scan = manager.async_register_active_scan("AA:BB:CC:DD:EE:99")
+        assert _PASSIVE_WARNING not in caplog.text
+    finally:
+        cancel_scan()
+        cancel_auto()
+        cancel_active()
+
+
+@pytest.mark.asyncio
+async def test_passive_scanner_warning_resets_after_unregister(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Re-registering a passive scanner warns again after it is unregistered."""
+    manager = get_manager()
+    cancel_scan = manager.async_register_active_scan("AA:BB:CC:DD:EE:99")
+    try:
+        with caplog.at_level(logging.WARNING):
+            cancel_scanner = manager.async_register_scanner(
+                FakeScanner(
+                    "AA:BB:CC:DD:EE:06",
+                    "hci6",
+                    requested_mode=BluetoothScanningMode.PASSIVE,
+                )
+            )
+        assert caplog.text.count(_PASSIVE_WARNING) == 1
+        cancel_scanner()
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            cancel_scanner2 = manager.async_register_scanner(
+                FakeScanner(
+                    "AA:BB:CC:DD:EE:06",
+                    "hci6",
+                    requested_mode=BluetoothScanningMode.PASSIVE,
+                )
+            )
+        assert caplog.text.count(_PASSIVE_WARNING) == 1
+        cancel_scanner2()
+    finally:
+        cancel_scan()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A passive-only scanner never runs an active window, so if it becomes the closest scanner for a device that only answers on its scan response, it will silently starve that device; there is no signal today that this is happening.

This warns once per source when an active scan is registered while a passive-only scanner exists, and when a scanner goes passive while active-scan requests already exist. The dedup keeps one passive proxy behind several devices from logging repeatedly, and the entry resets on unregister or when the scanner leaves passive mode.

Motivated by home-assistant/core#174169, where a 2nd ESPHome proxy left in passive mode took ownership of an Inkbird sensor and starved it with no warning.