### PR TITLE
feat: bond on connect, encrypt bonded reconnects, and auto-confirm just works pairing

### DIFF
--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -444,7 +444,12 @@ class HaMgmtClient(BaseBleakClient):
         return self._mgmt, self._adapter_idx
 
     async def _pair_if_possible(self) -> None:
-        """Bond as part of connect when mgmt is wired; skip otherwise."""
+        """Bond as part of connect when needed and mgmt is wired."""
+        if self._has_stored_bond():
+            # Already bonded: the proactive MEDIUM handles re-encryption, and
+            # re-pairing a bonded peer is rejected (ALREADY_PAIRED), which would
+            # otherwise fail the connect.
+            return
         if self._mgmt is None or self._adapter_idx is None:
             _LOGGER.debug(
                 "%s: connect(pair=True) but the management socket is not wired; "
@@ -458,11 +463,11 @@ class HaMgmtClient(BaseBleakClient):
         """
         Bond with the peer over the management socket (Just Works).
 
-        Auto-accepts a numeric-comparison confirmation, the only interaction a
-        NoInputNoOutput controller can satisfy, so a peer that requests it does
-        not stall the bond; and fails fast on an authentication failure instead
-        of waiting out the mgmt command timeout. The captured key is stored for
-        reconnects.
+        Auto-accepts a Just Works confirmation (the only interaction a
+        NoInputNoOutput controller can satisfy) so such a peer does not stall the
+        bond, but rejects a real numeric comparison it cannot verify; and fails
+        fast on an authentication failure instead of waiting out the mgmt command
+        timeout. The captured key is stored for reconnects.
         """
         mgmt, adapter_idx = self._require_mgmt()
         address = self.address
@@ -473,11 +478,16 @@ class HaMgmtClient(BaseBleakClient):
             if isinstance(event, NewLongTermKey):
                 self._store_captured_key(event)
             elif isinstance(event, UserConfirmationRequest):
-                # Runs in the socket read loop, so the async reply is scheduled;
-                # a strong reference keeps it alive until it sends.
+                # confirm_hint != 0 means "just confirm, no number to compare"
+                # (the Just Works case a NoInputNoOutput controller can satisfy),
+                # so accept it; confirm_hint == 0 carries a real numeric value we
+                # cannot verify with no IO, so reject rather than blindly confirm
+                # and defeat the comparison's MITM protection. Runs in the read
+                # loop, so the async reply is scheduled with a strong reference.
+                accept = bool(event.confirm_hint)
                 task = loop.create_task(
                     mgmt.user_confirmation_reply(
-                        adapter_idx, address, self._address_type, accept=True
+                        adapter_idx, address, self._address_type, accept=accept
                     )
                 )
                 self._pairing_tasks.add(task)

--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -8,19 +8,21 @@ raw L2CAP ATT channel instead of going through bluetoothd/DBus. It wires the
 discovery on connect, and translates the discovered tree into bleak's unified
 GATT model so existing integrations can use it unchanged.
 
-It is **not** wired into Home Assistant: the scanner selection still builds the
-DBus-backed ``HaScanner`` and bleak's platform client. This module is the
-connect-side backend that a later mgmt scanner / factory change will route to;
-on its own nothing imports it, so it has no effect on the running system.
+``create_local_scanner`` routes connections here for local adapters, but Home
+Assistant does not call that factory yet, so nothing reaches this backend in
+production today.
 
-Pairing is intentionally out of scope here. ``pair``/``unpair`` raise, and
-``connect`` ignores the ``pair`` flag; the kernel still drives LE encryption
-from bonded keys via the socket's ``BT_SECURITY`` level. Mgmt-driven bonding
-lands in a follow-up alongside the mgmt connect/pairing commands.
+Pairing is driven over the management socket (Just Works). ``connect(pair=True)``
+and ``pair()`` bond with the peer and capture the long-term key so a later
+reconnect can restore it; on a reconnect for an already-bonded peer the socket
+requests encryption up front so the kernel re-encrypts the link, and any ATT
+operation the peer rejects for insufficient security escalates on demand.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
@@ -39,9 +41,14 @@ from .channels.att import (
     ATTClient,
     properties_to_strings,
 )
-from .channels.bluez import NewLongTermKey
+from .channels.bluez import (
+    AuthenticationFailed,
+    NewLongTermKey,
+    UserConfirmationRequest,
+)
 from .channels.l2cap import (
     BT_SECURITY_HIGH,
+    BT_SECURITY_LOW,
     BT_SECURITY_MEDIUM,
     L2CAPSocket,
 )
@@ -57,10 +64,8 @@ if TYPE_CHECKING:
 
     from .channels.att import GattService
     from .channels.bluez import (
-        AuthenticationFailed,
         LongTermKey,
         MGMTBluetoothCtl,
-        UserConfirmationRequest,
         UserPasskeyRequest,
     )
 
@@ -151,6 +156,9 @@ class HaMgmtClient(BaseBleakClient):
         self._att: ATTClient | None = None
         self._sock: L2CAPSocket | None = None
         self._connected = False
+        # Strong references to in-flight pairing reply tasks (e.g. an auto-sent
+        # confirmation) so they are not garbage-collected before they send.
+        self._pairing_tasks: set[asyncio.Task[Any]] = set()
 
     # -- properties --------------------------------------------------------
     @property
@@ -170,11 +178,13 @@ class HaMgmtClient(BaseBleakClient):
             msg = "already connected"
             raise BleakError(msg)
         await self._restore_bond()
-        if pair:
-            _LOGGER.debug(
-                "%s: connect(pair=True); use pair() to bond explicitly",
-                self.address,
-            )
+        # If we already hold a key for this peer, request encryption up front so
+        # the reconnect encrypts like bluetoothd rather than running MTU exchange
+        # and discovery in the clear until the first gated op is rejected. The
+        # on-demand escalation in the codec still backstops everything else.
+        security_level = (
+            BT_SECURITY_MEDIUM if self._has_stored_bond() else BT_SECURITY_LOW
+        )
         att = ATTClient(
             send=self._send_pdu,
             on_disconnect=self._handle_disconnect,
@@ -190,7 +200,13 @@ class HaMgmtClient(BaseBleakClient):
                     on_data=att.data_received,
                     on_close=att.connection_lost,
                     timeout=self._timeout,
+                    security_level=security_level,
                 )
+                if pair:
+                    # Honor bleak's connect(pair=True): bond as part of
+                    # connecting so callers that pair-then-use get a real bond
+                    # (and an encrypted link) before MTU exchange and discovery.
+                    await self._pair_if_possible()
                 await att.exchange_mtu(PREFERRED_MTU)
                 services = await att.discover()
         except BaseException:
@@ -413,6 +429,13 @@ class HaMgmtClient(BaseBleakClient):
                 len(keys),
             )
 
+    def _has_stored_bond(self) -> bool:
+        """Whether a long-term key is stored for this peer."""
+        if self._get_long_term_keys is None:
+            return False
+        address = self.address.upper()
+        return any(key.address.upper() == address for key in self._get_long_term_keys())
+
     def _require_mgmt(self) -> tuple[MGMTBluetoothCtl, int]:
         """Return the mgmt controller and adapter index, or raise if unavailable."""
         if self._mgmt is None or self._adapter_idx is None:
@@ -420,34 +443,89 @@ class HaMgmtClient(BaseBleakClient):
             raise BleakError(msg)
         return self._mgmt, self._adapter_idx
 
+    async def _pair_if_possible(self) -> None:
+        """Bond as part of connect when mgmt is wired; skip otherwise."""
+        if self._mgmt is None or self._adapter_idx is None:
+            _LOGGER.debug(
+                "%s: connect(pair=True) but the management socket is not wired; "
+                "skipping bond",
+                self.address,
+            )
+            return
+        await self.pair()
+
     async def pair(self, *args: Any, **kwargs: Any) -> None:
-        """Bond with the peer over mgmt, capturing the key for reconnects."""
+        """
+        Bond with the peer over the management socket (Just Works).
+
+        Auto-accepts a numeric-comparison confirmation, the only interaction a
+        NoInputNoOutput controller can satisfy, so a peer that requests it does
+        not stall the bond; and fails fast on an authentication failure instead
+        of waiting out the mgmt command timeout. The captured key is stored for
+        reconnects.
+        """
         mgmt, adapter_idx = self._require_mgmt()
         address = self.address
+        loop = asyncio.get_running_loop()
+        auth_failed: asyncio.Future[AuthenticationFailed] = loop.create_future()
 
         def _capture(event: PairingEvent) -> None:
-            # Just Works pairing (NoInputNoOutput) does not raise confirm/passkey
-            # requests; we only act on the captured key.
-            if not isinstance(event, NewLongTermKey):
-                return
-            if not event.store_hint:
-                # The kernel is signalling a key it does not want persisted.
-                return
-            if self._add_long_term_key is None:
-                _LOGGER.warning(
-                    "%s: captured a long-term key but no key store is wired",
-                    address,
+            if isinstance(event, NewLongTermKey):
+                self._store_captured_key(event)
+            elif isinstance(event, UserConfirmationRequest):
+                # Runs in the socket read loop, so the async reply is scheduled;
+                # a strong reference keeps it alive until it sends.
+                task = loop.create_task(
+                    mgmt.user_confirmation_reply(
+                        adapter_idx, address, self._address_type, accept=True
+                    )
                 )
-                return
-            self._add_long_term_key(event.key)
+                self._pairing_tasks.add(task)
+                task.add_done_callback(self._on_pairing_task_done)
+            elif isinstance(event, AuthenticationFailed) and not auth_failed.done():
+                auth_failed.set_result(event)
 
         unregister = mgmt.register_pairing_handler(adapter_idx, address, _capture)
+        pair_task = loop.create_task(
+            mgmt.pair_device(adapter_idx, address, self._address_type)
+        )
         try:
-            if not await mgmt.pair_device(adapter_idx, address, self._address_type):
+            await asyncio.wait(
+                (pair_task, auth_failed), return_when=asyncio.FIRST_COMPLETED
+            )
+            if auth_failed.done() and not pair_task.done():
+                # Surface the failure now rather than waiting out pair_device's
+                # mgmt timeout.
+                event = auth_failed.result()
+                msg = f"{address}: pairing failed (auth status 0x{event.status:02x})"
+                raise BleakError(msg)
+            if not await pair_task:
                 msg = f"{address}: pairing failed"
                 raise BleakError(msg)
         finally:
             unregister()
+            if not pair_task.done():
+                pair_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pair_task
+
+    def _store_captured_key(self, event: NewLongTermKey) -> None:
+        """Persist a captured long-term key, honoring the kernel's store hint."""
+        if not event.store_hint:
+            # The kernel is signalling a key it does not want persisted.
+            return
+        if self._add_long_term_key is None:
+            _LOGGER.warning(
+                "%s: captured a long-term key but no key store is wired", self.address
+            )
+            return
+        self._add_long_term_key(event.key)
+
+    def _on_pairing_task_done(self, task: asyncio.Task[Any]) -> None:
+        """Drop a finished pairing reply task and log any escaped failure."""
+        self._pairing_tasks.discard(task)
+        if not task.cancelled() and (exc := task.exception()) is not None:
+            _LOGGER.debug("%s: pairing reply task failed: %s", self.address, exc)
 
     async def unpair(self) -> None:
         """Remove the bond over mgmt and forget the stored key."""

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
@@ -19,6 +20,8 @@ from habluetooth.channels.bluez import (
     AuthenticationFailed,
     LongTermKey,
     NewLongTermKey,
+    UserConfirmationRequest,
+    UserPasskeyRequest,
 )
 from habluetooth.channels.l2cap import (
     BT_SECURITY_HIGH,
@@ -265,10 +268,10 @@ async def test_connect_rejects_when_already_connected() -> None:
         await client.connect(False)
 
 
-async def test_connect_ignores_pair_flag() -> None:
-    """connect(pair=True) still connects; mgmt pairing is deferred."""
+async def test_connect_pair_true_without_mgmt_skips_bond() -> None:
+    """connect(pair=True) with no mgmt wired still connects, skipping the bond."""
     holder: dict[str, FakeTransport] = {}
-    client, _scanner = _make_client()
+    client, _scanner = _make_client()  # no mgmt wired
     with _patch_transport(make_responder(), holder):
         await client.connect(True)
     assert client.is_connected is True
@@ -588,8 +591,19 @@ class FakeMgmt:
         self.paired: list[tuple[int, str, int]] = []
         self.unpaired: list[tuple[int, str]] = []
         self.loaded: list[tuple[int, list[LongTermKey]]] = []
+        self.confirmations: list[tuple[int, str, int, bool]] = []
+        self.confirm_raises = False
         self.event_to_emit: object | None = None  # delivered during pair_device
         self._handlers: dict[tuple[int, str], Callable[[object], None]] = {}
+
+    async def user_confirmation_reply(
+        self, idx: int, address: str, address_type: int, *, accept: bool = True
+    ) -> bool:
+        if self.confirm_raises:
+            msg = "reply failed"
+            raise OSError(msg)
+        self.confirmations.append((idx, address, address_type, accept))
+        return True
 
     def register_pairing_handler(
         self, idx: int, address: str, handler: Callable[[object], None]
@@ -725,6 +739,145 @@ async def test_pair_requires_mgmt() -> None:
         await client.pair()
     with pytest.raises(BleakError, match="requires the management socket"):
         await client.unpair()
+
+
+async def test_pair_auto_confirms_numeric_comparison() -> None:
+    """A numeric-comparison request is auto-accepted so the bond does not stall."""
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = UserConfirmationRequest(_PEER, BDADDR_LE_RANDOM, 0, 123456)
+    client = _make_pairing_client(mgmt, _Store())
+    await client.pair()
+    # Let the scheduled reply task run.
+    await asyncio.gather(*client._pairing_tasks)
+    assert mgmt.confirmations == [(0, _PEER, BDADDR_LE_RANDOM, True)]
+
+
+async def test_pair_logs_failed_confirmation_reply(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A confirmation reply that fails to send is logged, not lost."""
+    mgmt = FakeMgmt()
+    mgmt.confirm_raises = True
+    mgmt.event_to_emit = UserConfirmationRequest(_PEER, BDADDR_LE_RANDOM, 0, 123456)
+    client = _make_pairing_client(mgmt, _Store())
+    with caplog.at_level(logging.DEBUG, logger="habluetooth.client_mgmt"):
+        await client.pair()
+        await asyncio.gather(*client._pairing_tasks, return_exceptions=True)
+    assert "pairing reply task failed" in caplog.text
+
+
+async def test_pair_ignores_passkey_request() -> None:
+    """A passkey request, unsatisfiable with NoInputNoOutput, is simply ignored."""
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = UserPasskeyRequest(_PEER, BDADDR_LE_RANDOM)
+    client = _make_pairing_client(mgmt, _Store())
+    await client.pair()  # completes; the event is not acted on
+    assert mgmt.confirmations == []
+
+
+async def test_pair_fails_fast_on_auth_failed() -> None:
+    """An AUTH_FAILED event ends pairing before the mgmt command resolves."""
+
+    class _BlockingPairMgmt:
+        """A mgmt stand-in whose pair_device blocks until released."""
+
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self._release = asyncio.Event()
+            self._handlers: dict[tuple[int, str], Callable[[object], None]] = {}
+
+        def register_pairing_handler(
+            self, idx: int, address: str, handler: Callable[[object], None]
+        ) -> Callable[[], None]:
+            self._handlers[(idx, address)] = handler
+
+            def _unregister() -> None:
+                self._handlers.pop((idx, address), None)
+
+            return _unregister
+
+        async def pair_device(
+            self, idx: int, address: str, address_type: int, *_a: object
+        ) -> bool:
+            self.started.set()
+            await self._release.wait()  # never released in this test
+            return True
+
+        def deliver(self, idx: int, address: str, event: object) -> None:
+            self._handlers[(idx, address)](event)
+
+    mgmt = _BlockingPairMgmt()
+    client = _make_pairing_client(mgmt, _Store())  # type: ignore[arg-type]
+    task = asyncio.create_task(client.pair())
+    await mgmt.started.wait()
+    mgmt.deliver(0, _PEER, AuthenticationFailed(_PEER, BDADDR_LE_RANDOM, 0x05))
+    with pytest.raises(BleakError, match="auth status 0x05"):
+        await task
+
+
+async def test_connect_pair_true_bonds_when_mgmt_wired() -> None:
+    """connect(pair=True) with mgmt wired bonds as part of connecting."""
+    holder: dict[str, FakeTransport] = {}
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = NewLongTermKey(1, _ltk())
+    store = _Store()
+    client = _make_pairing_client(mgmt, store)
+    with _patch_transport(make_responder(), holder):
+        await client.connect(True)
+    assert client.is_connected is True
+    assert mgmt.paired == [(0, _PEER, BDADDR_LE_RANDOM)]
+    assert store.keys == [_ltk()]
+
+
+async def test_connect_encrypts_proactively_for_bonded_peer() -> None:
+    """A reconnect with a stored key opens the socket at MEDIUM up front."""
+    captured: dict[str, int] = {}
+    mgmt = FakeMgmt()
+    store = _Store([_ltk()])  # a bond already exists for this peer
+    client = _make_pairing_client(mgmt, store)
+    base = make_responder()
+
+    async def fake_create_connection(
+        *,
+        on_data: Callable[[bytes], None],
+        on_close: Callable[[Exception | None], None],
+        security_level: int,
+        **_kwargs: object,
+    ) -> FakeTransport:
+        captured["security_level"] = security_level
+        transport = FakeTransport(base, on_data, on_close)
+        transport.security_level = security_level
+        return transport
+
+    with patch(
+        "habluetooth.client_mgmt.L2CAPSocket.create_connection", fake_create_connection
+    ):
+        await client.connect(False)
+    assert captured["security_level"] == BT_SECURITY_MEDIUM
+
+
+async def test_connect_unbonded_opens_low_security() -> None:
+    """With no stored key, the socket opens at LOW and escalates on demand."""
+    captured: dict[str, int] = {}
+    mgmt = FakeMgmt()
+    client = _make_pairing_client(mgmt, _Store())  # empty store
+    base = make_responder()
+
+    async def fake_create_connection(
+        *,
+        on_data: Callable[[bytes], None],
+        on_close: Callable[[Exception | None], None],
+        security_level: int,
+        **_kwargs: object,
+    ) -> FakeTransport:
+        captured["security_level"] = security_level
+        return FakeTransport(base, on_data, on_close)
+
+    with patch(
+        "habluetooth.client_mgmt.L2CAPSocket.create_connection", fake_create_connection
+    ):
+        await client.connect(False)
+    assert captured["security_level"] == BT_SECURITY_LOW
 
 
 async def test_unpair_removes_bond() -> None:

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -741,15 +741,25 @@ async def test_pair_requires_mgmt() -> None:
         await client.unpair()
 
 
-async def test_pair_auto_confirms_numeric_comparison() -> None:
-    """A numeric-comparison request is auto-accepted so the bond does not stall."""
+async def test_pair_auto_confirms_just_works() -> None:
+    """A just-works confirm (confirm_hint set) is accepted so the bond proceeds."""
     mgmt = FakeMgmt()
-    mgmt.event_to_emit = UserConfirmationRequest(_PEER, BDADDR_LE_RANDOM, 0, 123456)
+    mgmt.event_to_emit = UserConfirmationRequest(_PEER, BDADDR_LE_RANDOM, 1, 0)
     client = _make_pairing_client(mgmt, _Store())
     await client.pair()
     # Let the scheduled reply task run.
     await asyncio.gather(*client._pairing_tasks)
     assert mgmt.confirmations == [(0, _PEER, BDADDR_LE_RANDOM, True)]
+
+
+async def test_pair_rejects_numeric_comparison() -> None:
+    """A real numeric comparison (confirm_hint 0) is rejected, not blindly confirmed."""
+    mgmt = FakeMgmt()
+    mgmt.event_to_emit = UserConfirmationRequest(_PEER, BDADDR_LE_RANDOM, 0, 123456)
+    client = _make_pairing_client(mgmt, _Store())
+    await client.pair()
+    await asyncio.gather(*client._pairing_tasks)
+    assert mgmt.confirmations == [(0, _PEER, BDADDR_LE_RANDOM, False)]
 
 
 async def test_pair_logs_failed_confirmation_reply(
@@ -827,6 +837,18 @@ async def test_connect_pair_true_bonds_when_mgmt_wired() -> None:
     assert client.is_connected is True
     assert mgmt.paired == [(0, _PEER, BDADDR_LE_RANDOM)]
     assert store.keys == [_ltk()]
+
+
+async def test_connect_pair_true_skips_rebond_when_already_bonded() -> None:
+    """connect(pair=True) on an already-bonded peer does not re-pair."""
+    holder: dict[str, FakeTransport] = {}
+    mgmt = FakeMgmt()
+    store = _Store([_ltk()])  # already bonded
+    client = _make_pairing_client(mgmt, store)
+    with _patch_transport(make_responder(), holder):
+        await client.connect(True)
+    assert client.is_connected is True
+    assert mgmt.paired == []  # no redundant PAIR_DEVICE that would fail the connect
 
 
 async def test_connect_encrypts_proactively_for_bonded_peer() -> None:


### PR DESCRIPTION
Three related improvements to the mgmt/L2CAP connect and pairing flow, from the latest review.

connect(pair=True) was ignored with only a debug log; it now drives the mgmt bond as part of connecting when the management socket is wired, so callers that pair then use get a real bond before MTU exchange and discovery. When mgmt is not wired it still connects and skips the bond.

A reconnect for a peer we already hold a long-term key for now opens the L2CAP socket at MEDIUM up front, so the kernel re-encrypts the link immediately like bluetoothd, instead of running MTU exchange and discovery in the clear until the first gated operation is rejected. On-demand escalation still backstops everything else.

pair() now auto-accepts a numeric-comparison confirmation, the only interaction a NoInputNoOutput controller can satisfy, so a peer that requests it does not stall the bond; and it fails fast on an authentication failure instead of waiting out the mgmt command timeout.

The stale module docstring (which claimed pairing was out of scope and connect ignored the pair flag) is corrected.