### PR TITLE
test(benchmark): cover cross-source advertisement arbitration

### DIFF
--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -169,6 +169,89 @@ async def test_inject_100_cross_source_keep_previous(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_inject_100_cross_source_switch(benchmark: BenchmarkFixture) -> None:
+    """
+    Inject 100 advertisements that flip ownership between two scanners.
+
+    Two equal-strength scanners alternate advertising the device with
+    ever-later timestamps, so each advertisement is stale relative to the
+    current owner and ownership switches on every injection. This drives the
+    other half of the arbitration hot path
+    (``_prefer_previous_adv_from_different_source`` returning False, the
+    switch decision) on every iteration, complementing the keep-previous
+    benchmark above. The source changes every injection, which resets the
+    interval tracker, so the fallback stale window stays in effect.
+    """
+    manager = get_manager()
+
+    address = "44:44:33:11:23:46"
+    adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+        service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+        manufacturer_data={1: b"\x01"},
+        rssi=-60,
+    )
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner_a = BaseHaRemoteScanner("esp32_a", "esp32_a", connector, True)
+    scanner_b = BaseHaRemoteScanner("esp32_b", "esp32_b", connector, True)
+    unsetup_a = scanner_a.async_setup()
+    unsetup_b = scanner_b.async_setup()
+    cancel_a = manager.async_register_scanner(scanner_a)
+    cancel_b = manager.async_register_scanner(scanner_b)
+    # Small known stale window so a +100s step per injection is always stale.
+    manager.async_set_fallback_availability_interval(address, 10)
+
+    _name = "wohand"
+    _service_uuids = adv.service_uuids
+    _service_data = adv.service_data
+    _manufacturer_data = adv.manufacturer_data
+    _tx_power = adv.tx_power
+    _details = {"scanner_specific_data": "x"}
+    _time = [monotonic_time_coarse()]
+
+    # Seed ownership on scanner_a; the first loop injection (scanner_b) flips it.
+    scanner_a._async_on_advertisement(
+        address,
+        -60,
+        _name,
+        _service_uuids,
+        _service_data,
+        _manufacturer_data,
+        _tx_power,
+        _details,
+        _time[0],
+    )
+
+    scanners = (scanner_b, scanner_a)
+
+    @benchmark
+    def run():
+        for i in range(100):
+            _time[0] += 100.0
+            scanners[i & 1]._async_on_advertisement(
+                address,
+                -60,
+                _name,
+                _service_uuids,
+                _service_data,
+                _manufacturer_data,
+                _tx_power,
+                _details,
+                _time[0],
+            )
+
+    cancel_a()
+    cancel_b()
+    unsetup_a()
+    unsetup_b()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_inject_100_complex_advertisements(benchmark: BenchmarkFixture) -> None:
     """Test injecting 100 complex advertisements."""
     manager = get_manager()

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -86,6 +86,89 @@ async def test_inject_100_simple_advertisements(benchmark: BenchmarkFixture) -> 
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_inject_100_cross_source_keep_previous(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """
+    Inject 100 advertisements from a second, weaker scanner for an owned device.
+
+    The single-source ``test_inject_100_*`` benchmarks never reach the
+    cross-scanner arbitration path, because every advertisement shares the
+    owner's source and ``_should_keep_previous_adv`` short-circuits on the
+    source check. Here a strong scanner owns the device and a weaker second
+    scanner advertises it repeatedly, so each injection runs
+    ``_should_keep_previous_adv`` -> ``_prefer_previous_adv_from_different_source``
+    and keeps the owner (no ownership flip), exercising the hot path that a
+    multi-proxy setup hits on every cross-source advertisement.
+    """
+    manager = get_manager()
+
+    address = "44:44:33:11:23:45"
+    owner_adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+        service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+        manufacturer_data={1: b"\x01"},
+        rssi=-60,
+    )
+
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner_a = BaseHaRemoteScanner("esp32_a", "esp32_a", connector, True)
+    scanner_b = BaseHaRemoteScanner("esp32_b", "esp32_b", connector, True)
+    unsetup_a = scanner_a.async_setup()
+    unsetup_b = scanner_b.async_setup()
+    cancel_a = manager.async_register_scanner(scanner_a)
+    cancel_b = manager.async_register_scanner(scanner_b)
+
+    _name = "wohand"
+    _service_uuids = owner_adv.service_uuids
+    _service_data = owner_adv.service_data
+    _manufacturer_data = owner_adv.manufacturer_data
+    _tx_power = owner_adv.tx_power
+    _now = monotonic_time_coarse()
+
+    # Seed ownership on scanner_a with a strong, fresh advertisement.
+    scanner_a._async_on_advertisement(
+        address,
+        -60,
+        _name,
+        _service_uuids,
+        _service_data,
+        _manufacturer_data,
+        _tx_power,
+        {"scanner_specific_data": "a"},
+        _now,
+    )
+
+    _details_b = {"scanner_specific_data": "b"}
+
+    @benchmark
+    def run():
+        for _ in range(100):
+            # Weaker and fresh from a different source: the owner is kept,
+            # so arbitration runs without flipping ownership.
+            scanner_b._async_on_advertisement(
+                address,
+                -90,
+                _name,
+                _service_uuids,
+                _service_data,
+                _manufacturer_data,
+                _tx_power,
+                _details_b,
+                _now,
+            )
+
+    cancel_a()
+    cancel_b()
+    unsetup_a()
+    unsetup_b()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_inject_100_complex_advertisements(benchmark: BenchmarkFixture) -> None:
     """Test injecting 100 complex advertisements."""
     manager = get_manager()

--- a/tests/test_benchmark_base_scanner.py
+++ b/tests/test_benchmark_base_scanner.py
@@ -102,6 +102,9 @@ async def test_inject_100_cross_source_keep_previous(
     multi-proxy setup hits on every cross-source advertisement.
     """
     manager = get_manager()
+    # Match production: debug logging is off, so the switch path does not
+    # pay for _async_describe_source formatting.
+    manager._debug = False
 
     address = "44:44:33:11:23:45"
     owner_adv = generate_advertisement_data(
@@ -183,6 +186,10 @@ async def test_inject_100_cross_source_switch(benchmark: BenchmarkFixture) -> No
     interval tracker, so the fallback stale window stays in effect.
     """
     manager = get_manager()
+    # Match production: debug logging is off, so the switch path does not
+    # pay for the _LOGGER.debug + _async_describe_source formatting that
+    # otherwise dominates this benchmark.
+    manager._debug = False
 
     address = "44:44:33:11:23:46"
     adv = generate_advertisement_data(


### PR DESCRIPTION
The existing inject benchmarks all use a single source, so they never reach the cross-scanner arbitration path; _should_keep_previous_adv short-circuits on the source check and _prefer_previous_adv_from_different_source is never called. A multi-proxy setup hits that path on every cross-source advertisement, so it is worth a baseline.

This adds two benchmarks: one where a strong owner keeps the device against a weaker second scanner (the keep decision, no ownership flip), and one where two equal scanners alternate with ever-later timestamps so ownership switches every injection (the switch decision). Together they cover both halves of the arbitration.

Landing this first gives a baseline; a follow-up that changes the arbitration (#570) can rebase on top so codspeed shows the real effect on this path. Relates to #568.