### PR TITLE
feat: add bond key serialization and persistence hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,10 @@ repos:
     rev: v2.4.2
     hooks:
       - id: codespell
+        args:
+          # "hass" is the Home Assistant instance variable, not a typo of "hash".
+          - -L
+          - hass
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.1.0
     hooks:

--- a/docs/bond_persistence.md
+++ b/docs/bond_persistence.md
@@ -1,0 +1,79 @@
+# Bond key persistence (experimental)
+
+> **Experimental.** This covers the DBus-free management/L2CAP path
+> (`HaScannerMgmt` + `HaMgmtClient`). The API is not stable and may change or be
+> renamed. Home Assistant does not select this path yet.
+
+When pairing over the BlueZ management socket, the kernel hands back a
+long-term key (LTK) per bond. `habluetooth` keeps these **in memory only** (it is
+a library and does no disk I/O), so without help they are lost on restart and
+the peer must be re-paired. To survive a restart, the consumer (Home Assistant)
+persists them and seeds them back on startup.
+
+Keys are **per adapter**: an LTK is tied to the local adapter identity it paired
+with, so it is only valid on that adapter. Persist keyed by adapter.
+
+## What `habluetooth` provides
+
+- `LongTermKey` — the bonded key (`habluetooth.LongTermKey`).
+- `long_term_key_to_dict()` / `long_term_key_from_dict()` — JSON-safe
+  (de)serialization (the `bytes` fields become hex strings), shaped like the
+  discovery-cache helpers.
+- On `HaScannerMgmt`:
+  - `export_long_term_keys() -> list[LongTermKey]` — snapshot for saving.
+  - `restore_long_term_keys(keys)` — seed the store on startup.
+  - `set_long_term_keys_changed_callback(callback)` — `callback` fires whenever
+    the store changes (a pair captured a key, or an unpair removed one), so the
+    consumer can schedule a debounced save.
+
+## Wiring it in Home Assistant
+
+Mirror the existing remote-scanner storage (`Store` + `async_delay_save`), but
+keyed by adapter and holding a list of serialized keys:
+
+```python
+from habluetooth import (
+    HaScannerMgmt,
+    LongTermKeyDict,
+    long_term_key_from_dict,
+    long_term_key_to_dict,
+)
+from homeassistant.helpers.storage import Store
+
+BOND_STORAGE_VERSION = 1
+BOND_STORAGE_KEY = "bluetooth.bonds"
+SAVE_DELAY = 5
+
+StoredBonds = dict[str, list[LongTermKeyDict]]  # keyed by adapter (e.g. "hci0")
+
+
+class BondStorage:
+    def __init__(self, hass):
+        self._store: Store[StoredBonds] = Store(
+            hass, BOND_STORAGE_VERSION, BOND_STORAGE_KEY
+        )
+        self._data: StoredBonds = {}
+
+    async def async_setup(self):
+        self._data = await self._store.async_load() or {}
+
+    def async_attach(self, scanner: HaScannerMgmt):
+        adapter = scanner.adapter
+        # Seed the scanner with any keys we saved last run.
+        if saved := self._data.get(adapter):
+            scanner.restore_long_term_keys(
+                long_term_key_from_dict(key) for key in saved
+            )
+        # Save (debounced) whenever the scanner's bonds change.
+        scanner.set_long_term_keys_changed_callback(
+            lambda: self._async_save(scanner)
+        )
+
+    def _async_save(self, scanner: HaScannerMgmt):
+        self._data[scanner.adapter] = [
+            long_term_key_to_dict(key) for key in scanner.export_long_term_keys()
+        ]
+        self._store.async_delay_save(lambda: self._data, SAVE_DELAY)
+```
+
+Call `async_attach()` when the scanner is created and `set_long_term_keys_changed_callback(None)` if it is torn down.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@
 
 installation
 usage
+bond_persistence
 ```
 
 ```{toctree}

--- a/src/habluetooth/__init__.py
+++ b/src/habluetooth/__init__.py
@@ -8,6 +8,7 @@ from .advertisement_tracker import (
 )
 from .base_scanner import BaseHaRemoteScanner, BaseHaScanner
 from .central_manager import get_manager, set_manager
+from .channels.bluez import LongTermKey
 from .const import (
     CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -35,9 +36,12 @@ from .storage import (
     DiscoveredDeviceAdvertisementData,
     DiscoveredDeviceAdvertisementDataDict,
     DiscoveryStorageType,
+    LongTermKeyDict,
     discovered_device_advertisement_data_from_dict,
     discovered_device_advertisement_data_to_dict,
     expire_stale_scanner_discovered_device_advertisement_data,
+    long_term_key_from_dict,
+    long_term_key_to_dict,
 )
 from .wrappers import HaBleakClientWrapper, HaBleakScannerWrapper
 
@@ -72,11 +76,15 @@ __all__ = [
     "HaScannerRegistration",
     "HaScannerRegistrationEvent",
     "HaScannerType",
+    "LongTermKey",
+    "LongTermKeyDict",
     "ScannerStartError",
     "create_local_scanner",
     "discovered_device_advertisement_data_from_dict",
     "discovered_device_advertisement_data_to_dict",
     "expire_stale_scanner_discovered_device_advertisement_data",
     "get_manager",
+    "long_term_key_from_dict",
+    "long_term_key_to_dict",
     "set_manager",
 ]

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -300,8 +300,13 @@ class HaScannerMgmt(BaseHaScanner):
 
     def _notify_long_term_keys_changed(self) -> None:
         """Tell the owner the bond store changed so it can be persisted."""
-        if self._long_term_keys_changed is not None:
+        if self._long_term_keys_changed is None:
+            return
+        try:
             self._long_term_keys_changed()
+        except Exception:
+            # A faulty persistence hook must not break a pair/unpair flow.
+            _LOGGER.exception("%s: long-term key change callback failed", self.name)
 
     def set_long_term_keys_changed_callback(
         self, callback: Callable[[], None] | None

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -44,7 +44,7 @@ from .models import BluetoothScanningMode, HaBluetoothConnector
 from .scanner_bleak import IS_LINUX, HaScanner, ScannerStartError, _resolve_radio_mode
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine, Iterable
+    from collections.abc import Callable, Coroutine, Iterable
     from typing import Any
 
     from bleak.backends.client import BaseBleakClient
@@ -121,6 +121,10 @@ class HaScannerMgmt(BaseHaScanner):
         self._monitor_handle: int | None = None
         self._connections: set[str] = set()
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        # Fired when the bond store changes so the owner can persist it; the
+        # store itself is in memory (this scanner is a library object and does
+        # no disk I/O).
+        self._long_term_keys_changed: Callable[[], None] | None = None
 
     # -- lifecycle ---------------------------------------------------------
     def async_setup(self) -> CALLBACK_TYPE:
@@ -277,15 +281,39 @@ class HaScannerMgmt(BaseHaScanner):
         # Canonicalize the address so forget (which may be called with a
         # differently-cased address) always matches.
         self._long_term_keys[(key.address.upper(), key.central, key.ediv)] = key
+        self._notify_long_term_keys_changed()
 
     def _forget_long_term_keys(self, address: str) -> None:
         """Drop every bonded key for a peer (called by the client on unpair)."""
         canonical = address.upper()
-        self._long_term_keys = {
+        remaining = {
             stored_key: value
             for stored_key, value in self._long_term_keys.items()
             if value.address.upper() != canonical
         }
+        if remaining != self._long_term_keys:
+            self._long_term_keys = remaining
+            self._notify_long_term_keys_changed()
+
+    def _notify_long_term_keys_changed(self) -> None:
+        """Tell the owner the bond store changed so it can be persisted."""
+        if self._long_term_keys_changed is not None:
+            self._long_term_keys_changed()
+
+    def set_long_term_keys_changed_callback(
+        self, callback: Callable[[], None] | None
+    ) -> None:
+        """Register a callback fired whenever the bond store changes."""
+        self._long_term_keys_changed = callback
+
+    def export_long_term_keys(self) -> list[LongTermKey]:
+        """Snapshot the bonded keys so the owner can persist them."""
+        return list(self._long_term_keys.values())
+
+    def restore_long_term_keys(self, keys: Iterable[LongTermKey]) -> None:
+        """Seed the bond store from persistence (e.g. on startup)."""
+        for key in keys:
+            self._long_term_keys[(key.address.upper(), key.central, key.ediv)] = key
 
     def get_allocations(self) -> Allocations | None:
         """Report slot usage from this scanner's own connection tracking."""

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -105,7 +105,7 @@ class HaScannerMgmt(BaseHaScanner):
                         unregister_connection=self._unregister_connection,
                         adapter_idx=adapter_idx,
                         mgmt=get_manager().get_bluez_mgmt_ctl(),
-                        get_long_term_keys=self._all_long_term_keys,
+                        get_long_term_keys=self.export_long_term_keys,
                         add_long_term_key=self._store_long_term_key,
                         forget_long_term_keys=self._forget_long_term_keys,
                     ),
@@ -271,10 +271,6 @@ class HaScannerMgmt(BaseHaScanner):
     def _unregister_connection(self, address: str) -> None:
         """Drop a connection (called by the client on disconnect)."""
         self._connections.discard(address)
-
-    def _all_long_term_keys(self) -> list[LongTermKey]:
-        """Return every bonded key for this adapter (for restore)."""
-        return list(self._long_term_keys.values())
 
     def _store_long_term_key(self, key: LongTermKey) -> None:
         """Persist a bonded key (called by the client after pairing)."""

--- a/src/habluetooth/scanner_mgmt.py
+++ b/src/habluetooth/scanner_mgmt.py
@@ -280,7 +280,10 @@ class HaScannerMgmt(BaseHaScanner):
         """Persist a bonded key (called by the client after pairing)."""
         # Canonicalize the address so forget (which may be called with a
         # differently-cased address) always matches.
-        self._long_term_keys[(key.address.upper(), key.central, key.ediv)] = key
+        stored_key = (key.address.upper(), key.central, key.ediv)
+        if self._long_term_keys.get(stored_key) == key:
+            return  # unchanged; nothing to persist, symmetric with forget
+        self._long_term_keys[stored_key] = key
         self._notify_long_term_keys_changed()
 
     def _forget_long_term_keys(self, address: str) -> None:

--- a/src/habluetooth/storage.py
+++ b/src/habluetooth/storage.py
@@ -342,16 +342,16 @@ class LongTermKeyDict(TypedDict):
 
 def long_term_key_to_dict(key: LongTermKey) -> LongTermKeyDict:
     """Serialize a long-term key for persistence (bytes as hex)."""
-    return {
-        "address": key.address,
-        "address_type": key.address_type,
-        "key_type": key.key_type,
-        "central": key.central,
-        "encryption_size": key.encryption_size,
-        "ediv": key.ediv,
-        "rand": key.rand.hex(),
-        "value": key.value.hex(),
-    }
+    return LongTermKeyDict(
+        address=key.address,
+        address_type=key.address_type,
+        key_type=key.key_type,
+        central=key.central,
+        encryption_size=key.encryption_size,
+        ediv=key.ediv,
+        rand=key.rand.hex(),
+        value=key.value.hex(),
+    )
 
 
 def long_term_key_from_dict(data: LongTermKeyDict) -> LongTermKey:

--- a/src/habluetooth/storage.py
+++ b/src/habluetooth/storage.py
@@ -10,6 +10,8 @@ from typing import Any, Final, TypedDict
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
+from .channels.bluez import LongTermKey
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -323,3 +325,44 @@ def _serialize_discovered_device_raw(
 
 
 DiscoveryStorageType = dict[str, DiscoveredDeviceAdvertisementDataDict]
+
+
+class LongTermKeyDict(TypedDict):
+    """A bonded long-term key serialized for storage."""
+
+    address: str
+    address_type: int
+    key_type: int
+    central: bool
+    encryption_size: int
+    ediv: int
+    rand: str  # hex
+    value: str  # hex
+
+
+def long_term_key_to_dict(key: LongTermKey) -> LongTermKeyDict:
+    """Serialize a long-term key for persistence (bytes as hex)."""
+    return {
+        "address": key.address,
+        "address_type": key.address_type,
+        "key_type": key.key_type,
+        "central": key.central,
+        "encryption_size": key.encryption_size,
+        "ediv": key.ediv,
+        "rand": key.rand.hex(),
+        "value": key.value.hex(),
+    }
+
+
+def long_term_key_from_dict(data: LongTermKeyDict) -> LongTermKey:
+    """Deserialize a long-term key from persistence."""
+    return LongTermKey(
+        address=data["address"],
+        address_type=data["address_type"],
+        key_type=data["key_type"],
+        central=data["central"],
+        encryption_size=data["encryption_size"],
+        ediv=data["ediv"],
+        rand=bytes.fromhex(data["rand"]),
+        value=bytes.fromhex(data["value"]),
+    )

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -504,13 +504,18 @@ async def test_long_term_keys_changed_callback() -> None:
     key = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
     scanner._store_long_term_key(key)
     assert len(changes) == 1
-    scanner._forget_long_term_keys("00:00:00:00:00:00")  # nothing removed -> no fire
+    scanner._store_long_term_key(key)  # identical -> no fire (symmetric with forget)
     assert len(changes) == 1
-    scanner._forget_long_term_keys(_PEER)  # removes -> fires
+    updated = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(range(16)))
+    scanner._store_long_term_key(updated)  # same tuple, new value -> fires
     assert len(changes) == 2
+    scanner._forget_long_term_keys("00:00:00:00:00:00")  # nothing removed -> no fire
+    assert len(changes) == 2
+    scanner._forget_long_term_keys(_PEER)  # removes -> fires
+    assert len(changes) == 3
     scanner.set_long_term_keys_changed_callback(None)  # cleared
     scanner._store_long_term_key(key)
-    assert len(changes) == 2
+    assert len(changes) == 3
 
 
 async def test_slot_limit_zero_when_adapter_unregistered() -> None:

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -481,10 +481,10 @@ async def test_long_term_key_store() -> None:
     scanner._store_long_term_key(key_a)
     scanner._store_long_term_key(key_a2)
     scanner._store_long_term_key(other)
-    assert set(scanner._all_long_term_keys()) == {key_a, key_a2, other}
+    assert set(scanner.export_long_term_keys()) == {key_a, key_a2, other}
     # Forget is case-insensitive: stored addresses are canonical upper-case.
     scanner._forget_long_term_keys(_PEER.lower())
-    assert scanner._all_long_term_keys() == [other]
+    assert scanner.export_long_term_keys() == [other]
     scanner._forget_long_term_keys(_PEER)  # idempotent
 
 

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -488,6 +488,31 @@ async def test_long_term_key_store() -> None:
     scanner._forget_long_term_keys(_PEER)  # idempotent
 
 
+async def test_long_term_key_export_and_restore() -> None:
+    """Keys can be exported for persistence and seeded back on startup."""
+    scanner = _scanner()
+    key = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
+    scanner.restore_long_term_keys([key])
+    assert scanner.export_long_term_keys() == [key]
+
+
+async def test_long_term_keys_changed_callback() -> None:
+    """The change callback fires on store and on an actual forget, not a no-op."""
+    scanner = _scanner()
+    changes: list[int] = []
+    scanner.set_long_term_keys_changed_callback(lambda: changes.append(1))
+    key = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
+    scanner._store_long_term_key(key)
+    assert len(changes) == 1
+    scanner._forget_long_term_keys("00:00:00:00:00:00")  # nothing removed -> no fire
+    assert len(changes) == 1
+    scanner._forget_long_term_keys(_PEER)  # removes -> fires
+    assert len(changes) == 2
+    scanner.set_long_term_keys_changed_callback(None)  # cleared
+    scanner._store_long_term_key(key)
+    assert len(changes) == 2
+
+
 async def test_slot_limit_zero_when_adapter_unregistered() -> None:
     """An adapter with no registered slot count reports 0 (unlimited)."""
     scanner = _scanner()

--- a/tests/test_scanner_mgmt.py
+++ b/tests/test_scanner_mgmt.py
@@ -518,6 +518,23 @@ async def test_long_term_keys_changed_callback() -> None:
     assert len(changes) == 3
 
 
+async def test_long_term_keys_changed_callback_failure_is_isolated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising persistence callback is logged, not propagated into pairing."""
+    scanner = _scanner()
+
+    def boom() -> None:
+        msg = "persistence broke"
+        raise RuntimeError(msg)
+
+    scanner.set_long_term_keys_changed_callback(boom)
+    key = LongTermKey(_PEER, 1, 0x05, False, 16, 0x1234, bytes(8), bytes(16))
+    with caplog.at_level("ERROR", logger="habluetooth.scanner_mgmt"):
+        scanner._store_long_term_key(key)  # must not raise
+    assert "change callback failed" in caplog.text
+
+
 async def test_slot_limit_zero_when_adapter_unregistered() -> None:
     """An adapter with no registered slot count reports 0 (unlimited)."""
     scanner = _scanner()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,12 +5,15 @@ import pytest
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
+from habluetooth.channels.bluez import LongTermKey
 from habluetooth.storage import (
     DiscoveredDeviceAdvertisementData,
     DiscoveredDeviceAdvertisementDataDict,
     discovered_device_advertisement_data_from_dict,
     discovered_device_advertisement_data_to_dict,
     expire_stale_scanner_discovered_device_advertisement_data,
+    long_term_key_from_dict,
+    long_term_key_to_dict,
 )
 
 
@@ -452,3 +455,22 @@ def test_backward_compatibility_rssi_in_device_dict():
     assert ble_device.address == "AA:BB:CC:DD:EE:FF"
     assert ble_device.name == "Test Device"
     assert adv_data.rssi == -50
+
+
+def test_long_term_key_roundtrip() -> None:
+    """A long-term key serializes to JSON-able dict and back unchanged."""
+    key = LongTermKey(
+        address="AA:BB:CC:DD:EE:FF",
+        address_type=1,
+        key_type=5,
+        central=True,
+        encryption_size=16,
+        ediv=0x1234,
+        rand=bytes(range(8)),
+        value=bytes(range(16)),
+    )
+    data = long_term_key_to_dict(key)
+    assert data["rand"] == "0001020304050607"  # bytes as hex
+    assert data["value"] == "000102030405060708090a0b0c0d0e0f"
+    assert data["central"] is True
+    assert long_term_key_from_dict(data) == key


### PR DESCRIPTION
Lets a consumer (Home Assistant) persist mgmt bonded keys to disk so they survive a restart without re-pairing. habluetooth is a library and does no disk I/O, so this provides the serialization plus the scanner hooks the consumer wires to its own Store, mirroring how the discovery cache is persisted today.

storage.py gains long_term_key_to_dict and long_term_key_from_dict plus the LongTermKeyDict TypedDict; the bytes fields serialize as hex, the same shape as the discovery helpers. HaScannerMgmt gains export_long_term_keys (snapshot for saving), restore_long_term_keys (seed on startup), and set_long_term_keys_changed_callback (fires when the bond store changes so the consumer can schedule a debounced save). LongTermKey, LongTermKeyDict, and the two functions are exported from the package.

Keys are per adapter (an LTK is tied to the local adapter identity it paired with), so the consumer persists keyed by adapter; nothing here writes to disk and nothing in Home Assistant selects this path yet, so there is no behavior change.

Added docs/bond_persistence.md with a worked Home Assistant wiring example (Store plus async_delay_save, keyed by adapter, using the change callback), matching the pattern HA already uses for remote scanner storage; the codespell hook now ignores hass so the example reads naturally.

Tested the to_dict/from_dict roundtrip and hex encoding, and the scanner export, restore, and change callback (fires on store and on a real forget, not a no-op, and can be cleared); scanner_mgmt and storage both 100 percent line and branch, full suite green.