### PR TITLE
feat: wire mgmt pairing and bond restore into the gatt client

### DIFF
--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -405,7 +405,11 @@ class HaMgmtClient(BaseBleakClient):
     async def unpair(self) -> None:
         """Remove the bond over mgmt and forget the stored key."""
         mgmt, adapter_idx = self._require_mgmt()
-        await mgmt.unpair_device(adapter_idx, self.address, self._address_type)
+        if not await mgmt.unpair_device(adapter_idx, self.address, self._address_type):
+            # Don't drop the local key if the kernel bond is still there, or the
+            # store would silently desync from the controller.
+            msg = f"{self.address}: unpair failed"
+            raise BleakError(msg)
         if self._forget_long_term_keys is not None:
             self._forget_long_term_keys(self.address)
 

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -92,9 +92,13 @@ class MgmtClientData:
     # instance so reconnects can restore them).
     adapter_idx: int | None = None
     mgmt: MGMTBluetoothCtl | None = None
-    get_long_term_key: Callable[[str], LongTermKey | None] | None = None
-    set_long_term_key: Callable[[str, LongTermKey], None] | None = None
-    forget_long_term_key: Callable[[str], None] | None = None
+    # get_long_term_keys returns every bonded key for the adapter (LOAD_LONG_TERM_
+    # KEYS replaces the controller's whole list, so a restore must send them all);
+    # add_long_term_key stores one captured key; forget_long_term_keys drops all
+    # keys for a peer on unpair.
+    get_long_term_keys: Callable[[], list[LongTermKey]] | None = None
+    add_long_term_key: Callable[[LongTermKey], None] | None = None
+    forget_long_term_keys: Callable[[str], None] | None = None
 
 
 class HaMgmtClient(BaseBleakClient):
@@ -116,9 +120,9 @@ class HaMgmtClient(BaseBleakClient):
         self._unregister_connection = client_data.unregister_connection
         self._adapter_idx = client_data.adapter_idx
         self._mgmt = client_data.mgmt
-        self._get_long_term_key = client_data.get_long_term_key
-        self._set_long_term_key = client_data.set_long_term_key
-        self._forget_long_term_key = client_data.forget_long_term_key
+        self._get_long_term_keys = client_data.get_long_term_keys
+        self._add_long_term_key = client_data.add_long_term_key
+        self._forget_long_term_keys = client_data.forget_long_term_keys
         details = getattr(address_or_ble_device, "details", None) or {}
         if "address_type" in details:
             self._address_type: int = details["address_type"]
@@ -346,14 +350,23 @@ class HaMgmtClient(BaseBleakClient):
 
     # -- pairing -----------------------------------------------------------
     async def _restore_bond(self) -> None:
-        """Reload a stored long-term key so the kernel re-encrypts a known peer."""
+        """Reload all bonded keys so the kernel re-encrypts known peers."""
         if (
-            self._mgmt is not None
-            and self._adapter_idx is not None
-            and self._get_long_term_key is not None
-            and (ltk := self._get_long_term_key(self.address)) is not None
+            self._mgmt is None
+            or self._adapter_idx is None
+            or self._get_long_term_keys is None
         ):
-            await self._mgmt.load_long_term_keys(self._adapter_idx, [ltk])
+            return
+        # LOAD_LONG_TERM_KEYS replaces the controller's whole list, so send every
+        # stored key; the kernel ignores keys for peers that are not connecting,
+        # and we must not wipe other peers' bonds on this adapter.
+        keys = self._get_long_term_keys()
+        if keys and not await self._mgmt.load_long_term_keys(self._adapter_idx, keys):
+            _LOGGER.warning(
+                "%s: failed to restore %d bonded key(s); the link may not encrypt",
+                self.address,
+                len(keys),
+            )
 
     def _require_mgmt(self) -> tuple[MGMTBluetoothCtl, int]:
         """Return the mgmt controller and adapter index, or raise if unavailable."""
@@ -368,8 +381,18 @@ class HaMgmtClient(BaseBleakClient):
         address = self.address
 
         def _capture(event: NewLongTermKey | AuthenticationFailed) -> None:
-            if isinstance(event, NewLongTermKey) and self._set_long_term_key:
-                self._set_long_term_key(address, event.key)
+            if not isinstance(event, NewLongTermKey):
+                return
+            if not event.store_hint:
+                # The kernel is signalling a key it does not want persisted.
+                return
+            if self._add_long_term_key is None:
+                _LOGGER.warning(
+                    "%s: captured a long-term key but no key store is wired",
+                    address,
+                )
+                return
+            self._add_long_term_key(event.key)
 
         unregister = mgmt.register_pairing_handler(adapter_idx, address, _capture)
         try:
@@ -383,8 +406,8 @@ class HaMgmtClient(BaseBleakClient):
         """Remove the bond over mgmt and forget the stored key."""
         mgmt, adapter_idx = self._require_mgmt()
         await mgmt.unpair_device(adapter_idx, self.address, self._address_type)
-        if self._forget_long_term_key is not None:
-            self._forget_long_term_key(self.address)
+        if self._forget_long_term_keys is not None:
+            self._forget_long_term_keys(self.address)
 
     def _codec(self) -> ATTClient:
         """Return the live ATT codec or raise if the channel is down."""

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -38,6 +38,7 @@ from .channels.att import (
     ATTClient,
     properties_to_strings,
 )
+from .channels.bluez import NewLongTermKey
 from .channels.l2cap import L2CAPSocket
 from .const import BDADDR_LE_PUBLIC
 
@@ -50,6 +51,11 @@ if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
 
     from .channels.att import GattService
+    from .channels.bluez import (
+        AuthenticationFailed,
+        LongTermKey,
+        MGMTBluetoothCtl,
+    )
 
 
 class SupportsConnecting(Protocol):
@@ -81,6 +87,14 @@ class MgmtClientData:
     # the client reports connect/disconnect by peer address here.
     register_connection: Callable[[str], None] | None = None
     unregister_connection: Callable[[str], None] | None = None
+    # Pairing: the scanner supplies the mgmt controller, the adapter index, and a
+    # per-adapter long-term-key store (bonds must outlive a per-connection client
+    # instance so reconnects can restore them).
+    adapter_idx: int | None = None
+    mgmt: MGMTBluetoothCtl | None = None
+    get_long_term_key: Callable[[str], LongTermKey | None] | None = None
+    set_long_term_key: Callable[[str, LongTermKey], None] | None = None
+    forget_long_term_key: Callable[[str], None] | None = None
 
 
 class HaMgmtClient(BaseBleakClient):
@@ -100,6 +114,11 @@ class HaMgmtClient(BaseBleakClient):
         self._scanner = client_data.scanner
         self._register_connection = client_data.register_connection
         self._unregister_connection = client_data.unregister_connection
+        self._adapter_idx = client_data.adapter_idx
+        self._mgmt = client_data.mgmt
+        self._get_long_term_key = client_data.get_long_term_key
+        self._set_long_term_key = client_data.set_long_term_key
+        self._forget_long_term_key = client_data.forget_long_term_key
         details = getattr(address_or_ble_device, "details", None) or {}
         if "address_type" in details:
             self._address_type: int = details["address_type"]
@@ -132,9 +151,10 @@ class HaMgmtClient(BaseBleakClient):
         if self._connected:
             msg = "already connected"
             raise BleakError(msg)
+        await self._restore_bond()
         if pair:
             _LOGGER.debug(
-                "%s: mgmt client does not pair on connect; relying on bonded keys",
+                "%s: connect(pair=True); use pair() to bond explicitly",
                 self.address,
             )
         att = ATTClient(send=self._send_pdu, on_disconnect=self._handle_disconnect)
@@ -324,16 +344,47 @@ class HaMgmtClient(BaseBleakClient):
             await codec.write(cccd.handle, _CCCD_OFF)
         codec.remove_notify_handler(characteristic.handle)
 
-    # -- pairing (not yet supported) --------------------------------------
+    # -- pairing -----------------------------------------------------------
+    async def _restore_bond(self) -> None:
+        """Reload a stored long-term key so the kernel re-encrypts a known peer."""
+        if (
+            self._mgmt is not None
+            and self._adapter_idx is not None
+            and self._get_long_term_key is not None
+            and (ltk := self._get_long_term_key(self.address)) is not None
+        ):
+            await self._mgmt.load_long_term_keys(self._adapter_idx, [ltk])
+
+    def _require_mgmt(self) -> tuple[MGMTBluetoothCtl, int]:
+        """Return the mgmt controller and adapter index, or raise if unavailable."""
+        if self._mgmt is None or self._adapter_idx is None:
+            msg = "pairing requires the management socket"
+            raise BleakError(msg)
+        return self._mgmt, self._adapter_idx
+
     async def pair(self, *args: Any, **kwargs: Any) -> None:
-        """Pairing via mgmt is not implemented yet."""
-        msg = "pairing is not supported by the mgmt client yet"
-        raise NotImplementedError(msg)
+        """Bond with the peer over mgmt, capturing the key for reconnects."""
+        mgmt, adapter_idx = self._require_mgmt()
+        address = self.address
+
+        def _capture(event: NewLongTermKey | AuthenticationFailed) -> None:
+            if isinstance(event, NewLongTermKey) and self._set_long_term_key:
+                self._set_long_term_key(address, event.key)
+
+        unregister = mgmt.register_pairing_handler(adapter_idx, address, _capture)
+        try:
+            if not await mgmt.pair_device(adapter_idx, address, self._address_type):
+                msg = f"{address}: pairing failed"
+                raise BleakError(msg)
+        finally:
+            unregister()
 
     async def unpair(self) -> None:
-        """Unpairing via mgmt is not implemented yet."""
-        msg = "unpairing is not supported by the mgmt client yet"
-        raise NotImplementedError(msg)
+        """Remove the bond over mgmt and forget the stored key."""
+        mgmt, adapter_idx = self._require_mgmt()
+        await mgmt.unpair_device(adapter_idx, self.address, self._address_type)
+        if self._forget_long_term_key is not None:
+            self._forget_long_term_key(self.address)
 
     def _codec(self) -> ATTClient:
         """Return the live ATT codec or raise if the channel is down."""

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
     from bleak.backends.scanner import AdvertisementData
 
+    from .channels.bluez import LongTermKey
     from .const import CALLBACK_TYPE
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,6 +83,12 @@ class HaScannerMgmt(BaseHaScanner):
             raise ValueError(msg)
         self.mac_address = address
         source = address
+        # Per-adapter bond store; survives the per-connection client instances so
+        # a reconnect can restore captured keys.
+        self._long_term_keys: dict[str, LongTermKey] = {}
+        adapter_idx = (
+            int(adapter.removeprefix("hci")) if adapter.startswith("hci") else None
+        )
         connector = HaBluetoothConnector(
             # partial-bind the per-connection data; the wrapper calls
             # connector.client(device, ...) like any backend class.
@@ -94,6 +101,11 @@ class HaScannerMgmt(BaseHaScanner):
                         scanner=self,
                         register_connection=self._register_connection,
                         unregister_connection=self._unregister_connection,
+                        adapter_idx=adapter_idx,
+                        mgmt=get_manager().get_bluez_mgmt_ctl(),
+                        get_long_term_key=self._long_term_keys.get,
+                        set_long_term_key=self._store_long_term_key,
+                        forget_long_term_key=self._forget_long_term_key,
                     ),
                 ),
             ),
@@ -253,6 +265,14 @@ class HaScannerMgmt(BaseHaScanner):
     def _unregister_connection(self, address: str) -> None:
         """Drop a connection (called by the client on disconnect)."""
         self._connections.discard(address)
+
+    def _store_long_term_key(self, address: str, key: LongTermKey) -> None:
+        """Persist a bonded key (called by the client after pairing)."""
+        self._long_term_keys[address] = key
+
+    def _forget_long_term_key(self, address: str) -> None:
+        """Drop a bonded key (called by the client on unpair)."""
+        self._long_term_keys.pop(address, None)
 
     def get_allocations(self) -> Allocations | None:
         """Report slot usage from this scanner's own connection tracking."""

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -274,14 +274,17 @@ class HaScannerMgmt(BaseHaScanner):
 
     def _store_long_term_key(self, key: LongTermKey) -> None:
         """Persist a bonded key (called by the client after pairing)."""
-        self._long_term_keys[(key.address, key.central, key.ediv)] = key
+        # Canonicalize the address so forget (which may be called with a
+        # differently-cased address) always matches.
+        self._long_term_keys[(key.address.upper(), key.central, key.ediv)] = key
 
     def _forget_long_term_keys(self, address: str) -> None:
         """Drop every bonded key for a peer (called by the client on unpair)."""
+        canonical = address.upper()
         self._long_term_keys = {
             stored_key: value
             for stored_key, value in self._long_term_keys.items()
-            if value.address != address
+            if value.address.upper() != canonical
         }
 
     def get_allocations(self) -> Allocations | None:

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -84,10 +84,12 @@ class HaScannerMgmt(BaseHaScanner):
         self.mac_address = address
         source = address
         # Per-adapter bond store; survives the per-connection client instances so
-        # a reconnect can restore captured keys.
-        self._long_term_keys: dict[str, LongTermKey] = {}
+        # a reconnect can restore captured keys. Keyed by (address, central, ediv)
+        # so a peer can hold more than one LTK without later events clobbering it.
+        self._long_term_keys: dict[tuple[str, bool, int], LongTermKey] = {}
+        suffix = adapter.removeprefix("hci")
         adapter_idx = (
-            int(adapter.removeprefix("hci")) if adapter.startswith("hci") else None
+            int(suffix) if adapter.startswith("hci") and suffix.isdigit() else None
         )
         connector = HaBluetoothConnector(
             # partial-bind the per-connection data; the wrapper calls
@@ -103,9 +105,9 @@ class HaScannerMgmt(BaseHaScanner):
                         unregister_connection=self._unregister_connection,
                         adapter_idx=adapter_idx,
                         mgmt=get_manager().get_bluez_mgmt_ctl(),
-                        get_long_term_key=self._long_term_keys.get,
-                        set_long_term_key=self._store_long_term_key,
-                        forget_long_term_key=self._forget_long_term_key,
+                        get_long_term_keys=self._all_long_term_keys,
+                        add_long_term_key=self._store_long_term_key,
+                        forget_long_term_keys=self._forget_long_term_keys,
                     ),
                 ),
             ),
@@ -266,13 +268,21 @@ class HaScannerMgmt(BaseHaScanner):
         """Drop a connection (called by the client on disconnect)."""
         self._connections.discard(address)
 
-    def _store_long_term_key(self, address: str, key: LongTermKey) -> None:
-        """Persist a bonded key (called by the client after pairing)."""
-        self._long_term_keys[address] = key
+    def _all_long_term_keys(self) -> list[LongTermKey]:
+        """Return every bonded key for this adapter (for restore)."""
+        return list(self._long_term_keys.values())
 
-    def _forget_long_term_key(self, address: str) -> None:
-        """Drop a bonded key (called by the client on unpair)."""
-        self._long_term_keys.pop(address, None)
+    def _store_long_term_key(self, key: LongTermKey) -> None:
+        """Persist a bonded key (called by the client after pairing)."""
+        self._long_term_keys[(key.address, key.central, key.ediv)] = key
+
+    def _forget_long_term_keys(self, address: str) -> None:
+        """Drop every bonded key for a peer (called by the client on unpair)."""
+        self._long_term_keys = {
+            stored_key: value
+            for stored_key, value in self._long_term_keys.items()
+            if value.address != address
+        }
 
     def get_allocations(self) -> Allocations | None:
         """Report slot usage from this scanner's own connection tracking."""

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -515,9 +515,12 @@ async def test_operations_raise_after_disconnect() -> None:
 class FakeMgmt:
     """Records the pairing/bond mgmt commands the client issues."""
 
-    def __init__(self, *, pair_ok: bool = True, load_ok: bool = True) -> None:
+    def __init__(
+        self, *, pair_ok: bool = True, load_ok: bool = True, unpair_ok: bool = True
+    ) -> None:
         self.pair_ok = pair_ok
         self.load_ok = load_ok
+        self.unpair_ok = unpair_ok
         self.paired: list[tuple[int, str, int]] = []
         self.unpaired: list[tuple[int, str]] = []
         self.loaded: list[tuple[int, list[LongTermKey]]] = []
@@ -547,7 +550,7 @@ class FakeMgmt:
         self, idx: int, address: str, address_type: int, **_k: object
     ) -> bool:
         self.unpaired.append((idx, address))
-        return True
+        return self.unpair_ok
 
     async def load_long_term_keys(self, idx: int, keys: list[LongTermKey]) -> bool:
         self.loaded.append((idx, list(keys)))
@@ -676,6 +679,16 @@ async def test_unpair_without_store() -> None:
     client = _make_pairing_client(mgmt, None)
     await client.unpair()
     assert mgmt.unpaired == [(0, _PEER)]
+
+
+async def test_unpair_failure_keeps_stored_key() -> None:
+    """A failed UNPAIR_DEVICE raises and leaves the stored key in place."""
+    mgmt = FakeMgmt(unpair_ok=False)
+    store = _Store([_ltk()])
+    client = _make_pairing_client(mgmt, store)
+    with pytest.raises(BleakError, match="unpair failed"):
+        await client.unpair()
+    assert store.keys == [_ltk()]  # not desynced from the controller
 
 
 async def test_connect_restores_all_adapter_bonds() -> None:

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -515,8 +515,9 @@ async def test_operations_raise_after_disconnect() -> None:
 class FakeMgmt:
     """Records the pairing/bond mgmt commands the client issues."""
 
-    def __init__(self, *, pair_ok: bool = True) -> None:
+    def __init__(self, *, pair_ok: bool = True, load_ok: bool = True) -> None:
         self.pair_ok = pair_ok
+        self.load_ok = load_ok
         self.paired: list[tuple[int, str, int]] = []
         self.unpaired: list[tuple[int, str]] = []
         self.loaded: list[tuple[int, list[LongTermKey]]] = []
@@ -550,7 +551,23 @@ class FakeMgmt:
 
     async def load_long_term_keys(self, idx: int, keys: list[LongTermKey]) -> bool:
         self.loaded.append((idx, list(keys)))
-        return True
+        return self.load_ok
+
+
+class _Store:
+    """An in-memory per-adapter long-term-key store for tests."""
+
+    def __init__(self, keys: list[LongTermKey] | None = None) -> None:
+        self.keys: list[LongTermKey] = list(keys or [])
+
+    def all(self) -> list[LongTermKey]:
+        return list(self.keys)
+
+    def add(self, key: LongTermKey) -> None:
+        self.keys.append(key)
+
+    def forget(self, address: str) -> None:
+        self.keys = [key for key in self.keys if key.address != address]
 
 
 def _ltk(address: str = _PEER) -> LongTermKey:
@@ -561,14 +578,10 @@ def _ltk(address: str = _PEER) -> LongTermKey:
 
 def _make_pairing_client(
     mgmt: FakeMgmt,
-    store: dict[str, LongTermKey],
+    store: _Store | None,
     *,
     adapter_idx: int | None = 0,
-    with_store: bool = True,
 ) -> HaMgmtClient:
-    def _forget(address: str) -> None:
-        store.pop(address, None)
-
     return HaMgmtClient(
         _ble_device(),
         client_data=MgmtClientData(
@@ -576,9 +589,9 @@ def _make_pairing_client(
             scanner=FakeScanner(),
             adapter_idx=adapter_idx,
             mgmt=mgmt,  # type: ignore[arg-type]
-            get_long_term_key=store.get if with_store else None,
-            set_long_term_key=store.__setitem__ if with_store else None,
-            forget_long_term_key=_forget if with_store else None,
+            get_long_term_keys=store.all if store else None,
+            add_long_term_key=store.add if store else None,
+            forget_long_term_keys=store.forget if store else None,
         ),
         timeout=5.0,
     )
@@ -588,32 +601,54 @@ async def test_pair_captures_long_term_key() -> None:
     """pair() issues PAIR_DEVICE and persists the captured key."""
     mgmt = FakeMgmt()
     mgmt.event_to_emit = NewLongTermKey(1, _ltk())
-    store: dict[str, LongTermKey] = {}
+    store = _Store()
     client = _make_pairing_client(mgmt, store)
     await client.pair()
     assert mgmt.paired == [(0, _PEER, BDADDR_LE_RANDOM)]
-    assert store == {_PEER: _ltk()}
+    assert store.keys == [_ltk()]
+
+
+async def test_pair_ignores_zero_store_hint() -> None:
+    """A key the kernel asks not to persist (store_hint 0) is not stored."""
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = NewLongTermKey(0, _ltk())
+    store = _Store()
+    client = _make_pairing_client(mgmt, store)
+    await client.pair()
+    assert store.keys == []
 
 
 async def test_pair_ignores_non_key_event() -> None:
     """An AUTHENTICATION_FAILED event during pairing stores no key."""
     mgmt = FakeMgmt(pair_ok=False)
     mgmt.event_to_emit = AuthenticationFailed(_PEER, BDADDR_LE_RANDOM, 0x05)
-    store: dict[str, LongTermKey] = {}
+    store = _Store()
     client = _make_pairing_client(mgmt, store)
     with pytest.raises(BleakError, match="pairing failed"):
         await client.pair()
-    assert store == {}
+    assert store.keys == []
+
+
+async def test_pair_warns_when_no_store_wired(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A captured key with no store wired is logged, not silently dropped."""
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = NewLongTermKey(1, _ltk())
+    client = _make_pairing_client(mgmt, None)
+    with caplog.at_level("WARNING", logger="habluetooth.client_mgmt"):
+        await client.pair()
+    assert "no key store" in caplog.text
 
 
 async def test_pair_failure_raises() -> None:
     """A failed PAIR_DEVICE raises and captures no key."""
     mgmt = FakeMgmt(pair_ok=False)
-    store: dict[str, LongTermKey] = {}
+    store = _Store()
     client = _make_pairing_client(mgmt, store)
     with pytest.raises(BleakError, match="pairing failed"):
         await client.pair()
-    assert store == {}
+    assert store.keys == []
 
 
 async def test_pair_requires_mgmt() -> None:
@@ -628,37 +663,64 @@ async def test_pair_requires_mgmt() -> None:
 async def test_unpair_removes_bond() -> None:
     """unpair() issues UNPAIR_DEVICE and forgets the stored key."""
     mgmt = FakeMgmt()
-    store: dict[str, LongTermKey] = {_PEER: _ltk()}
+    store = _Store([_ltk()])
     client = _make_pairing_client(mgmt, store)
     await client.unpair()
     assert mgmt.unpaired == [(0, _PEER)]
-    assert store == {}
+    assert store.keys == []
 
 
 async def test_unpair_without_store() -> None:
     """unpair() works when no key store was wired."""
     mgmt = FakeMgmt()
-    client = _make_pairing_client(mgmt, {}, with_store=False)
+    client = _make_pairing_client(mgmt, None)
     await client.unpair()
     assert mgmt.unpaired == [(0, _PEER)]
 
 
-async def test_connect_restores_stored_bond() -> None:
-    """connect() reloads a stored long-term key before opening the channel."""
+async def test_connect_restores_all_adapter_bonds() -> None:
+    """connect() reloads every stored key (LOAD replaces the whole list)."""
     holder: dict[str, FakeTransport] = {}
     mgmt = FakeMgmt()
-    store: dict[str, LongTermKey] = {_PEER: _ltk()}
+    other = LongTermKey(
+        "11:22:33:44:55:66",
+        BDADDR_LE_RANDOM,
+        0x05,
+        True,
+        16,
+        0x9999,
+        bytes(8),
+        bytes(16),
+    )
+    store = _Store([_ltk(), other])
     client = _make_pairing_client(mgmt, store)
     with _patch_transport(make_responder(), holder):
         await client.connect(False)
-    assert mgmt.loaded == [(0, [_ltk()])]
+    # All keys are sent, not just the connecting peer's, so other bonds survive.
+    assert mgmt.loaded == [(0, [_ltk(), other])]
+
+
+async def test_connect_warns_when_restore_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed key restore is logged rather than silently proceeding."""
+    holder: dict[str, FakeTransport] = {}
+    mgmt = FakeMgmt(load_ok=False)
+    store = _Store([_ltk()])
+    client = _make_pairing_client(mgmt, store)
+    with (
+        _patch_transport(make_responder(), holder),
+        caplog.at_level("WARNING", logger="habluetooth.client_mgmt"),
+    ):
+        await client.connect(False)
+    assert "failed to restore" in caplog.text
 
 
 async def test_connect_without_bond_loads_nothing() -> None:
-    """connect() does not load keys when the peer is not bonded."""
+    """connect() does not load keys when nothing is bonded on the adapter."""
     holder: dict[str, FakeTransport] = {}
     mgmt = FakeMgmt()
-    client = _make_pairing_client(mgmt, {})
+    client = _make_pairing_client(mgmt, _Store())
     with _patch_transport(make_responder(), holder):
         await client.connect(False)
     assert mgmt.loaded == []

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -11,6 +11,11 @@ import pytest
 from bleak import BleakError
 from bleak.backends.device import BLEDevice
 
+from habluetooth.channels.bluez import (
+    AuthenticationFailed,
+    LongTermKey,
+    NewLongTermKey,
+)
 from habluetooth.client_mgmt import HaMgmtClient, MgmtClientData
 from habluetooth.const import BDADDR_LE_RANDOM
 
@@ -507,13 +512,156 @@ async def test_operations_raise_after_disconnect() -> None:
         await client.read_gatt_char(char)
 
 
-async def test_pair_and_unpair_not_supported() -> None:
-    """Pairing is not implemented in this client yet."""
-    client, _scanner = _make_client()
-    with pytest.raises(NotImplementedError, match="pairing"):
+class FakeMgmt:
+    """Records the pairing/bond mgmt commands the client issues."""
+
+    def __init__(self, *, pair_ok: bool = True) -> None:
+        self.pair_ok = pair_ok
+        self.paired: list[tuple[int, str, int]] = []
+        self.unpaired: list[tuple[int, str]] = []
+        self.loaded: list[tuple[int, list[LongTermKey]]] = []
+        self.event_to_emit: object | None = None  # delivered during pair_device
+        self._handlers: dict[tuple[int, str], Callable[[object], None]] = {}
+
+    def register_pairing_handler(
+        self, idx: int, address: str, handler: Callable[[object], None]
+    ) -> Callable[[], None]:
+        self._handlers[(idx, address)] = handler
+
+        def _unregister() -> None:
+            self._handlers.pop((idx, address), None)
+
+        return _unregister
+
+    async def pair_device(
+        self, idx: int, address: str, address_type: int, *_a: object
+    ) -> bool:
+        self.paired.append((idx, address, address_type))
+        if self.event_to_emit is not None:
+            # Simulate the kernel pushing a pairing event during pairing.
+            self._handlers[(idx, address)](self.event_to_emit)
+        return self.pair_ok
+
+    async def unpair_device(
+        self, idx: int, address: str, address_type: int, **_k: object
+    ) -> bool:
+        self.unpaired.append((idx, address))
+        return True
+
+    async def load_long_term_keys(self, idx: int, keys: list[LongTermKey]) -> bool:
+        self.loaded.append((idx, list(keys)))
+        return True
+
+
+def _ltk(address: str = _PEER) -> LongTermKey:
+    return LongTermKey(
+        address, BDADDR_LE_RANDOM, 0x05, False, 16, 0x1234, bytes(8), bytes(16)
+    )
+
+
+def _make_pairing_client(
+    mgmt: FakeMgmt,
+    store: dict[str, LongTermKey],
+    *,
+    adapter_idx: int | None = 0,
+    with_store: bool = True,
+) -> HaMgmtClient:
+    def _forget(address: str) -> None:
+        store.pop(address, None)
+
+    return HaMgmtClient(
+        _ble_device(),
+        client_data=MgmtClientData(
+            adapter_address=_ADAPTER,
+            scanner=FakeScanner(),
+            adapter_idx=adapter_idx,
+            mgmt=mgmt,  # type: ignore[arg-type]
+            get_long_term_key=store.get if with_store else None,
+            set_long_term_key=store.__setitem__ if with_store else None,
+            forget_long_term_key=_forget if with_store else None,
+        ),
+        timeout=5.0,
+    )
+
+
+async def test_pair_captures_long_term_key() -> None:
+    """pair() issues PAIR_DEVICE and persists the captured key."""
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = NewLongTermKey(1, _ltk())
+    store: dict[str, LongTermKey] = {}
+    client = _make_pairing_client(mgmt, store)
+    await client.pair()
+    assert mgmt.paired == [(0, _PEER, BDADDR_LE_RANDOM)]
+    assert store == {_PEER: _ltk()}
+
+
+async def test_pair_ignores_non_key_event() -> None:
+    """An AUTHENTICATION_FAILED event during pairing stores no key."""
+    mgmt = FakeMgmt(pair_ok=False)
+    mgmt.event_to_emit = AuthenticationFailed(_PEER, BDADDR_LE_RANDOM, 0x05)
+    store: dict[str, LongTermKey] = {}
+    client = _make_pairing_client(mgmt, store)
+    with pytest.raises(BleakError, match="pairing failed"):
         await client.pair()
-    with pytest.raises(NotImplementedError, match="unpairing"):
+    assert store == {}
+
+
+async def test_pair_failure_raises() -> None:
+    """A failed PAIR_DEVICE raises and captures no key."""
+    mgmt = FakeMgmt(pair_ok=False)
+    store: dict[str, LongTermKey] = {}
+    client = _make_pairing_client(mgmt, store)
+    with pytest.raises(BleakError, match="pairing failed"):
+        await client.pair()
+    assert store == {}
+
+
+async def test_pair_requires_mgmt() -> None:
+    """Without the mgmt socket, pairing raises a clear error."""
+    client, _scanner = _make_client()  # no mgmt/adapter_idx wired
+    with pytest.raises(BleakError, match="requires the management socket"):
+        await client.pair()
+    with pytest.raises(BleakError, match="requires the management socket"):
         await client.unpair()
+
+
+async def test_unpair_removes_bond() -> None:
+    """unpair() issues UNPAIR_DEVICE and forgets the stored key."""
+    mgmt = FakeMgmt()
+    store: dict[str, LongTermKey] = {_PEER: _ltk()}
+    client = _make_pairing_client(mgmt, store)
+    await client.unpair()
+    assert mgmt.unpaired == [(0, _PEER)]
+    assert store == {}
+
+
+async def test_unpair_without_store() -> None:
+    """unpair() works when no key store was wired."""
+    mgmt = FakeMgmt()
+    client = _make_pairing_client(mgmt, {}, with_store=False)
+    await client.unpair()
+    assert mgmt.unpaired == [(0, _PEER)]
+
+
+async def test_connect_restores_stored_bond() -> None:
+    """connect() reloads a stored long-term key before opening the channel."""
+    holder: dict[str, FakeTransport] = {}
+    mgmt = FakeMgmt()
+    store: dict[str, LongTermKey] = {_PEER: _ltk()}
+    client = _make_pairing_client(mgmt, store)
+    with _patch_transport(make_responder(), holder):
+        await client.connect(False)
+    assert mgmt.loaded == [(0, [_ltk()])]
+
+
+async def test_connect_without_bond_loads_nothing() -> None:
+    """connect() does not load keys when the peer is not bonded."""
+    holder: dict[str, FakeTransport] = {}
+    mgmt = FakeMgmt()
+    client = _make_pairing_client(mgmt, {})
+    with _patch_transport(make_responder(), holder):
+        await client.connect(False)
+    assert mgmt.loaded == []
 
 
 async def test_mtu_size_default_before_connect() -> None:

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -482,7 +482,8 @@ async def test_long_term_key_store() -> None:
     scanner._store_long_term_key(key_a2)
     scanner._store_long_term_key(other)
     assert set(scanner._all_long_term_keys()) == {key_a, key_a2, other}
-    scanner._forget_long_term_keys(_PEER)
+    # Forget is case-insensitive: stored addresses are canonical upper-case.
+    scanner._forget_long_term_keys(_PEER.lower())
     assert scanner._all_long_term_keys() == [other]
     scanner._forget_long_term_keys(_PEER)  # idempotent
 

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -470,14 +470,21 @@ async def test_registered_scanner_reports_discovered_devices(
 
 
 async def test_long_term_key_store() -> None:
-    """The scanner stores and forgets bonded keys for the client to use."""
+    """The scanner stores, lists, and forgets bonded keys per peer."""
     scanner = _scanner()
-    key = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
-    scanner._store_long_term_key(_PEER, key)
-    assert scanner._long_term_keys[_PEER] is key
-    scanner._forget_long_term_key(_PEER)
-    assert _PEER not in scanner._long_term_keys
-    scanner._forget_long_term_key(_PEER)  # idempotent
+    key_a = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
+    # Same peer, distinct (central, ediv) so both survive rather than clobber.
+    key_a2 = LongTermKey(_PEER, 1, 0x05, True, 16, 0x5678, bytes(8), bytes(16))
+    other = LongTermKey(
+        "11:22:33:44:55:66", 1, 0x05, False, 16, 0x1, bytes(8), bytes(16)
+    )
+    scanner._store_long_term_key(key_a)
+    scanner._store_long_term_key(key_a2)
+    scanner._store_long_term_key(other)
+    assert set(scanner._all_long_term_keys()) == {key_a, key_a2, other}
+    scanner._forget_long_term_keys(_PEER)
+    assert scanner._all_long_term_keys() == [other]
+    scanner._forget_long_term_keys(_PEER)  # idempotent
 
 
 async def test_slot_limit_zero_when_adapter_unregistered() -> None:

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -17,6 +17,7 @@ from habluetooth import (
     create_local_scanner,
     get_manager,
 )
+from habluetooth.channels.bluez import LongTermKey
 from habluetooth.scanner_bleak import ScannerStartError
 
 if TYPE_CHECKING:
@@ -466,6 +467,17 @@ async def test_registered_scanner_reports_discovered_devices(
         assert scanner.discovered_devices[0].address == _PEER
     finally:
         unregister()
+
+
+async def test_long_term_key_store() -> None:
+    """The scanner stores and forgets bonded keys for the client to use."""
+    scanner = _scanner()
+    key = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
+    scanner._store_long_term_key(_PEER, key)
+    assert scanner._long_term_keys[_PEER] is key
+    scanner._forget_long_term_key(_PEER)
+    assert _PEER not in scanner._long_term_keys
+    scanner._forget_long_term_key(_PEER)  # idempotent
 
 
 async def test_slot_limit_zero_when_adapter_unregistered() -> None:


### PR DESCRIPTION
Makes HaMgmtClient.pair() and unpair() actually work, and restores bonds on connect, using the merged mgmt pairing codec.

pair() issues PAIR_DEVICE over the management socket and registers a pairing handler so the NEW_LONG_TERM_KEY pushed by the kernel during bonding is captured and persisted in a per adapter key store; a failed PAIR_DEVICE raises BleakError. unpair() issues UNPAIR_DEVICE and forgets the stored key. connect() now reloads a stored long term key via LOAD_LONG_TERM_KEYS before opening the L2CAP channel so the kernel re-encrypts a known peer without re-pairing, replacing the earlier relying on bonded keys placeholder.

The key store lives on HaScannerMgmt (per adapter, so bonds outlive the per connection client instances); the scanner hands the client the mgmt controller, the adapter index, and get/set/forget callbacks via MgmtClientData. All the new MgmtClientData fields are optional and additive, so a client built without them simply reports that pairing requires the management socket and skips bond restore.

This is the integration that lets the experimental DBus free client bond; it is still gated behind the experimental HaScannerMgmt and create_local_scanner, which Home Assistant does not select yet, so there is no behavior change. The passkey and confirmation interactive replies and honoring connect(pair=True) inline are follow ups.

Tested pair capturing and persisting the key, a non key event during pairing storing nothing, pairing failure raising, pairing without the mgmt socket raising, unpair removing the bond, connect restoring a stored key and loading nothing when unbonded, and the scanner key store; client_mgmt and scanner_mgmt both at 100 percent line and branch, full suite green.