### PR TITLE
feat(manager): smooth per-source RSSI for advertisement owner selection

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -57,6 +57,16 @@ DURABLY_GONE_STALE_FACTOR: Final = 2.5
 # unaffected, and below typical close-proxy readings.
 STRONG_OWNER_STALE_RSSI: Final = -70
 
+# Smoothing factor (EWMA alpha) for the per-(address, source) advertisement
+# RSSI used to choose a device's owning scanner. Ownership switches on the
+# smoothed value rather than a single sample, so a stationary device whose
+# RSSI to a fixed proxy fades by multipath does not flap between proxies on
+# momentary spikes; a genuine move still crosses once the average shifts.
+# Smaller = steadier but slower to follow a real move. At 0.3 a single spike
+# moves the smoothed value ~30% of the gap, so even a 30 dB spike shifts it
+# under the 16 dB switch threshold.
+RSSI_SMOOTHING_FACTOR: Final = 0.3
+
 
 # We must recover before we hit the 180s mark
 # where the device is removed from the stack

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -11,6 +11,7 @@ cdef double TRACKER_BUFFERING_WOBBLE_SECONDS
 cdef double FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 cdef double _DURABLY_GONE_STALE_FACTOR
 cdef int _STRONG_OWNER_STALE_RSSI
+cdef double _RSSI_SMOOTHING_FACTOR
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice
@@ -49,6 +50,7 @@ cdef class BluetoothManager:
     cdef public set _bleak_callbacks
     cdef public dict _all_history
     cdef public dict _connectable_history
+    cdef public dict _smoothed_rssi
     cdef public dict _name_cache
     cdef public set _non_connectable_scanners
     cdef public set _connectable_scanners
@@ -86,18 +88,23 @@ cdef class BluetoothManager:
         durably_gone=double,
         comparable_or_stronger=bint,
         owner_strong=bint,
+        old_rssi=double,
     )
     cdef bint _prefer_previous_adv_from_different_source(
         self,
         BluetoothServiceInfoBleak old,
-        BluetoothServiceInfoBleak new
+        BluetoothServiceInfoBleak new,
+        dict smoothed,
+        double new_rssi
     )
 
     @cython.locals(scanner=BaseHaScanner)
     cdef bint _should_keep_previous_adv(
         self,
         BluetoothServiceInfoBleak old_info,
-        BluetoothServiceInfoBleak new_info
+        BluetoothServiceInfoBleak new_info,
+        dict smoothed,
+        double new_rssi
     )
 
     @cython.locals(
@@ -126,6 +133,11 @@ cdef class BluetoothManager:
         bleak_callback=BleakCallback,
         cached_name=str,
         auto_scheduler=AutoScanScheduler,
+        smoothed_bucket=dict,
+        prev_smoothed=object,
+        prev_double=double,
+        new_smoothed=double,
+        rssi=int,
     )
     cdef void _scanner_adv_received(self, BluetoothServiceInfoBleak service_info)
 

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -43,6 +43,7 @@ from .const import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     MIN_ACTIVE_SCAN_DURATION,
     MIN_ACTIVE_SCAN_INTERVAL,
+    RSSI_SMOOTHING_FACTOR,
     STRONG_OWNER_STALE_RSSI,
     UNAVAILABLE_TRACK_SECONDS,
 )
@@ -88,6 +89,7 @@ _int = int
 # the public names stay patchable Python constants.
 _DURABLY_GONE_STALE_FACTOR = DURABLY_GONE_STALE_FACTOR
 _STRONG_OWNER_STALE_RSSI = STRONG_OWNER_STALE_RSSI
+_RSSI_SMOOTHING_FACTOR = RSSI_SMOOTHING_FACTOR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,6 +156,7 @@ class BluetoothManager:
         "_scanner_mode_change_callbacks",
         "_scanner_registration_callbacks",
         "_side_channel_scanners",
+        "_smoothed_rssi",
         "_sources",
         "_subclass_discover_info",
         "_unavailable_callbacks",
@@ -185,6 +188,11 @@ class BluetoothManager:
         self._bleak_callbacks: set[BleakCallback] = set()
         self._all_history: dict[str, BluetoothServiceInfoBleak] = {}
         self._connectable_history: dict[str, BluetoothServiceInfoBleak] = {}
+        # address -> source -> EWMA-smoothed advertisement RSSI. Only
+        # populated for addresses seen from more than one source (the
+        # arbitration that uses it only runs cross-source); single-proxy
+        # devices never allocate a bucket. Evicted with the device.
+        self._smoothed_rssi: dict[str, dict[str, float]] = {}
         # Cross-scanner name cache: address -> best name seen across all
         # scanners. Passive scanners typically miss the device name because
         # it lives in SCAN_RSP (active-only); the cache lets a name learned
@@ -502,6 +510,7 @@ class BluetoothManager:
                     tracker.async_remove_fallback_interval(address)
                     tracker.async_remove_address(address)
                     self._name_cache.pop(address, None)
+                    self._smoothed_rssi.pop(address, None)
                     for disappear_callback in self._disappeared_callbacks:
                         try:
                             disappear_callback(address)
@@ -533,28 +542,47 @@ class BluetoothManager:
         self,
         old_info: BluetoothServiceInfoBleak,
         new_info: BluetoothServiceInfoBleak,
+        smoothed: dict[str, float] | None,
+        new_rssi: float,
     ) -> bool:
         """
         Return True when ``old_info`` should win over ``new_info``.
 
         Only relevant when ``old_info`` came from a different still-scanning
         source. The ``is not / !=`` ordering is a PyObject_RichCompare
-        short-circuit that dominates this hot path; keep it intact.
+        short-circuit that dominates this hot path; keep it intact. ``smoothed``
+        is the address's per-source smoothed-RSSI bucket, which is None until
+        the device is seen from more than one source; testing it first lets a
+        single-proxy device exit before the source compares and narrows the
+        bucket to non-None for the cross-source predicate. ``new_rssi`` is the
+        already-computed smoothed value for new_info's source, threaded through
+        to avoid re-looking it up.
         """
         return (
-            new_info.source is not old_info.source
+            smoothed is not None
+            and new_info.source is not old_info.source
             and new_info.source != old_info.source
             and (scanner := self._sources.get(old_info.source)) is not None
             and scanner.scanning
-            and self._prefer_previous_adv_from_different_source(old_info, new_info)
+            and self._prefer_previous_adv_from_different_source(
+                old_info, new_info, smoothed, new_rssi
+            )
         )
 
     def _prefer_previous_adv_from_different_source(
         self,
         old: BluetoothServiceInfoBleak,
         new: BluetoothServiceInfoBleak,
+        smoothed: dict[str, float],
+        new_rssi: float,
     ) -> bool:
         """Prefer previous advertisement from a different source if it is better."""
+        # Compare smoothed per-source RSSI so a momentary spike does not flip
+        # ownership for a stationary device. ``new_rssi`` is the caller's
+        # already-computed smoothed value for new.source; old's smoothed value
+        # is looked up here, falling back to its instantaneous RSSI when this
+        # source has no smoothed sample yet.
+        old_rssi = smoothed.get(old.source, old.rssi or NO_RSSI_VALUE)
         if stale_seconds := self._intervals.get(
             new.address, self._fallback_intervals.get(new.address, 0)
         ):
@@ -576,16 +604,14 @@ class BluetoothManager:
             durably_gone = stale_seconds * _DURABLY_GONE_STALE_FACTOR
             if durably_gone > FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS:
                 durably_gone = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
-            comparable_or_stronger = (new.rssi or NO_RSSI_VALUE) >= (
-                old.rssi or NO_RSSI_VALUE
-            ) - ADV_RSSI_SWITCH_THRESHOLD
+            comparable_or_stronger = new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
             # A strong/close owner that briefly goes quiet is almost
             # certainly still there (RF / scan-response reception jitter),
             # so a merely-comparable challenger must wait for durable
             # absence rather than steal on one missed interval and flap a
             # stationary device. A weaker owner keeps the normal
             # comparable-on-stale handoff.
-            owner_strong = (old.rssi or NO_RSSI_VALUE) >= _STRONG_OWNER_STALE_RSSI
+            owner_strong = old_rssi >= _STRONG_OWNER_STALE_RSSI
             if (comparable_or_stronger and not owner_strong) or elapsed > durably_gone:
                 if self._debug:
                     _LOGGER.debug(
@@ -603,11 +629,9 @@ class BluetoothManager:
                         durably_gone,
                     )
                 return False
-        if (new.rssi or NO_RSSI_VALUE) - ADV_RSSI_SWITCH_THRESHOLD > (
-            old.rssi or NO_RSSI_VALUE
-        ):
+        if new_rssi - ADV_RSSI_SWITCH_THRESHOLD > old_rssi:
             # If new advertisement is ADV_RSSI_SWITCH_THRESHOLD more,
-            # the new one is preferred.
+            # the new one is preferred (smoothed RSSI when available).
             if self._debug:
                 _LOGGER.debug(
                     "%s (%s): Switching from %s to %s (new rssi:%s - threshold:%s >"
@@ -616,9 +640,9 @@ class BluetoothManager:
                     new.address,
                     self._async_describe_source(old),
                     self._async_describe_source(new),
-                    new.rssi,
+                    new_rssi,
                     ADV_RSSI_SWITCH_THRESHOLD,
-                    old.rssi,
+                    old_rssi,
                 )
             return False
         return True
@@ -809,6 +833,57 @@ class BluetoothManager:
             )
         else:
             old_connectable_service_info = None
+
+        source = service_info.source
+        old_service_info = self._all_history.get(service_info.address)
+        # Maintain the smoothed RSSI used by cross-source owner arbitration
+        # so a stationary device does not flap between similar-distance
+        # proxies on momentary RSSI spikes. The bucket only exists once an
+        # address is seen from more than one source; a single-proxy device
+        # just takes the miss-lookup below and skips the rest (its
+        # new_smoothed is never read, since the predicate bails when the
+        # bucket is None). Runs before the same-payload short-circuit below
+        # because RSSI changes even when the payload does not. A missing
+        # RSSI (0) is folded to NO_RSSI_VALUE, matching arbitration.
+        new_smoothed = 0.0
+        # Fast path for proxy-free setups: when no address has ever been seen
+        # from more than one source the whole map is empty, so skip the keyed
+        # lookup and only pay an O(1) emptiness check.
+        smoothed_bucket = (
+            self._smoothed_rssi.get(service_info.address)
+            if self._smoothed_rssi
+            else None
+        )
+        if smoothed_bucket is not None:
+            rssi = service_info.rssi or NO_RSSI_VALUE
+            new_smoothed = rssi
+            prev_smoothed = smoothed_bucket.get(source)
+            if prev_smoothed is not None:
+                # prev_double is a cdef double, so the EWMA stays C-only.
+                prev_double = prev_smoothed
+                new_smoothed = (
+                    _RSSI_SMOOTHING_FACTOR * rssi
+                    + (1.0 - _RSSI_SMOOTHING_FACTOR) * prev_double
+                )
+            smoothed_bucket[source] = new_smoothed
+        elif (
+            old_service_info is not None
+            and old_service_info.source is not source
+            and old_service_info.source != source
+            # Only seed against a source that is still registered. An old
+            # source can linger in _all_history after it unregisters (the
+            # unavailable sweep clears it later), and seeding its stale RSSI
+            # would reintroduce the source the unregister cleanup just dropped,
+            # defeating the "re-registered scanner starts fresh" guarantee.
+            and old_service_info.source in self._sources
+        ):
+            new_smoothed = service_info.rssi or NO_RSSI_VALUE
+            smoothed_bucket = {
+                old_service_info.source: old_service_info.rssi or NO_RSSI_VALUE,
+                source: new_smoothed,
+            }
+            self._smoothed_rssi[service_info.address] = smoothed_bucket
+
         # This logic is complex due to the many combinations of scanners
         # that are supported.
         #
@@ -825,10 +900,8 @@ class BluetoothManager:
         #                       scanners with the best advertisement from each
         #                       connectable scanner
         #
-        if (
-            old_service_info := self._all_history.get(service_info.address)
-        ) is not None and self._should_keep_previous_adv(
-            old_service_info, service_info
+        if old_service_info is not None and self._should_keep_previous_adv(
+            old_service_info, service_info, smoothed_bucket, new_smoothed
         ):
             # If we are rejecting the new advertisement and the device is connectable
             # but not in the connectable history or the connectable source is the same
@@ -841,7 +914,10 @@ class BluetoothManager:
                     # Otherwise the old connectable came from a different source;
                     # re-run the predicate against the connectable history entry.
                     or self._should_keep_previous_adv(
-                        old_connectable_service_info, service_info
+                        old_connectable_service_info,
+                        service_info,
+                        smoothed_bucket,
+                        new_smoothed,
                     )
                 ):
                     return
@@ -961,6 +1037,7 @@ class BluetoothManager:
         self._all_history.pop(address, None)
         self._connectable_history.pop(address, None)
         self._name_cache.pop(address, None)
+        self._smoothed_rssi.pop(address, None)
         for scanner in self._sources.values():
             scanner._previous_service_info.pop(address, None)
 
@@ -1217,6 +1294,19 @@ class BluetoothManager:
         scanner._clear_connection_history()
         self._sources.pop(scanner.source, None)
         self._warned_passive_active_scan.discard(scanner.source)
+        # Drop this source's smoothed RSSI from every address bucket so a
+        # re-registered scanner starts fresh and a stale value can't win, and
+        # remove any bucket left empty so the map can return to truly empty
+        # (re-enabling the proxy-free fast path) instead of lingering until the
+        # unavailable sweep clears it.
+        source = scanner.source
+        emptied: list[str] = []
+        for address, bucket in self._smoothed_rssi.items():
+            bucket.pop(source, None)
+            if not bucket:
+                emptied.append(address)
+        for address in emptied:
+            del self._smoothed_rssi[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._allocations.pop(scanner.source, None)
         if connection_slots:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1327,6 +1327,214 @@ async def test_stale_strong_owner_yields_to_stronger_scanner(
     assert get_manager().async_ble_device_from_address(address, True) is stronger
 
 
+def _rssi_adv(rssi: int) -> AdvertisementData:
+    return generate_advertisement_data(
+        local_name="smoothing", service_uuids=[], rssi=rssi
+    )
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_ignores_single_spike(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A one-off RSSI spike from a challenger does not flip a stationary owner.
+
+    Instantaneously the spike clears the 16 dB threshold, but the smoothed
+    per-source RSSI does not, so ownership stays put.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:50"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # Challenger first seen weaker (-60), so it enters the smoothing bucket.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-60), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+    # Single spike to -30 (instantaneously 20 dB stronger than the owner):
+    # smoothed hci1 = 0.3*-30 + 0.7*-60 = -51, still below -50 + threshold,
+    # so it must NOT switch.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-30), t + 2, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_switches_on_sustained_stronger(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A sustained stronger challenger wins once its smoothed RSSI crosses."""
+    manager = get_manager()
+    address = "44:44:33:11:23:51"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-55), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+    # Sustained -20 (30 dB stronger): the smoothed value climbs past the
+    # threshold after a few samples and ownership flips.
+    for i in range(8):
+        inject_advertisement_with_time_and_source(
+            challenger, _rssi_adv(-20), t + 2 + i, HCI1_SOURCE_ADDRESS
+        )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_first_sighting_switches_immediately(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A first-seen challenger with a real margin switches at once (instantaneous)."""
+    manager = get_manager()
+    address = "44:44:33:11:23:52"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # No prior smoothed history for the challenger: it seeds at its
+    # instantaneous -20, which is a genuine 30 dB margin, so it wins now.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-20), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_bucket_evicted_with_history(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """The smoothed-RSSI bucket is allocated cross-source and cleared with history."""
+    manager = get_manager()
+    address = "44:44:33:11:23:53"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # Single source so far: no bucket allocated.
+    assert address not in manager._smoothed_rssi
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-60), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    # Cross-source seen: bucket now holds both sources.
+    assert set(manager._smoothed_rssi[address]) == {
+        HCI0_SOURCE_ADDRESS,
+        HCI1_SOURCE_ADDRESS,
+    }
+
+    manager.async_clear_advertisement_history(address)
+    assert address not in manager._smoothed_rssi
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_source_evicted_on_unregister(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """Unregistering a scanner drops its source from every smoothed bucket."""
+    manager = get_manager()
+    address = "44:44:33:11:23:54"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-60), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert HCI1_SOURCE_ADDRESS in manager._smoothed_rssi[address]
+
+    def _unregister(source: str) -> None:
+        for scanner in list(manager._sources.values()):
+            if scanner.source == source:
+                manager._async_unregister_scanner_internal(
+                    manager._connectable_scanners, scanner, None
+                )
+
+    _unregister(HCI1_SOURCE_ADDRESS)
+    # One source remains, so the bucket survives without the dropped source.
+    assert HCI1_SOURCE_ADDRESS not in manager._smoothed_rssi[address]
+    assert HCI0_SOURCE_ADDRESS in manager._smoothed_rssi[address]
+
+    # Dropping the last source empties the bucket; the address is removed so
+    # the map can return to truly empty and re-enable the proxy-free fast path.
+    _unregister(HCI0_SOURCE_ADDRESS)
+    assert address not in manager._smoothed_rssi
+    assert not manager._smoothed_rssi
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_skips_unregistered_old_source(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A new bucket is not seeded against a source that has unregistered.
+
+    An old source lingers in _all_history after it unregisters (the
+    unavailable sweep clears it later); seeding its stale RSSI would
+    reintroduce the source the unregister cleanup just dropped.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:55"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    # Seen from hci0 only, so no bucket exists yet.
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    assert address not in manager._smoothed_rssi
+
+    # hci0 unregisters, but its advertisement lingers in _all_history.
+    for scanner in list(manager._sources.values()):
+        if scanner.source == HCI0_SOURCE_ADDRESS:
+            manager._async_unregister_scanner_internal(
+                manager._connectable_scanners, scanner, None
+            )
+    assert manager._all_history[address].source == HCI0_SOURCE_ADDRESS
+
+    # hci1 now advertises; the dead hci0 source must not be seeded, so no
+    # bucket is created for what is now effectively a single-source device.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-60), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert address not in manager._smoothed_rssi
+
+
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
 async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(


### PR DESCRIPTION
Follow-up to #570 and #580. On an all-stationary setup, devices behind several similar-distance proxies still flapped owner ~40 times in a window; nothing was moving, so it was pure RSSI noise. Multipath fades a fixed device's RSSI by 10 to 15 dB, so two proxies cross the 16 dB switch threshold on a single sample. This matters because, with the auto-scheduler, only the current owner actively scans a scan-response-only sensor, so each spurious flip hands the device to a proxy that has no fresh scan response yet.

This tracks an EWMA-smoothed RSSI per address and source and switches ownership on the smoothed value instead of the latest sample. A momentary spike barely moves the average so ownership stays put; a genuine move still crosses once the average shifts. The bucket is allocated only once an address is seen from more than one source, and it is evicted with the device and per source on unregister. The same smoothed value feeds the stale-path strong-owner and comparable checks for consistency.

On cost: a proxy-free host keeps the smoothed map empty, so every advert pays only an O(1) emptiness check and nothing else. Once any address on the host is seen from 2+ sources the map is non-empty, so single-proxy devices still pay that check plus a missed lookup and the source comparisons; they just never allocate a bucket.

Replaying the actual debug log, smoothing suppressed about 81% of the RSSI-path owner switches (855 down to 159); the busiest stationary devices dropped hardest, one going from 178 switches to 28, while genuinely moving devices still handed off. The single-source and proxy-free benchmarks stay flat. The two cross-source benchmarks regress about 20% and 12%, roughly 450 ns per advert: that path now maintains the EWMA and compares smoothed values on every advert from a device seen by 2+ proxies, which is the steady-state multi-proxy path. That cost is inherent to the feature and is acknowledged on CodSpeed; it is the deliberate trade for killing the per-window flapping.

Relates to home-assistant/core#174169.
