### PR TITLE
feat(manager): add asymmetric rssi switch hysteresis to stop reclaim flapping

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -140,6 +140,20 @@ ADV_RSSI_SWITCH_THRESHOLD: Final = 16
 # selection that uses RSSI_SWITCH_THRESHOLD from
 # bleak_retry_connector
 
+# Extra margin, on top of ADV_RSSI_SWITCH_THRESHOLD, that a challenger must beat
+# the current owner by to RECLAIM ownership it was just demoted from, on the
+# active RSSI path (both scanners reporting). This is asymmetric hysteresis:
+# smoothing removes single-sample noise, but a heavily-multipathed stationary
+# device whose smoothed RSSI to two proxies genuinely straddles the 16 dB line
+# still oscillates, because each leg of the A->B->A ping-pong only needs 16 dB.
+# Charging 16 + deadband only to the source that was just demoted widens the
+# band its smoothed signal must swing back through to reclaim, killing that
+# residual ping-pong, while a genuine one-way move (never the demoted source)
+# still hands off at the plain 16 dB threshold and is not slowed. The stale-path
+# "comparable" handoff deliberately does not use this; a silent owner should
+# still be easy to replace.
+ADV_RSSI_SWITCH_DEADBAND: Final = 6
+
 
 # Connection parameter constants (units of 1.25ms for intervals)
 # Fast connection parameters for initial connection and service discovery

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -12,6 +12,7 @@ cdef double FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 cdef double _DURABLY_GONE_STALE_FACTOR
 cdef int _STRONG_OWNER_STALE_RSSI
 cdef double _RSSI_SMOOTHING_FACTOR
+cdef int _ADV_RSSI_SWITCH_DEADBAND
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice
@@ -51,6 +52,7 @@ cdef class BluetoothManager:
     cdef public dict _all_history
     cdef public dict _connectable_history
     cdef public dict _smoothed_rssi
+    cdef public dict _demoted_source
     cdef public dict _name_cache
     cdef public set _non_connectable_scanners
     cdef public set _connectable_scanners
@@ -89,13 +91,15 @@ cdef class BluetoothManager:
         comparable_or_stronger=bint,
         owner_strong=bint,
         old_rssi=double,
+        switch_margin=int,
     )
     cdef bint _prefer_previous_adv_from_different_source(
         self,
         BluetoothServiceInfoBleak old,
         BluetoothServiceInfoBleak new,
         dict smoothed,
-        double new_rssi
+        double new_rssi,
+        bint record_demotion
     )
 
     @cython.locals(scanner=BaseHaScanner)
@@ -104,7 +108,8 @@ cdef class BluetoothManager:
         BluetoothServiceInfoBleak old_info,
         BluetoothServiceInfoBleak new_info,
         dict smoothed,
-        double new_rssi
+        double new_rssi,
+        bint record_demotion
     )
 
     @cython.locals(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -33,6 +33,7 @@ from .advertisement_tracker import (
 from .auto_scheduler import ActiveScanRequest, AutoScanScheduler
 from .channels.bluez import CONNECTION_ERRORS, MGMTBluetoothCtl
 from .const import (
+    ADV_RSSI_SWITCH_DEADBAND,
     ADV_RSSI_SWITCH_THRESHOLD,
     CALLBACK_TYPE,
     DEFAULT_ACTIVE_SCAN_DURATION,
@@ -90,6 +91,7 @@ _int = int
 _DURABLY_GONE_STALE_FACTOR = DURABLY_GONE_STALE_FACTOR
 _STRONG_OWNER_STALE_RSSI = STRONG_OWNER_STALE_RSSI
 _RSSI_SMOOTHING_FACTOR = RSSI_SMOOTHING_FACTOR
+_ADV_RSSI_SWITCH_DEADBAND = ADV_RSSI_SWITCH_DEADBAND
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,6 +147,7 @@ class BluetoothManager:
         "_connectable_unavailable_callbacks",
         "_connection_history",
         "_debug",
+        "_demoted_source",
         "_disappeared_callbacks",
         "_fallback_intervals",
         "_intervals",
@@ -193,6 +196,18 @@ class BluetoothManager:
         # arbitration that uses it only runs cross-source); single-proxy
         # devices never allocate a bucket. Evicted with the device.
         self._smoothed_rssi: dict[str, dict[str, float]] = {}
+        # address -> the source that most recently lost ownership (the previous
+        # all-history owner before ownership moved to a different source). Used
+        # for asymmetric switch hysteresis: a challenger that is reclaiming the
+        # ownership it was just demoted from must clear an extra deadband, so a
+        # boundary-straddling stationary device stops ping-ponging between two
+        # proxies; a genuine one-way move is never the demoted source and pays
+        # nothing. This is a single slot holding only the most-recent loser, so
+        # the hysteresis is pairwise: it damps the two-proxy ping-pong it
+        # targets, but in N-way contention each switch overwrites the record, so
+        # an older owner reclaiming pays only the plain threshold. Evicted with
+        # the device and per source on unregister.
+        self._demoted_source: dict[str, str] = {}
         # Cross-scanner name cache: address -> best name seen across all
         # scanners. Passive scanners typically miss the device name because
         # it lives in SCAN_RSP (active-only); the cache lets a name learned
@@ -511,6 +526,7 @@ class BluetoothManager:
                     tracker.async_remove_address(address)
                     self._name_cache.pop(address, None)
                     self._smoothed_rssi.pop(address, None)
+                    self._demoted_source.pop(address, None)
                     for disappear_callback in self._disappeared_callbacks:
                         try:
                             disappear_callback(address)
@@ -544,6 +560,7 @@ class BluetoothManager:
         new_info: BluetoothServiceInfoBleak,
         smoothed: dict[str, float] | None,
         new_rssi: float,
+        record_demotion: bool,
     ) -> bool:
         """
         Return True when ``old_info`` should win over ``new_info``.
@@ -556,7 +573,9 @@ class BluetoothManager:
         single-proxy device exit before the source compares and narrows the
         bucket to non-None for the cross-source predicate. ``new_rssi`` is the
         already-computed smoothed value for new_info's source, threaded through
-        to avoid re-looking it up.
+        to avoid re-looking it up. ``record_demotion`` is forwarded to the
+        predicate so an RSSI-path switch can remember the demoted owner; it is
+        True only for the all-history decision, not the connectable re-check.
         """
         return (
             smoothed is not None
@@ -565,7 +584,7 @@ class BluetoothManager:
             and (scanner := self._sources.get(old_info.source)) is not None
             and scanner.scanning
             and self._prefer_previous_adv_from_different_source(
-                old_info, new_info, smoothed, new_rssi
+                old_info, new_info, smoothed, new_rssi, record_demotion
             )
         )
 
@@ -575,6 +594,7 @@ class BluetoothManager:
         new: BluetoothServiceInfoBleak,
         smoothed: dict[str, float],
         new_rssi: float,
+        record_demotion: bool,
     ) -> bool:
         """Prefer previous advertisement from a different source if it is better."""
         # Compare smoothed per-source RSSI so a momentary spike does not flip
@@ -629,9 +649,26 @@ class BluetoothManager:
                         durably_gone,
                     )
                 return False
-        if new_rssi - ADV_RSSI_SWITCH_THRESHOLD > old_rssi:
-            # If new advertisement is ADV_RSSI_SWITCH_THRESHOLD more,
-            # the new one is preferred (smoothed RSSI when available).
+        # Asymmetric hysteresis: a challenger normally only needs THRESHOLD, but
+        # one that is reclaiming the ownership it was just demoted from must also
+        # clear DEADBAND. This stops a heavily-multipathed stationary device
+        # whose smoothed RSSI straddles the threshold from ping-ponging between
+        # two proxies, while a genuine one-way move (never the demoted source)
+        # still hands off at THRESHOLD (see ADV_RSSI_SWITCH_DEADBAND).
+        switch_margin = ADV_RSSI_SWITCH_THRESHOLD
+        if self._demoted_source.get(new.address) == new.source:
+            switch_margin += _ADV_RSSI_SWITCH_DEADBAND
+        if new_rssi - switch_margin > old_rssi:
+            # The new source wins ownership on the active RSSI path. Remember the
+            # demoted owner so a quick reclaim by it faces the deadband above.
+            # Recorded only here (not the stale handoff, so a strong owner
+            # recovering from transient silence still reclaims at THRESHOLD) and
+            # only for the all-history decision (record_demotion); old.source is
+            # guaranteed registered, since _should_keep_previous_adv checked it.
+            if record_demotion:
+                self._demoted_source[new.address] = old.source
+            # If new advertisement is switch_margin more, prefer the new one
+            # (smoothed RSSI when available).
             if self._debug:
                 _LOGGER.debug(
                     "%s (%s): Switching from %s to %s (new rssi:%s - threshold:%s >"
@@ -641,7 +678,7 @@ class BluetoothManager:
                     self._async_describe_source(old),
                     self._async_describe_source(new),
                     new_rssi,
-                    ADV_RSSI_SWITCH_THRESHOLD,
+                    switch_margin,
                     old_rssi,
                 )
             return False
@@ -901,7 +938,7 @@ class BluetoothManager:
         #                       connectable scanner
         #
         if old_service_info is not None and self._should_keep_previous_adv(
-            old_service_info, service_info, smoothed_bucket, new_smoothed
+            old_service_info, service_info, smoothed_bucket, new_smoothed, True
         ):
             # If we are rejecting the new advertisement and the device is connectable
             # but not in the connectable history or the connectable source is the same
@@ -918,6 +955,7 @@ class BluetoothManager:
                         service_info,
                         smoothed_bucket,
                         new_smoothed,
+                        False,
                     )
                 ):
                     return
@@ -1038,6 +1076,7 @@ class BluetoothManager:
         self._connectable_history.pop(address, None)
         self._name_cache.pop(address, None)
         self._smoothed_rssi.pop(address, None)
+        self._demoted_source.pop(address, None)
         for scanner in self._sources.values():
             scanner._previous_service_info.pop(address, None)
 
@@ -1307,6 +1346,16 @@ class BluetoothManager:
                 emptied.append(address)
         for address in emptied:
             del self._smoothed_rssi[address]
+        # Drop any reclaim-hysteresis record pointing at this source so a
+        # re-registered scanner is not penalized for an ownership it lost before
+        # it went away.
+        demoted_here = [
+            address
+            for address, demoted in self._demoted_source.items()
+            if demoted == source
+        ]
+        for address in demoted_here:
+            del self._demoted_source[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._allocations.pop(scanner.source, None)
         if connection_slots:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1537,6 +1537,186 @@ async def test_rssi_smoothing_skips_unregistered_old_source(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_rssi_deadband_does_not_slow_one_way_move(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A fresh challenger still takes ownership at the plain threshold.
+
+    The deadband only applies to a source reclaiming ownership it was just
+    demoted from; a challenger that has never owned the address pays only
+    ADV_RSSI_SWITCH_THRESHOLD (16 dB), so a 17 dB one-way move is not slowed.
+    The demoted owner is recorded for the asymmetric reclaim check.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:56"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # 17 dB stronger and never previously the owner: switches on the plain
+    # 16 dB threshold, no deadband.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-33), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+    # hci0 was demoted, so a quick reclaim by it now faces the deadband.
+    assert manager._demoted_source[address] == HCI0_SOURCE_ADDRESS
+
+    # Per-address eviction clears the reclaim record.
+    manager.async_clear_advertisement_history(address)
+    assert address not in manager._demoted_source
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_deadband_damps_reclaim(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A just-demoted source must clear THRESHOLD + DEADBAND to reclaim ownership.
+
+    hci0 owns, hci1 takes over (one-way, plain threshold), then hci0 tries to
+    reclaim: a 20 dB margin sits inside the 16 + 6 deadband and must not switch
+    back, while a sustained 24 dB margin clears it and reclaims. Without the
+    asymmetric deadband the 20 dB reclaim would flip ownership immediately.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:57"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # hci1 takes over (fresh challenger, plain 16 dB threshold).
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-30), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+    assert manager._demoted_source[address] == HCI0_SOURCE_ADDRESS
+
+    # hci0 reclaims at a sustained 20 dB margin (smoothed converges to -10 vs
+    # hci1's -30): inside the 16 + 6 deadband, so ownership stays with hci1.
+    for i in range(15):
+        inject_advertisement_with_time_and_source(
+            owner, _rssi_adv(-10), t + 2 + i, HCI0_SOURCE_ADDRESS
+        )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+
+    # A sustained 24 dB margin (smoothed converges to -6) clears the deadband
+    # and hci0 reclaims.
+    for i in range(15):
+        inject_advertisement_with_time_and_source(
+            owner, _rssi_adv(-6), t + 20 + i, HCI0_SOURCE_ADDRESS
+        )
+    assert manager.async_ble_device_from_address(address, True) is owner
+    # The reclaim demotes hci1 in turn.
+    assert manager._demoted_source[address] == HCI1_SOURCE_ADDRESS
+
+    # Per-source eviction on unregister drops the reclaim record for that source.
+    for scanner in list(manager._sources.values()):
+        if scanner.source == HCI1_SOURCE_ADDRESS:
+            manager._async_unregister_scanner_internal(
+                manager._connectable_scanners, scanner, None
+            )
+    assert address not in manager._demoted_source
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_deadband_not_charged_after_stale_handoff(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A stale-path handoff records no demotion, so the owner reclaims at THRESHOLD.
+
+    The deadband must only damp active RSSI ping-pong; a weak owner that goes
+    silent and is taken over on the stale path must not then be charged the
+    deadband to recover, which would leave the rightful owner stuck on a weaker
+    proxy (the regression #570/#580 guard against). Only an active RSSI switch
+    records a demotion.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:58"
+    start = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    owner_adv = generate_advertisement_data(
+        local_name="owner_hci0", service_uuids=[], rssi=-90
+    )
+    inject_advertisement_with_time_and_source(
+        owner, owner_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    manager.async_set_fallback_availability_interval(address, 10)
+
+    # Weak owner goes silent; a comparable (weaker) scanner takes over on the
+    # stale path, not the active RSSI path.
+    comparable = generate_ble_device(address, "comparable_hci1")
+    comparable_adv = generate_advertisement_data(
+        local_name="comparable_hci1", service_uuids=[], rssi=-95
+    )
+    inject_advertisement_with_time_and_source(
+        comparable,
+        comparable_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert manager.async_ble_device_from_address(address, True) is comparable
+    # The stale handoff is not an RSSI-path switch, so no reclaim penalty is set.
+    assert address not in manager._demoted_source
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_deadband_connectable_recheck_records_no_demotion(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A connectable re-check switch does not record an all-history demotion.
+
+    When the best (all-history) advertisement stays put but the connectable
+    history switches sources on RSSI, that switch must not write to
+    _demoted_source; it is not an all-history ownership change, so a future
+    challenger of the all-history owner is not wrongly treated as a reclaim.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:59"
+    now = 50.0
+    # hci1 owns the best (all-history) path with a strong non-connectable adv.
+    best = generate_ble_device(address, "best_hci1")
+    inject_advertisement_with_time_and_source_connectable(
+        best, _rssi_adv(-30), now, HCI1_SOURCE_ADDRESS, False
+    )
+    # hci0 is the only connectable path, but weak.
+    weak_conn = generate_ble_device(address, "weak_conn_hci0")
+    inject_advertisement_with_time_and_source_connectable(
+        weak_conn, _rssi_adv(-90), now + 1, HCI0_SOURCE_ADDRESS, True
+    )
+    assert manager.async_ble_device_from_address(address, True) is weak_conn
+
+    # A third source sends a much stronger connectable adv: it loses the
+    # all-history compare to hci1 but wins the connectable re-check over hci0.
+    strong_conn = generate_ble_device(address, "strong_conn_hci2")
+    inject_advertisement_with_time_and_source_connectable(
+        strong_conn, _rssi_adv(-50), now + 2, "hci2", True
+    )
+    # all-history owner unchanged; connectable history switched to the new path.
+    assert manager.async_ble_device_from_address(address, False) is best
+    assert manager.async_ble_device_from_address(address, True) is strong_conn
+    # The connectable-only switch records no all-history demotion.
+    assert address not in manager._demoted_source
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
     register_hci0_scanner: None,
     register_hci1_scanner: None,


### PR DESCRIPTION
Follow up to #584, now merged. Once smoothing landed, the deployed build took the worst flapper from 178 owner switches to 10, but two heavily multipathed stationary devices still ping pong between two proxies; their smoothed RSSI genuinely straddles the 16 dB switch threshold, and each leg of the A to B to A switch only needs 16 dB.

This adds asymmetric hysteresis. A challenger pays an extra deadband (6 dB) only when it is reclaiming the ownership it was just demoted from, tracked per address in `_demoted_source`. A boundary device must swing its smoothed signal through a wider band to reclaim, so the oscillation stops; a genuine one way move is never the demoted source and still hands off at the plain 16 dB threshold, so real moves are not slowed.

The demotion is recorded inside the active RSSI branch of the predicate, so a stale path handoff records nothing; a weak owner that goes silent and is taken over on the stale path still reclaims at the plain threshold, not the deadband, so it is never left stuck on a weaker proxy. Recording there also means only a currently registered source is ever stored, since the predicate already checked it is in `_sources`. The state is evicted with the device and per source on unregister, mirroring `_smoothed_rssi`.

On the deployed log the two offenders' reclaim gaps cluster at 16 to 20 dB then jump to 22 dB and up, so this suppresses the boundary ping pong while leaving the genuine large smoothed crossings. Relates to #568 and home-assistant/core#174169.
