### PR TITLE
fix: drop the notify handler when the stop_notify CCCD write fails

### DIFF
--- a/src/habluetooth/client_mgmt.py
+++ b/src/habluetooth/client_mgmt.py
@@ -389,9 +389,14 @@ class HaMgmtClient(BaseBleakClient):
         """Disable notifications by clearing the CCCD and dropping the handler."""
         codec = self._codec()
         cccd = characteristic.get_descriptor(CCCD_UUID)
-        if cccd is not None:
-            await codec.write(cccd.handle, _CCCD_OFF)
-        codec.remove_notify_handler(characteristic.handle)
+        try:
+            if cccd is not None:
+                await codec.write(cccd.handle, _CCCD_OFF)
+        finally:
+            # Drop the handler even if disabling the CCCD failed, mirroring
+            # start_notify's unwind, so a failed write leaves no stale handler
+            # routing notifications for a subscription the caller stopped.
+            codec.remove_notify_handler(characteristic.handle)
 
     # -- pairing -----------------------------------------------------------
     async def _restore_bond(self) -> None:

--- a/tests/test_client_mgmt.py
+++ b/tests/test_client_mgmt.py
@@ -440,6 +440,31 @@ async def test_start_notify_unwinds_handler_on_cccd_write_failure() -> None:
     assert received == []
 
 
+async def test_stop_notify_drops_handler_when_cccd_write_fails() -> None:
+    """A failed CCCD-off write still drops the handler, then surfaces the error."""
+    holder: dict[str, FakeTransport] = {}
+    fail = {"on": False}
+    base = make_responder()
+
+    def responder(req: bytes) -> bytes | None:
+        if req[0] == 0x12 and fail["on"]:  # WRITE_REQ
+            return _error(0x12, int.from_bytes(req[1:3], "little"), 0x03)
+        return base(req)
+
+    client, _scanner = await _connect(holder, responder)
+    char = _char(client)
+    received: list[bytearray] = []
+    await client.start_notify(char, received.append)
+    ntf = bytes([_NTF]) + (0x0003).to_bytes(2, "little") + b"\x09"
+    holder["transport"].inject(ntf)
+    assert received == [bytearray(b"\x09")]  # handler is live
+    fail["on"] = True
+    with pytest.raises(BleakError):
+        await client.stop_notify(char)
+    holder["transport"].inject(ntf)
+    assert received == [bytearray(b"\x09")]  # handler dropped despite the failure
+
+
 async def test_stop_notify_without_cccd_only_drops_handler() -> None:
     """stop_notify on a characteristic with no CCCD just drops the handler."""
     holder: dict[str, FakeTransport] = {}


### PR DESCRIPTION
stop_notify removed the notify handler only after the CCCD-off write returned, so if that write failed the handler was left registered, still routing notifications for a subscription the caller had stopped.

The handler is now removed in a finally, mirroring start_notify's unwind, so a failed disable leaves no stale handler; the write error still surfaces to the caller.