### PR TITLE
fix(manager): require durable staleness before a weaker scanner takes ownership

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -41,7 +41,7 @@ CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS: Final = 195
 # the owner). A materially weaker scanner must wait until the owner has been
 # silent for stale_seconds * this factor (capped at
 # FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS) before it can take over. This
-# stops a far, weaker proxy from stealing ownership on a single missed
+# stops a far weaker proxy from stealing ownership on a single missed
 # interval and surfacing a stale capture for scan-response-only sensors
 # (e.g. Govee H5074) seen by many active proxies, while still letting a
 # device that genuinely moved into weak-only coverage hand off.

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -35,6 +35,18 @@ FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS: Final = 60 * 15
 # than BlueZ's.
 CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS: Final = 195
 
+# When a different scanner's advertisement arrives after the owner's last
+# advertisement is stale, the owner is handed off immediately only if the
+# challenger is comparable-or-stronger (within ADV_RSSI_SWITCH_THRESHOLD of
+# the owner). A materially weaker scanner must wait until the owner has been
+# silent for stale_seconds * this factor (capped at
+# FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS) before it can take over. This
+# stops a far, weaker proxy from stealing ownership on a single missed
+# interval and surfacing a stale capture for scan-response-only sensors
+# (e.g. Govee H5074) seen by many active proxies, while still letting a
+# device that genuinely moved into weak-only coverage hand off.
+DURABLY_GONE_STALE_FACTOR: Final = 2.5
+
 
 # We must recover before we hit the 180s mark
 # where the device is removed from the stack

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -9,6 +9,7 @@ cdef int NO_RSSI_VALUE
 cdef int ADV_RSSI_SWITCH_THRESHOLD
 cdef double TRACKER_BUFFERING_WOBBLE_SECONDS
 cdef double FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
+cdef double _DURABLY_GONE_STALE_FACTOR
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice
@@ -78,7 +79,7 @@ cdef class BluetoothManager:
     # a direct vtable dispatch.
     cdef public object _auto_scheduler
 
-    @cython.locals(stale_seconds=double)
+    @cython.locals(stale_seconds=double, elapsed=double, durably_gone=double)
     cdef bint _prefer_previous_adv_from_different_source(
         self,
         BluetoothServiceInfoBleak old,

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -79,7 +79,12 @@ cdef class BluetoothManager:
     # a direct vtable dispatch.
     cdef public object _auto_scheduler
 
-    @cython.locals(stale_seconds=double, elapsed=double, durably_gone=double)
+    @cython.locals(
+        stale_seconds=double,
+        elapsed=double,
+        durably_gone=double,
+        comparable_or_stronger=bint,
+    )
     cdef bint _prefer_previous_adv_from_different_source(
         self,
         BluetoothServiceInfoBleak old,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -574,19 +574,23 @@ class BluetoothManager:
             durably_gone = stale_seconds * _DURABLY_GONE_STALE_FACTOR
             if durably_gone > FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS:
                 durably_gone = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
-            if (new.rssi or NO_RSSI_VALUE) >= (
+            comparable_or_stronger = (new.rssi or NO_RSSI_VALUE) >= (
                 old.rssi or NO_RSSI_VALUE
-            ) - ADV_RSSI_SWITCH_THRESHOLD or elapsed > durably_gone:
+            ) - ADV_RSSI_SWITCH_THRESHOLD
+            if comparable_or_stronger or elapsed > durably_gone:
                 if self._debug:
                     _LOGGER.debug(
                         "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
-                        " seconds:%s)",
+                        " seconds:%s; comparable_or_stronger:%s, durably-gone"
+                        " threshold:%s)",
                         new.name,
                         new.address,
                         self._async_describe_source(old),
                         self._async_describe_source(new),
                         elapsed,
                         stale_seconds,
+                        comparable_or_stronger,
+                        durably_gone,
                     )
                 return False
         if (new.rssi or NO_RSSI_VALUE) - ADV_RSSI_SWITCH_THRESHOLD > (

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -38,6 +38,7 @@ from .const import (
     DEFAULT_ACTIVE_SCAN_DURATION,
     DEFAULT_ACTIVE_SCAN_INTERVAL,
     DEFAULT_ON_DEMAND_SWEEP_DURATION,
+    DURABLY_GONE_STALE_FACTOR,
     FAILED_ADAPTER_MAC,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     MIN_ACTIVE_SCAN_DURATION,
@@ -81,6 +82,10 @@ APPLE_FINDMY_START_BYTE: Final = 0x12  # FindMy network advertisements
 
 _str = str
 _int = int
+
+# Hot-path C double copy of the public constant (declared cdef in the
+# .pxd); the public name stays a patchable Python constant.
+_DURABLY_GONE_STALE_FACTOR = DURABLY_GONE_STALE_FACTOR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -554,20 +559,36 @@ class BluetoothManager:
             stale_seconds += TRACKER_BUFFERING_WOBBLE_SECONDS
         else:
             stale_seconds = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
-        if new.time - old.time > stale_seconds:
-            # If the old advertisement is stale, any new advertisement is preferred
-            if self._debug:
-                _LOGGER.debug(
-                    "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
-                    " seconds:%s)",
-                    new.name,
-                    new.address,
-                    self._async_describe_source(old),
-                    self._async_describe_source(new),
-                    new.time - old.time,
-                    stale_seconds,
-                )
-            return False
+        elapsed = new.time - old.time
+        if elapsed > stale_seconds:
+            # The owner has not been heard within its expected interval.
+            # Hand off immediately to a comparable-or-stronger scanner
+            # (ordinary roaming), but make a materially weaker scanner wait
+            # until the owner is durably silent. Otherwise, for a
+            # scan-response-only sensor seen by many active proxies, a far
+            # weaker proxy steals ownership on a single missed interval and
+            # surfaces a stale capture (issue #568). Receive time is all we
+            # have (adverts carry no timestamp), so the durably-gone wait is
+            # what lets a device that truly moved into weak-only coverage
+            # still hand off.
+            durably_gone = stale_seconds * _DURABLY_GONE_STALE_FACTOR
+            if durably_gone > FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS:
+                durably_gone = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
+            if (new.rssi or NO_RSSI_VALUE) >= (
+                old.rssi or NO_RSSI_VALUE
+            ) - ADV_RSSI_SWITCH_THRESHOLD or elapsed > durably_gone:
+                if self._debug:
+                    _LOGGER.debug(
+                        "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
+                        " seconds:%s)",
+                        new.name,
+                        new.address,
+                        self._async_describe_source(old),
+                        self._async_describe_source(new),
+                        elapsed,
+                        stale_seconds,
+                    )
+                return False
         if (new.rssi or NO_RSSI_VALUE) - ADV_RSSI_SWITCH_THRESHOLD > (
             old.rssi or NO_RSSI_VALUE
         ):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1105,6 +1105,116 @@ async def test_switching_adapters_based_on_stale_with_discovered_interval(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_stale_does_not_switch_to_much_weaker_scanner(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A far weaker scanner must not steal a strong owner on a single stale interval.
+
+    Regression for #568: scan-response-only sensors behind many active proxies
+    oscillated because a weaker proxy holding a stale capture won the receive-time
+    staleness check on a single missed interval.
+    """
+    address = "44:44:33:11:23:42"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-46
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    get_manager().async_set_fallback_availability_interval(address, 10)  # stale=15
+
+    weak = generate_ble_device(address, "weak_hci1")
+    weak_adv = generate_advertisement_data(
+        local_name="weak_hci1", service_uuids=[], rssi=-90
+    )
+    # Just past the normal stale window: a 44 dB weaker scanner must NOT win.
+    inject_advertisement_with_time_and_source(
+        weak,
+        weak_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is strong
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_switches_to_weaker_scanner_once_durably_gone(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A device that moved into weak-only coverage still hands off after a longer wait.
+
+    The weaker scanner is held off on a single stale interval but takes over once
+    the owner has been silent for stale_seconds * DURABLY_GONE_STALE_FACTOR.
+    """
+    address = "44:44:33:11:23:43"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-46
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    # stale_seconds = 15, durably-gone = 15 * 2.5 = 37.5
+    get_manager().async_set_fallback_availability_interval(address, 10)
+
+    weak = generate_ble_device(address, "weak_hci1")
+    weak_adv = generate_advertisement_data(
+        local_name="weak_hci1", service_uuids=[], rssi=-90
+    )
+    # Within the durably-gone window: still the strong owner.
+    inject_advertisement_with_time_and_source(
+        weak, weak_adv, start + 30, HCI1_SOURCE_ADDRESS
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is strong
+    # Past the durably-gone window: the weak scanner finally takes over.
+    inject_advertisement_with_time_and_source(
+        weak, weak_adv, start + 40, HCI1_SOURCE_ADDRESS
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is weak
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_switches_to_comparable_scanner_at_normal_window(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A comparable-strength scanner still takes over at the normal stale window."""
+    address = "44:44:33:11:23:44"
+    start = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    owner_adv = generate_advertisement_data(
+        local_name="owner_hci0", service_uuids=[], rssi=-60
+    )
+    inject_advertisement_with_time_and_source(
+        owner, owner_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    get_manager().async_set_fallback_availability_interval(address, 10)
+
+    # Within 16 dB of the owner: ordinary roaming handoff at the normal window.
+    comparable = generate_ble_device(address, "comparable_hci1")
+    comparable_adv = generate_advertisement_data(
+        local_name="comparable_hci1", service_uuids=[], rssi=-70
+    )
+    inject_advertisement_with_time_and_source(
+        comparable,
+        comparable_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is comparable
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
     register_hci0_scanner: None,
     register_hci1_scanner: None,


### PR DESCRIPTION
Scan-response-only sensors (Govee H5074, Inkbird IBS-TH2) behind many active proxies oscillate between fresh and stale readings. The closest proxy holds the current value but captures the scan response irregularly, so its receive time goes stale and a far weaker proxy carrying an older value steals ownership by the staleness check; RSSI then yanks it back, and the entity flip-flops.

Adverts carry no timestamp, so receive time is all we have. This keeps the stale handoff, but when the challenger is materially weaker than the owner it must wait until the owner is silent for stale_seconds times DURABLY_GONE_STALE_FACTOR (2.5, capped at the 900s fallback) before taking over. A comparable or stronger scanner still takes over at the normal stale window, so ordinary roaming is unchanged; only a device that moved into weak-only coverage hands off a little slower.

Fixes #568.