### PR TITLE
fix(manager): keep a strong owner against a comparable scanner on stale

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -47,6 +47,16 @@ CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS: Final = 195
 # device that genuinely moved into weak-only coverage hand off.
 DURABLY_GONE_STALE_FACTOR: Final = 2.5
 
+# An owner whose last advertisement was at least this strong is treated as
+# close/stationary: a brief reception gap is almost certainly RF/scan-response
+# jitter rather than the device leaving, so a merely-comparable challenger
+# (not ADV_RSSI_SWITCH_THRESHOLD stronger) must wait for durable absence
+# before stealing ownership, instead of flapping the device on a single
+# missed interval. A weaker owner keeps the normal comparable-on-stale
+# handoff. Above the -100 owners used in the stale tests so they are
+# unaffected, and below typical close-proxy readings.
+STRONG_OWNER_STALE_RSSI: Final = -70
+
 
 # We must recover before we hit the 180s mark
 # where the device is removed from the stack

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -10,6 +10,7 @@ cdef int ADV_RSSI_SWITCH_THRESHOLD
 cdef double TRACKER_BUFFERING_WOBBLE_SECONDS
 cdef double FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 cdef double _DURABLY_GONE_STALE_FACTOR
+cdef int _STRONG_OWNER_STALE_RSSI
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice
@@ -84,6 +85,7 @@ cdef class BluetoothManager:
         elapsed=double,
         durably_gone=double,
         comparable_or_stronger=bint,
+        owner_strong=bint,
     )
     cdef bint _prefer_previous_adv_from_different_source(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -43,6 +43,7 @@ from .const import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     MIN_ACTIVE_SCAN_DURATION,
     MIN_ACTIVE_SCAN_INTERVAL,
+    STRONG_OWNER_STALE_RSSI,
     UNAVAILABLE_TRACK_SECONDS,
 )
 from .models import (
@@ -83,9 +84,10 @@ APPLE_FINDMY_START_BYTE: Final = 0x12  # FindMy network advertisements
 _str = str
 _int = int
 
-# Hot-path C double copy of the public constant (declared cdef in the
-# .pxd); the public name stays a patchable Python constant.
+# Hot-path C copies of the public constants (declared cdef in the .pxd);
+# the public names stay patchable Python constants.
 _DURABLY_GONE_STALE_FACTOR = DURABLY_GONE_STALE_FACTOR
+_STRONG_OWNER_STALE_RSSI = STRONG_OWNER_STALE_RSSI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -577,12 +579,19 @@ class BluetoothManager:
             comparable_or_stronger = (new.rssi or NO_RSSI_VALUE) >= (
                 old.rssi or NO_RSSI_VALUE
             ) - ADV_RSSI_SWITCH_THRESHOLD
-            if comparable_or_stronger or elapsed > durably_gone:
+            # A strong/close owner that briefly goes quiet is almost
+            # certainly still there (RF / scan-response reception jitter),
+            # so a merely-comparable challenger must wait for durable
+            # absence rather than steal on one missed interval and flap a
+            # stationary device. A weaker owner keeps the normal
+            # comparable-on-stale handoff.
+            owner_strong = (old.rssi or NO_RSSI_VALUE) >= _STRONG_OWNER_STALE_RSSI
+            if (comparable_or_stronger and not owner_strong) or elapsed > durably_gone:
                 if self._debug:
                     _LOGGER.debug(
                         "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
-                        " seconds:%s; comparable_or_stronger:%s, durably-gone"
-                        " threshold:%s)",
+                        " seconds:%s; comparable_or_stronger:%s, owner_strong:%s,"
+                        " durably-gone threshold:%s)",
                         new.name,
                         new.address,
                         self._async_describe_source(old),
@@ -590,6 +599,7 @@ class BluetoothManager:
                         elapsed,
                         stale_seconds,
                         comparable_or_stronger,
+                        owner_strong,
                         durably_gone,
                     )
                 return False

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1187,22 +1187,29 @@ async def test_stale_switches_to_comparable_scanner_at_normal_window(
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
-    """A comparable-strength scanner still takes over at the normal stale window."""
+    """
+    A comparable scanner takes over a weak owner at the normal stale window.
+
+    The owner is weak (below STRONG_OWNER_STALE_RSSI), so its silence is
+    treated as the device possibly being gone and a comparable scanner is
+    allowed to take over at the normal window. A strong owner is protected
+    (see test_stale_keeps_strong_owner_against_comparable_scanner).
+    """
     address = "44:44:33:11:23:44"
     start = 50.0
     owner = generate_ble_device(address, "owner_hci0")
     owner_adv = generate_advertisement_data(
-        local_name="owner_hci0", service_uuids=[], rssi=-60
+        local_name="owner_hci0", service_uuids=[], rssi=-90
     )
     inject_advertisement_with_time_and_source(
         owner, owner_adv, start, HCI0_SOURCE_ADDRESS
     )
     get_manager().async_set_fallback_availability_interval(address, 10)
 
-    # Within 16 dB of the owner: ordinary roaming handoff at the normal window.
+    # Weak owner, comparable challenger: ordinary handoff at the normal window.
     comparable = generate_ble_device(address, "comparable_hci1")
     comparable_adv = generate_advertisement_data(
-        local_name="comparable_hci1", service_uuids=[], rssi=-70
+        local_name="comparable_hci1", service_uuids=[], rssi=-95
     )
     inject_advertisement_with_time_and_source(
         comparable,
@@ -1211,6 +1218,113 @@ async def test_stale_switches_to_comparable_scanner_at_normal_window(
         HCI1_SOURCE_ADDRESS,
     )
     assert get_manager().async_ble_device_from_address(address, True) is comparable
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_keeps_strong_owner_against_comparable_scanner(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A strong/close owner is not stolen by a comparable scanner on a stale interval.
+
+    Regression for the stationary-device flap: a strong owner (>=
+    STRONG_OWNER_STALE_RSSI) that briefly goes quiet is almost certainly
+    still there, so a merely-comparable scanner must wait for durable
+    absence rather than steal on one missed interval.
+    """
+    address = "44:44:33:11:23:47"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-50
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    get_manager().async_set_fallback_availability_interval(address, 10)  # stale=15
+
+    comparable = generate_ble_device(address, "comparable_hci1")
+    comparable_adv = generate_advertisement_data(
+        local_name="comparable_hci1", service_uuids=[], rssi=-60
+    )
+    # Just past the normal stale window: a comparable scanner must NOT steal
+    # the strong owner.
+    inject_advertisement_with_time_and_source(
+        comparable,
+        comparable_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is strong
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_strong_owner_yields_to_comparable_when_durably_gone(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A strong owner that is durably silent still hands off to a comparable scanner."""
+    address = "44:44:33:11:23:48"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-50
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    # stale_seconds = 15, durably-gone = 15 * 2.5 = 37.5
+    get_manager().async_set_fallback_availability_interval(address, 10)
+
+    comparable = generate_ble_device(address, "comparable_hci1")
+    comparable_adv = generate_advertisement_data(
+        local_name="comparable_hci1", service_uuids=[], rssi=-60
+    )
+    # Within the durably-gone window: strong owner kept.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 30, HCI1_SOURCE_ADDRESS
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is strong
+    # Past durably-gone: the comparable scanner finally takes over.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 40, HCI1_SOURCE_ADDRESS
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is comparable
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_strong_owner_yields_to_stronger_scanner(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A strong owner still yields immediately to a materially stronger scanner."""
+    address = "44:44:33:11:23:49"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-50
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    get_manager().async_set_fallback_availability_interval(address, 10)
+
+    # >16 dB stronger: the RSSI path takes over immediately, strong owner or not.
+    stronger = generate_ble_device(address, "stronger_hci1")
+    stronger_adv = generate_advertisement_data(
+        local_name="stronger_hci1", service_uuids=[], rssi=-20
+    )
+    inject_advertisement_with_time_and_source(
+        stronger,
+        stronger_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is stronger
 
 
 @pytest.mark.usefixtures("enable_bluetooth")


### PR DESCRIPTION
Follow-up to #570. On my own setup a stationary Inkbird/H5074 sitting right next to a strong proxy still flapped ownership ~8x in 9 minutes; every switch was a comparable proxy, so the data barely moved, but a device that never moves should not change owners.

Cause: the owner's normal ~10s reception gap (RF / scan-response jitter) barely beats the stale window, which is built from the aggregate advertising interval across all proxies and so underestimates a single owner's gap. A comparable proxy steals on the stale path, then the strong owner re-hears the device and reclaims on RSSI, twice per gap. The tracker cannot learn the real gap because the steal resets it.

Fix: when the owner's last advertisement was at least STRONG_OWNER_STALE_RSSI (-70 dBm), treat a brief silence as jitter; a merely-comparable challenger must wait for durable absence rather than steal on one missed interval. A weaker owner keeps the normal comparable-on-stale handoff, a materially stronger challenger still takes over immediately via RSSI, and #570's weak-steal block is unchanged.

Relates to home-assistant/core#174169.