### PR TITLE
feat: add mgmt passkey and confirmation pairing replies

### DIFF
--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -32,14 +32,6 @@ if TYPE_CHECKING:
 
     from ..base_scanner import BaseHaScanner
 
-    PairingHandler = Callable[
-        [
-            "NewLongTermKey | AuthenticationFailed"
-            " | UserConfirmationRequest | UserPasskeyRequest"
-        ],
-        None,
-    ]
-
 _LOGGER = logging.getLogger(__name__)
 _int = int
 _bytes = bytes
@@ -194,8 +186,11 @@ class UserConfirmationRequest:
 
     address: str
     address_type: int
-    confirm_hint: int  # non-zero: the value should be shown to the user
-    value: int  # the 6-digit numeric comparison value
+    # Per the mgmt API: when set, the value is not relevant and the user should
+    # just confirm the pairing (yes/no, no number to show); when 0, ``value``
+    # holds the number to display for comparison.
+    confirm_hint: int
+    value: int  # the 6-digit numeric comparison value (when confirm_hint is 0)
 
 
 @dataclass(slots=True, frozen=True)
@@ -204,6 +199,16 @@ class UserPasskeyRequest:
 
     address: str
     address_type: int
+
+
+if TYPE_CHECKING:
+    PairingEvent = (
+        NewLongTermKey
+        | AuthenticationFailed
+        | UserConfirmationRequest
+        | UserPasskeyRequest
+    )
+    PairingHandler = Callable[[PairingEvent], None]
 
 
 def _mgmt_address_bytes(address: str) -> bytes | None:
@@ -521,12 +526,7 @@ class BluetoothMGMTProtocol:
         self._dispatch_pairing_event(handler, UserPasskeyRequest(address, param[6]))
 
     def _dispatch_pairing_event(
-        self,
-        handler: PairingHandler,
-        event: NewLongTermKey
-        | AuthenticationFailed
-        | UserConfirmationRequest
-        | UserPasskeyRequest,
+        self, handler: PairingHandler, event: PairingEvent
     ) -> None:
         """Call a pairing handler, isolating it from the socket read loop."""
         # data_received runs in the read loop, so a raising handler must not tear
@@ -993,7 +993,16 @@ class MGMTBluetoothCtl:
         if addr is None:
             _LOGGER.error("hci%u: invalid address for reply: %s", adapter_idx, address)
             return False
-        result = await self._send_command_await(opcode, adapter_idx, pack(addr, *extra))
+        try:
+            # An out-of-range address_type or passkey raises struct.error; keep
+            # that a soft failure rather than letting it escape the command path.
+            payload = pack(addr, *extra)
+        except struct_error:
+            _LOGGER.exception(
+                "hci%u: invalid pairing reply parameters for %s", adapter_idx, address
+            )
+            return False
+        result = await self._send_command_await(opcode, adapter_idx, payload)
         if result is not None and result[0] == MGMT_STATUS_SUCCESS:
             return True
         _LOGGER.warning(

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -32,7 +32,13 @@ if TYPE_CHECKING:
 
     from ..base_scanner import BaseHaScanner
 
-    PairingHandler = Callable[["NewLongTermKey | AuthenticationFailed"], None]
+    PairingHandler = Callable[
+        [
+            "NewLongTermKey | AuthenticationFailed"
+            " | UserConfirmationRequest | UserPasskeyRequest"
+        ],
+        None,
+    ]
 
 _LOGGER = logging.getLogger(__name__)
 _int = int
@@ -64,7 +70,13 @@ IO_CAPABILITY_NO_INPUT_NO_OUTPUT = 0x03
 MGMT_EV_CMD_COMPLETE = 0x0001
 MGMT_EV_CMD_STATUS = 0x0002
 MGMT_EV_NEW_LONG_TERM_KEY = 0x000A
+MGMT_EV_USER_CONFIRM_REQUEST = 0x000F
+MGMT_EV_USER_PASSKEY_REQUEST = 0x0010
 MGMT_EV_AUTH_FAILED = 0x0011
+MGMT_OP_USER_CONFIRM_REPLY = 0x001C
+MGMT_OP_USER_CONFIRM_NEG_REPLY = 0x001D
+MGMT_OP_USER_PASSKEY_REPLY = 0x001E
+MGMT_OP_USER_PASSKEY_NEG_REPLY = 0x001F
 
 # Discovery address-type bitmask: BR/EDR (0x01) | LE Public (0x02) | LE Random (0x04).
 # We only scan for LE devices, so we combine the two LE bits.
@@ -98,6 +110,16 @@ PAIR_DEVICE_PACK = PAIR_DEVICE_STRUCT.pack
 # UNPAIR_DEVICE carries bdaddr (6) + address type (1) + disconnect flag (1).
 UNPAIR_DEVICE_STRUCT = Struct("<6sBB")
 UNPAIR_DEVICE_PACK = UNPAIR_DEVICE_STRUCT.pack
+# USER_*_REPLY (confirm + passkey-negative) carry bdaddr (6) + address type (1).
+USER_REPLY_STRUCT = Struct("<6sB")
+USER_REPLY_PACK = USER_REPLY_STRUCT.pack
+# USER_PASSKEY_REPLY adds a uint32 passkey.
+USER_PASSKEY_REPLY_STRUCT = Struct("<6sBI")
+USER_PASSKEY_REPLY_PACK = USER_PASSKEY_REPLY_STRUCT.pack
+# USER_CONFIRMATION_REQUEST event = bdaddr (6) + type (1) + confirm_hint (1) +
+# value (4); USER_PASSKEY_REQUEST event = bdaddr (6) + type (1).
+_USER_CONFIRM_REQ_EV_SIZE = 12
+_USER_PASSKEY_REQ_EV_SIZE = 7
 # LOAD_LONG_TERM_KEYS carries a uint16 key count followed by mgmt_ltk_info
 # records: bdaddr (6) + address type (1) + key type (1) + central flag (1) +
 # encryption size (1) + ediv (2) + rand (8) + value (16) = 36 bytes each.
@@ -164,6 +186,24 @@ class AuthenticationFailed:
     address: str
     address_type: int
     status: int
+
+
+@dataclass(slots=True, frozen=True)
+class UserConfirmationRequest:
+    """A USER_CONFIRMATION_REQUEST event: confirm a numeric comparison value."""
+
+    address: str
+    address_type: int
+    confirm_hint: int  # non-zero: the value should be shown to the user
+    value: int  # the 6-digit numeric comparison value
+
+
+@dataclass(slots=True, frozen=True)
+class UserPasskeyRequest:
+    """A USER_PASSKEY_REQUEST event: the peer wants a passkey entered."""
+
+    address: str
+    address_type: int
 
 
 def _mgmt_address_bytes(address: str) -> bytes | None:
@@ -381,6 +421,14 @@ class BluetoothMGMTProtocol:
                 self._handle_auth_failed(controller_idx, header[6 : self._pos])
                 self._remove_from_buffer()
                 continue
+            elif event_code == MGMT_EV_USER_CONFIRM_REQUEST:
+                self._handle_user_confirm_request(controller_idx, header[6 : self._pos])
+                self._remove_from_buffer()
+                continue
+            elif event_code == MGMT_EV_USER_PASSKEY_REQUEST:
+                self._handle_user_passkey_request(controller_idx, header[6 : self._pos])
+                self._remove_from_buffer()
+                continue
             else:
                 self._remove_from_buffer()
                 continue
@@ -449,10 +497,36 @@ class BluetoothMGMTProtocol:
             handler, AuthenticationFailed(address, param[6], param[7])
         )
 
+    def _handle_user_confirm_request(self, controller_idx: _int, param: _bytes) -> None:
+        """Decode a USER_CONFIRMATION_REQUEST event and route it to its handler."""
+        if len(param) < _USER_CONFIRM_REQ_EV_SIZE:
+            _LOGGER.debug("hci%u: truncated USER_CONFIRM_REQUEST event", controller_idx)
+            return
+        address = bytes_mac_to_str(param[0:6])
+        if (handler := self._pairing_handlers.get((controller_idx, address))) is None:
+            return
+        value = int.from_bytes(param[8:12], "little")
+        self._dispatch_pairing_event(
+            handler, UserConfirmationRequest(address, param[6], param[7], value)
+        )
+
+    def _handle_user_passkey_request(self, controller_idx: _int, param: _bytes) -> None:
+        """Decode a USER_PASSKEY_REQUEST event and route it to its handler."""
+        if len(param) < _USER_PASSKEY_REQ_EV_SIZE:
+            _LOGGER.debug("hci%u: truncated USER_PASSKEY_REQUEST event", controller_idx)
+            return
+        address = bytes_mac_to_str(param[0:6])
+        if (handler := self._pairing_handlers.get((controller_idx, address))) is None:
+            return
+        self._dispatch_pairing_event(handler, UserPasskeyRequest(address, param[6]))
+
     def _dispatch_pairing_event(
         self,
         handler: PairingHandler,
-        event: NewLongTermKey | AuthenticationFailed,
+        event: NewLongTermKey
+        | AuthenticationFailed
+        | UserConfirmationRequest
+        | UserPasskeyRequest,
     ) -> None:
         """Call a pairing handler, isolating it from the socket read loop."""
         # data_received runs in the read loop, so a raising handler must not tear
@@ -866,6 +940,66 @@ class MGMTBluetoothCtl:
         _LOGGER.warning(
             "hci%u: failed to disconnect %s: %s",
             adapter_idx,
+            address,
+            "no response" if result is None else f"status={result[0]:#x}",
+        )
+        return False
+
+    async def user_confirmation_reply(
+        self, adapter_idx: int, address: str, address_type: int, *, accept: bool = True
+    ) -> bool:
+        """Answer a USER_CONFIRMATION_REQUEST (numeric comparison) for a peer."""
+        opcode = (
+            MGMT_OP_USER_CONFIRM_REPLY if accept else MGMT_OP_USER_CONFIRM_NEG_REPLY
+        )
+        return await self._user_reply(
+            opcode, adapter_idx, address, USER_REPLY_PACK, (address_type,)
+        )
+
+    async def user_passkey_reply(
+        self, adapter_idx: int, address: str, address_type: int, passkey: int
+    ) -> bool:
+        """Answer a USER_PASSKEY_REQUEST with the entered passkey for a peer."""
+        return await self._user_reply(
+            MGMT_OP_USER_PASSKEY_REPLY,
+            adapter_idx,
+            address,
+            USER_PASSKEY_REPLY_PACK,
+            (address_type, passkey),
+        )
+
+    async def user_passkey_negative_reply(
+        self, adapter_idx: int, address: str, address_type: int
+    ) -> bool:
+        """Reject a USER_PASSKEY_REQUEST for a peer."""
+        return await self._user_reply(
+            MGMT_OP_USER_PASSKEY_NEG_REPLY,
+            adapter_idx,
+            address,
+            USER_REPLY_PACK,
+            (address_type,),
+        )
+
+    async def _user_reply(
+        self,
+        opcode: int,
+        adapter_idx: int,
+        address: str,
+        pack: Callable[..., bytes],
+        extra: tuple[int, ...],
+    ) -> bool:
+        """Send a USER_*_REPLY command for a peer and report success."""
+        addr = _mgmt_address_bytes(address)
+        if addr is None:
+            _LOGGER.error("hci%u: invalid address for reply: %s", adapter_idx, address)
+            return False
+        result = await self._send_command_await(opcode, adapter_idx, pack(addr, *extra))
+        if result is not None and result[0] == MGMT_STATUS_SUCCESS:
+            return True
+        _LOGGER.warning(
+            "hci%u: pairing reply %#x for %s failed: %s",
+            adapter_idx,
+            opcode,
             address,
             "no response" if result is None else f"status={result[0]:#x}",
         )

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -55,6 +55,15 @@ if TYPE_CHECKING:
         AuthenticationFailed,
         LongTermKey,
         MGMTBluetoothCtl,
+        UserConfirmationRequest,
+        UserPasskeyRequest,
+    )
+
+    PairingEvent = (
+        NewLongTermKey
+        | AuthenticationFailed
+        | UserConfirmationRequest
+        | UserPasskeyRequest
     )
 
 
@@ -380,7 +389,9 @@ class HaMgmtClient(BaseBleakClient):
         mgmt, adapter_idx = self._require_mgmt()
         address = self.address
 
-        def _capture(event: NewLongTermKey | AuthenticationFailed) -> None:
+        def _capture(event: PairingEvent) -> None:
+            # Just Works pairing (NoInputNoOutput) does not raise confirm/passkey
+            # requests; we only act on the captured key.
             if not isinstance(event, NewLongTermKey):
                 return
             if not event.store_hint:

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -2457,3 +2457,15 @@ def test_user_request_without_handler_is_dropped(
         + len(param).to_bytes(2, "little")
     )
     protocol.data_received(header + param)  # no handlers -> no-op
+
+
+@pytest.mark.asyncio
+async def test_user_reply_rejects_out_of_range_passkey() -> None:
+    """A passkey that does not fit a uint32 is a soft failure, not a struct.error."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert (
+        await mgmt_ctl.user_passkey_reply(0, _PEER_STR, BDADDR_LE_PUBLIC, 2**32)
+        is False
+    )
+    mock_protocol._write_to_socket.assert_not_called()

--- a/tests/channels/test_bluez.py
+++ b/tests/channels/test_bluez.py
@@ -20,12 +20,18 @@ from habluetooth.channels.bluez import (
     MGMT_OP_START_DISCOVERY,
     MGMT_OP_STOP_DISCOVERY,
     MGMT_OP_UNPAIR_DEVICE,
+    MGMT_OP_USER_CONFIRM_NEG_REPLY,
+    MGMT_OP_USER_CONFIRM_REPLY,
+    MGMT_OP_USER_PASSKEY_NEG_REPLY,
+    MGMT_OP_USER_PASSKEY_REPLY,
     SCAN_TYPE_LE,
     AuthenticationFailed,
     BluetoothMGMTProtocol,
     LongTermKey,
     MGMTBluetoothCtl,
     NewLongTermKey,
+    UserConfirmationRequest,
+    UserPasskeyRequest,
     bytes_mac_to_str,
     make_bluez_details,
 )
@@ -2310,3 +2316,144 @@ async def test_register_pairing_handler_last_wins() -> None:
     assert mgmt_ctl._pairing_handlers[key] is second
     unregister_first()  # must not remove the newer handler
     assert mgmt_ctl._pairing_handlers[key] is second
+
+
+# -- interactive pairing replies + request events -------------------------
+_REV_PEER = b"\xff\xee\xdd\xcc\xbb\xaa"  # little-endian AA:BB:CC:DD:EE:FF
+_PEER_STR = "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("accept", "opcode"),
+    [(True, MGMT_OP_USER_CONFIRM_REPLY), (False, MGMT_OP_USER_CONFIRM_NEG_REPLY)],
+)
+async def test_user_confirmation_reply(accept: bool, opcode: int) -> None:
+    """Confirmation accept/reject send the right opcode with addr + type."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert (
+        await mgmt_ctl.user_confirmation_reply(
+            0, _PEER_STR, BDADDR_LE_RANDOM, accept=accept
+        )
+        is True
+    )
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == opcode.to_bytes(2, "little")
+    assert sent[6:12] == _REV_PEER
+    assert sent[12] == BDADDR_LE_RANDOM
+
+
+@pytest.mark.asyncio
+async def test_user_passkey_reply() -> None:
+    """Passkey reply carries the addr, type, and uint32 passkey."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert (
+        await mgmt_ctl.user_passkey_reply(0, _PEER_STR, BDADDR_LE_RANDOM, 123456)
+        is True
+    )
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_USER_PASSKEY_REPLY.to_bytes(2, "little")
+    assert sent[6:12] == _REV_PEER
+    assert sent[12] == BDADDR_LE_RANDOM
+    assert sent[13:17] == (123456).to_bytes(4, "little")
+
+
+@pytest.mark.asyncio
+async def test_user_passkey_negative_reply() -> None:
+    """Passkey negative reply sends addr + type with the negative opcode."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert (
+        await mgmt_ctl.user_passkey_negative_reply(0, _PEER_STR, BDADDR_LE_PUBLIC)
+        is True
+    )
+    sent = mock_protocol._write_to_socket.call_args[0][0]
+    assert sent[0:2] == MGMT_OP_USER_PASSKEY_NEG_REPLY.to_bytes(2, "little")
+
+
+@pytest.mark.asyncio
+async def test_user_reply_failure() -> None:
+    """A non-success status returns False."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x03)
+    assert (
+        await mgmt_ctl.user_confirmation_reply(0, _PEER_STR, BDADDR_LE_PUBLIC) is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_user_reply_rejects_invalid_address() -> None:
+    """A malformed address is a soft failure with nothing sent."""
+    mgmt_ctl, mock_protocol = _mgmt_ctl_with_mock_protocol()
+    mock_protocol.command_response = _stub_command_response(0x00)
+    assert await mgmt_ctl.user_passkey_reply(0, "AA:BB", BDADDR_LE_PUBLIC, 1) is False
+    mock_protocol._write_to_socket.assert_not_called()
+
+
+def test_data_received_user_confirmation_request(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A USER_CONFIRMATION_REQUEST event decodes the comparison value."""
+    received: list[object] = []
+    protocol = _protocol_with_handlers(event_loop, {(0, _PEER_STR): received.append})
+    param = _REV_PEER + bytes([0x01, 0x01]) + (123456).to_bytes(4, "little")
+    header = (
+        (0x000F).to_bytes(2, "little") + b"\x00\x00" + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)
+    assert received == [UserConfirmationRequest(_PEER_STR, 0x01, 0x01, 123456)]
+
+
+def test_data_received_user_passkey_request(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A USER_PASSKEY_REQUEST event routes to the handler."""
+    received: list[object] = []
+    protocol = _protocol_with_handlers(event_loop, {(0, _PEER_STR): received.append})
+    param = _REV_PEER + bytes([0x01])
+    header = (
+        (0x0010).to_bytes(2, "little") + b"\x00\x00" + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)
+    assert received == [UserPasskeyRequest(_PEER_STR, 0x01)]
+
+
+@pytest.mark.parametrize(
+    ("event_code", "param"),
+    [(0x000F, b"\xff\xee\xdd"), (0x0010, b"\xff\xee")],
+)
+def test_truncated_user_request_is_dropped(
+    event_loop: asyncio.AbstractEventLoop, event_code: int, param: bytes
+) -> None:
+    """A user-request event too short to parse is dropped, not mis-read."""
+    received: list[object] = []
+    protocol = _protocol_with_handlers(event_loop, {(0, _PEER_STR): received.append})
+    header = (
+        event_code.to_bytes(2, "little")
+        + b"\x00\x00"
+        + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)
+    assert received == []
+
+
+@pytest.mark.parametrize(
+    ("event_code", "param"),
+    [
+        (0x000F, _REV_PEER + bytes([0x01, 0x01]) + (1).to_bytes(4, "little")),
+        (0x0010, _REV_PEER + bytes([0x01])),
+    ],
+)
+def test_user_request_without_handler_is_dropped(
+    event_loop: asyncio.AbstractEventLoop, event_code: int, param: bytes
+) -> None:
+    """A user-request event for an unregistered peer is dropped without error."""
+    protocol = _protocol_with_handlers(event_loop, {})
+    header = (
+        event_code.to_bytes(2, "little")
+        + b"\x00\x00"
+        + len(param).to_bytes(2, "little")
+    )
+    protocol.data_received(header + param)  # no handlers -> no-op


### PR DESCRIPTION
Adds the interactive-pairing codec for peers that do not do Just Works bonding. The kernel pushes USER_CONFIRMATION_REQUEST (numeric comparison) or USER_PASSKEY_REQUEST during pairing; data_received now decodes both and routes them to the same per peer pairing handler as NEW_LONG_TERM_KEY and AUTH_FAILED, and MGMTBluetoothCtl gains the four reply commands.

Events: UserConfirmationRequest (address, address_type, confirm_hint, value) and UserPasskeyRequest (address, address_type), dispatched through the existing isolated _dispatch_pairing_event so a raising handler cannot tear down the read loop. Commands: user_confirmation_reply(accept=True/False), user_passkey_reply(passkey), and user_passkey_negative_reply, sharing a small _user_reply helper that validates the address and reports success. Opcodes, the request event layouts, and the reply struct widths came from the installed btsocket btmgmt_protocol.

The new event codes stay plain module constants (rare frames, matched after the hot DEVICE_FOUND branch); no pxd change, the pairing handler map already exists. The client handler type was widened to the four event union; HaMgmtClient still only acts on NEW_LONG_TERM_KEY since it pairs NoInputNoOutput (Just Works), so confirm/passkey requests are not expected on its path. Nothing wires the new replies yet and Home Assistant does not select this path, so there is no behavior change.

Tested each reply command (confirm accept/reject, passkey reply with the uint32 passkey, passkey negative, failure status, invalid address) and both request events (decode and dispatch field by field, no handler, and truncated); the new code is fully covered, full suite green on a cython build.