### PR TITLE
docs: correct the stale att transport docstring and note the bond list limitation

### DIFF
--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -58,6 +58,40 @@ flag or an environment check) so it is off by default and a user can enable it
 per install. Fall back to the plain `HaScanner` constructor when the flag is
 off.
 
+### Controller ownership (required before enabling the connect path)
+
+The LE long-term-key table belongs to the **controller and its kernel**, not to
+a process or container. `AF_BLUETOOTH`/HCI control sockets are not
+network-namespaced, so a `habluetooth` running in the Home Assistant container
+and a `bluetoothd` running on the host share the **same** `hciN` and the **same**
+kernel bond table. The typical deployment (HA in a container, host `bluetoothd`)
+is therefore a single shared controller, not two isolated ones.
+
+The mgmt **discovery** side already coexists with host `bluetoothd` (it only
+reads advertisement events; that is the existing side channel). The mgmt
+**connect/pair** path does not: `LOAD_LONG_TERM_KEYS`, mgmt pairing, and the
+L2CAP ACL/GATT are stateful on the shared controller and collide with a
+`bluetoothd` that is still managing the same `hciN`. In particular
+`LOAD_LONG_TERM_KEYS` replaces the controller's whole key list, clearing the
+bonds `bluetoothd` loaded; those keys cannot be recovered (DBus never exposes
+key material, and `bluetoothd`'s `/var/lib/bluetooth` store is not reachable from
+the HA container).
+
+So the model is **per-adapter partitioning**, never co-management of one `hciN`:
+
+- Controllers `bluetoothd` manages stay on the bleak/DBus path (today's
+  behavior); their bonds remain `bluetoothd`'s and are untouched.
+- The mgmt connect path may own a controller only if `bluetoothd` is **not**
+  managing it (for example a dedicated adapter the host bluetooth service is
+  configured to ignore). It then creates its own bonds from the first pairing,
+  so `LOAD_LONG_TERM_KEYS` only ever replaces its own list.
+
+> **Factory gap.** `create_local_scanner` currently gates only on mgmt discovery
+> capability and L2CAP availability; it has **no** signal for "this controller is
+> not also managed by `bluetoothd`." Until that exclusivity gate exists, treat
+> the connect path as safe only on a controller you know `bluetoothd` does not
+> manage, and keep the opt-in above scoped to such adapters.
+
 ## 2. Persist bonds across restarts
 
 Pairing over mgmt yields long-term keys that `habluetooth` keeps **in memory**

--- a/src/habluetooth/channels/att.py
+++ b/src/habluetooth/channels/att.py
@@ -11,7 +11,7 @@ It is deliberately transport-agnostic. Outbound PDUs are written through the
 ``send`` coroutine supplied at construction, and inbound PDUs are delivered by
 the transport via :meth:`ATTClient.data_received`. Nothing here opens a socket,
 so the whole module is unit-testable without Bluetooth hardware. The L2CAP
-socket that feeds it lands in a later change.
+transport that feeds it is :class:`habluetooth.channels.l2cap.L2CAPSocket`.
 
 ATT is strictly sequential: at most one request is outstanding at a time, so a
 single transaction lock plus one pending future is sufficient. Notifications

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -1032,6 +1032,12 @@ class MGMTBluetoothCtl:
 
         Replaces the controller's LTK list (an empty list clears it) so the
         kernel can re-encrypt links to already-bonded peers without re-pairing.
+
+        The mgmt API has no add-one primitive, so this is the controller's whole
+        list: if another mgmt agent (e.g. bluetoothd) manages the same adapter,
+        loading our keys clears the bonds it loaded. The DBus-free path assumes
+        it owns the adapter, so this is a documented coexistence limitation, not
+        something the caller can avoid here.
         """
         records: list[bytes] = []
         for key in keys:

--- a/src/habluetooth/channels/bluez.py
+++ b/src/habluetooth/channels/bluez.py
@@ -1033,11 +1033,15 @@ class MGMTBluetoothCtl:
         Replaces the controller's LTK list (an empty list clears it) so the
         kernel can re-encrypt links to already-bonded peers without re-pairing.
 
-        The mgmt API has no add-one primitive, so this is the controller's whole
-        list: if another mgmt agent (e.g. bluetoothd) manages the same adapter,
-        loading our keys clears the bonds it loaded. The DBus-free path assumes
-        it owns the adapter, so this is a documented coexistence limitation, not
-        something the caller can avoid here.
+        The mgmt API has no add-one primitive, so this writes the controller's
+        whole list. That list belongs to the controller and its kernel, not to
+        this process or container, so it is shared with every other mgmt client
+        on the same kernel: if host bluetoothd is still managing this controller,
+        loading our keys clears the bonds it loaded, and there is no way to import
+        those back (DBus never exposes key material, and bluetoothd's on-disk
+        store is not reachable from another container). The mgmt connect path
+        therefore requires a controller bluetoothd is not managing; see the Home
+        Assistant integration guide on per-adapter controller ownership.
         """
         records: list[bytes] = []
         for key in keys:


### PR DESCRIPTION
Two documentation accuracy fixes from the review.

The att module docstring still said the L2CAP socket that feeds it would land in a later change; it landed, so it now points at L2CAPSocket.

load_long_term_keys now spells out that it replaces the controller's whole LTK list (the mgmt API has no add-one primitive), so if another mgmt agent such as bluetoothd manages the same adapter, loading our keys clears the bonds it loaded; the DBus-free path assumes it owns the adapter, so this is a documented coexistence limitation.