### PR TITLE
feat: escalate l2cap security on demand to match bluetoothd

### DIFF
--- a/src/habluetooth/channels/att.py
+++ b/src/habluetooth/channels/att.py
@@ -187,10 +187,16 @@ class ATTClient:
         self,
         send: Callable[[bytes], Awaitable[None]],
         on_disconnect: Callable[[Exception | None], None] | None = None,
+        escalate_security: Callable[[int], bool] | None = None,
     ) -> None:
         """Bind the client to a transport ``send`` coroutine."""
         self._send = send
         self._on_disconnect = on_disconnect
+        # Called with the ATT error code when a request is rejected for
+        # insufficient encryption/authentication; returns True if it raised the
+        # link security so the request can be re-issued once. Transport-agnostic:
+        # the codec knows nothing about how security is applied.
+        self._escalate_security = escalate_security
         self._txn_lock = asyncio.Lock()
         self._pending: asyncio.Future[bytes] | None = None
         self._mtu = DEFAULT_MTU
@@ -295,33 +301,53 @@ class ATTClient:
     async def _request(self, payload: bytes, expected_opcode: int) -> bytes:
         self._raise_if_closed()
         async with self._txn_lock:
-            fut: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
-            self._pending = fut
-            try:
-                await self._send(payload)
-                data = await asyncio.wait_for(fut, ATT_TIMEOUT)
-            except TimeoutError as exc:
-                # The timed-out request may still be in flight; ATT has no
-                # transaction id, so a late response could be matched to the
-                # next request. Poison the channel so nothing else is sent.
-                self._poison(exc)
-                msg = "ATT request timed out"
-                raise BleakError(msg) from exc
-            finally:
-                self._pending = None
-        opcode = data[0]
-        if opcode == ATT_ERROR_RSP:
-            if len(data) < 5:
-                msg = "truncated ATT error response"
-                raise BleakError(msg)
-            req_op, handle, err = _ERROR_RSP.unpack_from(data, 1)
-            raise ATTError(req_op, handle, err)
-        if opcode != expected_opcode:
-            msg = (
-                f"unexpected ATT opcode 0x{opcode:02x} (wanted 0x{expected_opcode:02x})"
-            )
-            raise BleakError(msg)
-        return data
+            # The lock is held across an escalation retry so no other request
+            # interleaves while the link security is being raised.
+            escalated = False
+            while True:
+                fut: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
+                self._pending = fut
+                try:
+                    await self._send(payload)
+                    data = await asyncio.wait_for(fut, ATT_TIMEOUT)
+                except TimeoutError as exc:
+                    # The timed-out request may still be in flight; ATT has no
+                    # transaction id, so a late response could be matched to the
+                    # next request. Poison the channel so nothing else is sent.
+                    self._poison(exc)
+                    msg = "ATT request timed out"
+                    raise BleakError(msg) from exc
+                finally:
+                    self._pending = None
+                opcode = data[0]
+                if opcode == ATT_ERROR_RSP:
+                    if len(data) < 5:
+                        msg = "truncated ATT error response"
+                        raise BleakError(msg)
+                    req_op, handle, err = _ERROR_RSP.unpack_from(data, 1)
+                    if (
+                        not escalated
+                        and err
+                        in (
+                            ATT_ERR_INSUFFICIENT_AUTHENTICATION,
+                            ATT_ERR_INSUFFICIENT_ENCRYPTION,
+                        )
+                        and self._escalate_security is not None
+                        and self._escalate_security(err)
+                    ):
+                        # The peer demanded stronger security; the transport
+                        # raised it, so re-issue the same request once. Matches
+                        # bluetoothd's one-shot retry on 0x05/0x0F.
+                        escalated = True
+                        continue
+                    raise ATTError(req_op, handle, err)
+                if opcode != expected_opcode:
+                    msg = (
+                        f"unexpected ATT opcode 0x{opcode:02x} "
+                        f"(wanted 0x{expected_opcode:02x})"
+                    )
+                    raise BleakError(msg)
+                return data
 
     async def exchange_mtu(self, mtu: int = PREFERRED_MTU) -> int:
         """Negotiate the ATT MTU and return the agreed value."""

--- a/src/habluetooth/channels/l2cap.py
+++ b/src/habluetooth/channels/l2cap.py
@@ -160,6 +160,7 @@ class L2CAPSocket:
         loop: asyncio.AbstractEventLoop,
         on_data: Callable[[bytes], None],
         on_close: Callable[[Exception | None], None],
+        security_level: int = BT_SECURITY_LOW,
     ) -> None:
         """Wrap an already-connected socket and start reading from it."""
         self._sock = sock
@@ -168,7 +169,34 @@ class L2CAPSocket:
         self._on_close = on_close
         self._closed = False
         self._write_lock = asyncio.Lock()
+        # The BT_SECURITY level currently requested on the socket; escalation
+        # raises it (never lowers it) when the peer rejects an ATT operation.
+        self._security_level = security_level
         loop.add_reader(sock.fileno(), self._read_ready)
+
+    @property
+    def security_level(self) -> int:
+        """The BT_SECURITY level currently requested on the socket."""
+        return self._security_level
+
+    def set_security_level(self, level: int) -> bool:
+        """
+        Raise the socket's BT_SECURITY level, never lowering it.
+
+        Returns True if the level was raised (so the caller can re-issue the
+        rejected operation), False if it was already at least ``level`` or the
+        kernel refused the change. Mirrors bluetoothd, which only escalates and
+        never downgrades a live ATT channel.
+        """
+        if level <= self._security_level:
+            return False
+        try:
+            _set_bt_security(self._sock, level)
+        except OSError as err:
+            _LOGGER.debug("Failed to raise L2CAP security to level %d: %s", level, err)
+            return False
+        self._security_level = level
+        return True
 
     @classmethod
     async def create_connection(
@@ -180,7 +208,7 @@ class L2CAPSocket:
         on_data: Callable[[bytes], None],
         on_close: Callable[[Exception | None], None],
         timeout: float,
-        security_level: int = BT_SECURITY_MEDIUM,
+        security_level: int = BT_SECURITY_LOW,
         sock: socket.socket | None = None,
     ) -> L2CAPSocket:
         """
@@ -188,8 +216,11 @@ class L2CAPSocket:
 
         ``source`` is the local adapter's public BD_ADDR (it selects which
         adapter the connection goes out of); ``address``/``address_type`` are the
-        peer. ``security_level`` requests kernel-driven LE encryption when bonded
-        keys exist; pass 0 to leave it unset. ``sock`` is injectable for testing.
+        peer. ``security_level`` is the initial BT_SECURITY level; it defaults to
+        ``BT_SECURITY_LOW`` (no encryption requested up front) to match
+        bluetoothd, which then escalates on demand via :meth:`set_security_level`
+        when the peer rejects an ATT operation. Pass 0 to leave it unset.
+        ``sock`` is injectable for testing.
         """
         loop = asyncio.get_running_loop()
         if sock is None:  # pragma: no cover - real socket needs a Linux adapter
@@ -203,7 +234,7 @@ class L2CAPSocket:
         except BaseException:
             sock.close()
             raise
-        return cls(sock, loop, on_data, on_close)
+        return cls(sock, loop, on_data, on_close, security_level=security_level)
 
     async def send(self, data: bytes) -> None:
         """

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -32,6 +32,7 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.service import BleakGATTService, BleakGATTServiceCollection
 
 from .channels.att import (
+    ATT_ERR_INSUFFICIENT_ENCRYPTION,
     CCCD_UUID,
     DEFAULT_MTU,
     PREFERRED_MTU,
@@ -39,7 +40,11 @@ from .channels.att import (
     properties_to_strings,
 )
 from .channels.bluez import NewLongTermKey
-from .channels.l2cap import L2CAPSocket
+from .channels.l2cap import (
+    BT_SECURITY_HIGH,
+    BT_SECURITY_MEDIUM,
+    L2CAPSocket,
+)
 from .const import BDADDR_LE_PUBLIC
 
 if TYPE_CHECKING:
@@ -170,7 +175,11 @@ class HaMgmtClient(BaseBleakClient):
                 "%s: connect(pair=True); use pair() to bond explicitly",
                 self.address,
             )
-        att = ATTClient(send=self._send_pdu, on_disconnect=self._handle_disconnect)
+        att = ATTClient(
+            send=self._send_pdu,
+            on_disconnect=self._handle_disconnect,
+            escalate_security=self._escalate_security,
+        )
         self._att = att
         try:
             with self._scanner.connecting():
@@ -216,6 +225,33 @@ class HaMgmtClient(BaseBleakClient):
             msg = "transport not connected"
             raise BleakError(msg)
         await self._sock.send(data)
+
+    def _escalate_security(self, att_error: int) -> bool:
+        """
+        Raise the link security to satisfy an ATT auth/encryption rejection.
+
+        Mirrors bluetoothd: insufficient encryption (0x0F) requests MEDIUM,
+        insufficient authentication (0x05) steps up one level. The kernel only
+        exposes LOW/MEDIUM/HIGH, so nothing above HIGH can be tried. Returns
+        whether the level was raised, so the codec knows to re-issue once.
+        """
+        if self._sock is None:  # pragma: no cover - only called once connected
+            return False
+        if att_error == ATT_ERR_INSUFFICIENT_ENCRYPTION:
+            target = BT_SECURITY_MEDIUM
+        else:  # ATT_ERR_INSUFFICIENT_AUTHENTICATION
+            target = self._sock.security_level + 1
+        if target > BT_SECURITY_HIGH:
+            return False
+        raised = self._sock.set_security_level(target)
+        if raised:
+            _LOGGER.debug(
+                "%s: raised link security to level %d after ATT error 0x%02x",
+                self.address,
+                target,
+                att_error,
+            )
+        return raised
 
     def _handle_disconnect(self, exc: Exception | None) -> None:
         """Tear the channel down once and notify on an unexpected drop."""

--- a/tests/channels/test_att.py
+++ b/tests/channels/test_att.py
@@ -12,6 +12,7 @@ from bleak import BleakError
 from habluetooth.channels.att import (
     ATT_ERR_ATTRIBUTE_NOT_FOUND,
     ATT_ERR_INSUFFICIENT_AUTHENTICATION,
+    ATT_ERR_INSUFFICIENT_ENCRYPTION,
     ATT_ERR_INVALID_OFFSET,
     ATT_ERR_READ_NOT_PERMITTED,
     ATT_ERR_REQUEST_NOT_SUPPORTED,
@@ -48,12 +49,15 @@ class FakePeer:
     """A fake ATT peer that captures sent PDUs and auto-replies."""
 
     def __init__(
-        self, responder: Callable[[bytes], bytes | None] | None = None
+        self,
+        responder: Callable[[bytes], bytes | None] | None = None,
+        *,
+        escalate_security: Callable[[int], bool] | None = None,
     ) -> None:
         """Create the bound ATTClient and optionally script replies."""
         self.sent: list[bytes] = []
         self.responder = responder
-        self.client = ATTClient(self.send)
+        self.client = ATTClient(self.send, escalate_security=escalate_security)
 
     async def send(self, data: bytes) -> None:
         """Capture an outbound PDU and feed back the scripted response."""
@@ -90,6 +94,71 @@ async def test_properties_to_strings() -> None:
     # 0x12 sets the read and notify bits
     assert properties_to_strings(0x12) == ["read", "notify"]
     assert properties_to_strings(0x00) == []
+
+
+# -- security escalation --------------------------------------------------
+async def test_request_escalates_and_retries_on_encryption_error() -> None:
+    """An insufficient-encryption error raises security and re-sends once."""
+    attempts = 0
+
+    def responder(req: bytes) -> bytes:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return _att_error(req[0], 0x0005, ATT_ERR_INSUFFICIENT_ENCRYPTION)
+        return bytes([ATT_READ_RSP]) + b"\x01\x02"
+
+    seen: list[int] = []
+
+    def escalate(err: int) -> bool:
+        seen.append(err)
+        return True
+
+    peer = FakePeer(responder, escalate_security=escalate)
+    assert await peer.client.read(0x0005) == b"\x01\x02"
+    assert seen == [ATT_ERR_INSUFFICIENT_ENCRYPTION]
+    assert len(peer.sent) == 2  # original request plus one retry
+
+
+async def test_request_does_not_retry_when_escalation_declines() -> None:
+    """If security cannot be raised, the error is surfaced without a retry."""
+    peer = FakePeer(
+        lambda req: _att_error(req[0], 0x0001, ATT_ERR_INSUFFICIENT_AUTHENTICATION),
+        escalate_security=lambda _err: False,
+    )
+    with pytest.raises(ATTError) as exc_info:
+        await peer.client.read(0x0001)
+    assert exc_info.value.error_code == ATT_ERR_INSUFFICIENT_AUTHENTICATION
+    assert len(peer.sent) == 1  # not retried
+
+
+async def test_request_escalates_at_most_once() -> None:
+    """A persistent security error is surfaced after a single retry."""
+    seen: list[int] = []
+
+    def escalate(err: int) -> bool:
+        seen.append(err)
+        return True
+
+    peer = FakePeer(
+        lambda req: _att_error(req[0], 0x0001, ATT_ERR_INSUFFICIENT_ENCRYPTION),
+        escalate_security=escalate,
+    )
+    with pytest.raises(ATTError):
+        await peer.client.read(0x0001)
+    assert len(seen) == 1  # escalated once
+    assert len(peer.sent) == 2  # original request plus one retry
+
+
+async def test_request_without_escalation_surfaces_security_error() -> None:
+    """With no escalation hook, a security error propagates immediately."""
+    peer = FakePeer(
+        lambda req: _att_error(req[0], 0x0001, ATT_ERR_INSUFFICIENT_ENCRYPTION)
+    )
+    with pytest.raises(ATTError) as exc_info:
+        await peer.client.read(0x0001)
+    assert exc_info.value.error_code == ATT_ERR_INSUFFICIENT_ENCRYPTION
+    assert len(peer.sent) == 1
 
 
 # -- MTU ------------------------------------------------------------------

--- a/tests/channels/test_l2cap.py
+++ b/tests/channels/test_l2cap.py
@@ -17,6 +17,9 @@ from bleak import BleakError
 from habluetooth.channels.l2cap import (
     AF_BLUETOOTH,
     ATT_CID,
+    BT_SECURITY_HIGH,
+    BT_SECURITY_LOW,
+    BT_SECURITY_MEDIUM,
     L2CAPSocket,
     _set_result_if_pending,
     _wait_connected,
@@ -140,6 +143,60 @@ async def test_create_connection_security_level(
         )
     sock.close()
     assert set_security.call_count == expected_calls
+
+
+async def test_default_security_level_is_low(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """The connection starts at BT_SECURITY_LOW to match bluetoothd."""
+    left, _right = pair
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    assert sock.security_level == BT_SECURITY_LOW
+    sock.close()
+
+
+async def test_set_security_level_raises_and_tracks(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """Raising the level applies the socket option and records the new level."""
+    left, _right = pair
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    with patch("habluetooth.channels.l2cap._set_bt_security") as set_security:
+        assert sock.set_security_level(BT_SECURITY_MEDIUM) is True
+    assert sock.security_level == BT_SECURITY_MEDIUM
+    set_security.assert_called_once_with(sock._sock, BT_SECURITY_MEDIUM)
+    sock.close()
+
+
+async def test_set_security_level_never_downgrades(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """A level at or below the current one is a no-op and is not applied."""
+    left, _right = pair
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    with patch("habluetooth.channels.l2cap._set_bt_security"):
+        sock.set_security_level(BT_SECURITY_HIGH)
+    with patch("habluetooth.channels.l2cap._set_bt_security") as set_security:
+        assert sock.set_security_level(BT_SECURITY_MEDIUM) is False  # lower
+        assert sock.set_security_level(BT_SECURITY_HIGH) is False  # equal
+        set_security.assert_not_called()
+    assert sock.security_level == BT_SECURITY_HIGH
+    sock.close()
+
+
+async def test_set_security_level_handles_oserror(
+    pair: tuple[socket.socket, socket.socket],
+) -> None:
+    """A kernel refusal leaves the tracked level unchanged and returns False."""
+    left, _right = pair
+    sock = await _connect(left, on_data=lambda _d: None, on_close=lambda _e: None)
+    with patch(
+        "habluetooth.channels.l2cap._set_bt_security",
+        side_effect=OSError(errno.EPERM, "denied"),
+    ):
+        assert sock.set_security_level(BT_SECURITY_MEDIUM) is False
+    assert sock.security_level == BT_SECURITY_LOW
+    sock.close()
 
 
 async def test_create_connection_immediate_success(

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -11,10 +11,19 @@ import pytest
 from bleak import BleakError
 from bleak.backends.device import BLEDevice
 
+from habluetooth.channels.att import (
+    ATT_ERR_INSUFFICIENT_AUTHENTICATION,
+    ATT_ERR_INSUFFICIENT_ENCRYPTION,
+)
 from habluetooth.channels.bluez import (
     AuthenticationFailed,
     LongTermKey,
     NewLongTermKey,
+)
+from habluetooth.channels.l2cap import (
+    BT_SECURITY_HIGH,
+    BT_SECURITY_LOW,
+    BT_SECURITY_MEDIUM,
 )
 from habluetooth.client_mgmt import HaMgmtClient, MgmtClientData
 from habluetooth.const import BDADDR_LE_RANDOM
@@ -128,6 +137,16 @@ class FakeTransport:
         self._on_close = on_close
         self.sent: list[bytes] = []
         self.closed = False
+        self.security_level = BT_SECURITY_LOW
+        self.security_requests: list[int] = []
+
+    def set_security_level(self, level: int) -> bool:
+        """Raise the tracked security level, never lowering it."""
+        self.security_requests.append(level)
+        if level <= self.security_level:
+            return False
+        self.security_level = level
+        return True
 
     async def send(self, data: bytes) -> None:
         self.sent.append(bytes(data))
@@ -312,6 +331,51 @@ async def test_write_gatt_descriptor() -> None:
     assert cccd is not None
     await client.write_gatt_descriptor(cccd, b"\x01\x00")
     assert holder["transport"].sent[-1] == b"\x12\x04\x00\x01\x00"
+
+
+# -- security escalation --------------------------------------------------
+async def test_read_escalates_security_then_succeeds() -> None:
+    """A read rejected for encryption raises link security and retries once."""
+    holder: dict[str, FakeTransport] = {}
+    base = make_responder()
+    attempts = 0
+
+    def responder(req: bytes) -> bytes | None:
+        nonlocal attempts
+        if req[0] == 0x0A:  # READ_REQ
+            attempts += 1
+            if attempts == 1:
+                handle = int.from_bytes(req[1:3], "little")
+                return _error(0x0A, handle, ATT_ERR_INSUFFICIENT_ENCRYPTION)
+        return base(req)
+
+    client, _scanner = await _connect(holder, responder)
+    assert await client.read_gatt_char(_char(client)) == bytearray(_VALUE)
+    assert holder["transport"].security_requests == [BT_SECURITY_MEDIUM]
+    assert holder["transport"].security_level == BT_SECURITY_MEDIUM
+
+
+async def test_escalate_security_steps_up_on_authentication() -> None:
+    """Insufficient authentication steps the level up one, capped at HIGH."""
+    client, _scanner = _make_client()
+    transport = FakeTransport(make_responder(), lambda _d: None, lambda _e: None)
+    transport.security_level = BT_SECURITY_MEDIUM
+    client._sock = transport  # type: ignore[assignment]
+    assert client._escalate_security(ATT_ERR_INSUFFICIENT_AUTHENTICATION) is True
+    assert transport.security_level == BT_SECURITY_HIGH
+    # The kernel exposes nothing above HIGH, so a further step declines.
+    assert client._escalate_security(ATT_ERR_INSUFFICIENT_AUTHENTICATION) is False
+    assert transport.security_level == BT_SECURITY_HIGH
+
+
+async def test_escalate_security_declines_when_already_encrypted() -> None:
+    """An encryption error at MEDIUM cannot be satisfied by encryption again."""
+    client, _scanner = _make_client()
+    transport = FakeTransport(make_responder(), lambda _d: None, lambda _e: None)
+    transport.security_level = BT_SECURITY_MEDIUM
+    client._sock = transport  # type: ignore[assignment]
+    assert client._escalate_security(ATT_ERR_INSUFFICIENT_ENCRYPTION) is False
+    assert transport.security_level == BT_SECURITY_MEDIUM
 
 
 # -- notifications --------------------------------------------------------


### PR DESCRIPTION
The raw L2CAP GATT client previously requested BT_SECURITY_MEDIUM up front on every connection, which forces encryption even for peers that do not need it. bluetoothd instead starts an ATT channel at the lowest level and escalates only when the peer rejects an operation.

This matches that behavior; the connection now starts at BT_SECURITY_LOW, and when an ATT request returns insufficient encryption (0x0F) or insufficient authentication (0x05) the codec asks the transport to raise the link security and re-issues the request once, exactly like bluetoothd's bt_att one-shot retry. 0x0F goes to MEDIUM, 0x05 steps up one level toward HIGH, and the level never downgrades. The codec stays transport agnostic, the error to level policy lives in the client, and the socket option lives in the transport.

Research basis: BlueZ src/shared/att.c change_security plus the op retry guard in handle_error_rsp.