### PR TITLE
fix(manager): don't fold missing rssi into the smoothed average

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -880,8 +880,14 @@ class BluetoothManager:
         # just takes the miss-lookup below and skips the rest (its
         # new_smoothed is never read, since the predicate bails when the
         # bucket is None). Runs before the same-payload short-circuit below
-        # because RSSI changes even when the payload does not. A missing
-        # RSSI (0) is folded to NO_RSSI_VALUE, matching arbitration.
+        # because RSSI changes even when the payload does not.
+        #
+        # A missing RSSI (proxies occasionally drop it) must NOT be folded in:
+        # NO_RSSI_VALUE (-127) would poison the average and, because the EWMA
+        # remembers it, drag the smoothed value down for several adverts
+        # afterwards, manufacturing phantom weak readings that flap ownership.
+        # So a no-RSSI advert keeps the last good smoothed value and writes
+        # nothing; it never seeds or updates the average.
         new_smoothed = 0.0
         # Fast path for proxy-free setups: when no address has ever been seen
         # from more than one source the whole map is empty, so skip the keyed
@@ -893,16 +899,26 @@ class BluetoothManager:
         )
         if smoothed_bucket is not None:
             rssi = service_info.rssi or NO_RSSI_VALUE
-            new_smoothed = rssi
             prev_smoothed = smoothed_bucket.get(source)
-            if prev_smoothed is not None:
+            if not service_info.rssi:
+                # No RSSI: keep the last good smoothed value (or NO_RSSI_VALUE
+                # with no history, which simply loses arbitration) and do not
+                # write, so the dropped reading can never poison the average.
+                if prev_smoothed is not None:
+                    new_smoothed = prev_smoothed
+                else:
+                    new_smoothed = NO_RSSI_VALUE
+            elif prev_smoothed is not None:
                 # prev_double is a cdef double, so the EWMA stays C-only.
                 prev_double = prev_smoothed
                 new_smoothed = (
                     _RSSI_SMOOTHING_FACTOR * rssi
                     + (1.0 - _RSSI_SMOOTHING_FACTOR) * prev_double
                 )
-            smoothed_bucket[source] = new_smoothed
+                smoothed_bucket[source] = new_smoothed
+            else:
+                new_smoothed = rssi
+                smoothed_bucket[source] = new_smoothed
         elif (
             old_service_info is not None
             and old_service_info.source is not source
@@ -914,11 +930,20 @@ class BluetoothManager:
             # defeating the "re-registered scanner starts fresh" guarantee.
             and old_service_info.source in self._sources
         ):
-            new_smoothed = service_info.rssi or NO_RSSI_VALUE
+            # First cross-source sighting: seed the bucket from the existing
+            # owner. Seed the new source only from a real reading; if it has no
+            # RSSI, leave it unseeded so it loses arbitration via NO_RSSI_VALUE
+            # (keeping the current owner) rather than priming the average with
+            # -127 or stealing ownership without a signal. Its next real advert
+            # seeds it cleanly.
             smoothed_bucket = {
-                old_service_info.source: old_service_info.rssi or NO_RSSI_VALUE,
-                source: new_smoothed,
+                old_service_info.source: old_service_info.rssi or NO_RSSI_VALUE
             }
+            if service_info.rssi:
+                new_smoothed = service_info.rssi
+                smoothed_bucket[source] = new_smoothed
+            else:
+                new_smoothed = NO_RSSI_VALUE
             self._smoothed_rssi[service_info.address] = smoothed_bucket
 
         # This logic is complex due to the many combinations of scanners

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1537,6 +1537,94 @@ async def test_rssi_smoothing_skips_unregistered_old_source(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_rssi_smoothing_ignores_missing_rssi(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A dropped RSSI (0) is not folded into the smoothed average.
+
+    Proxies occasionally report no RSSI. Folding NO_RSSI_VALUE (-127) into the
+    EWMA would poison the value and, because the average remembers it, drag it
+    down for several adverts, manufacturing phantom weak readings. A no-RSSI
+    advert must instead keep the last good smoothed value and write nothing.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:5A"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # First cross-source sighting seeds the bucket at the real reading.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-45), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager._smoothed_rssi[address][HCI1_SOURCE_ADDRESS] == -45
+
+    # A burst of no-RSSI adverts must leave the smoothed value pinned, not walk
+    # it toward -127.
+    for i in range(3):
+        inject_advertisement_with_time_and_source(
+            challenger, _rssi_adv(0), t + 2 + i, HCI1_SOURCE_ADDRESS
+        )
+    assert manager._smoothed_rssi[address][HCI1_SOURCE_ADDRESS] == -45
+    # The owner is unaffected by the dropped readings.
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+    # A new source whose very first advert has no RSSI is not seeded into the
+    # existing bucket (it loses arbitration via NO_RSSI_VALUE instead).
+    third = generate_ble_device(address, "third_hci2")
+    inject_advertisement_with_time_and_source(third, _rssi_adv(0), t + 6, "hci2")
+    assert "hci2" not in manager._smoothed_rssi[address]
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_smoothing_no_bucket_seeded_from_missing_rssi(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A no-RSSI first cross-source sighting does not seed or steal ownership.
+
+    The bucket is seeded from the existing owner only; the no-RSSI source is
+    left unseeded so it loses arbitration (NO_RSSI_VALUE) and the owner is kept,
+    rather than priming the average with -127 or taking ownership with no
+    signal. The source's next real advert seeds it cleanly.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:5B"
+    t = 50.0
+    owner = generate_ble_device(address, "owner_hci0")
+    challenger = generate_ble_device(address, "challenger_hci1")
+
+    inject_advertisement_with_time_and_source(
+        owner, _rssi_adv(-50), t, HCI0_SOURCE_ADDRESS
+    )
+    # First cross-source advert has no RSSI: the challenger is not seeded and
+    # does not take ownership.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(0), t + 1, HCI1_SOURCE_ADDRESS
+    )
+    assert manager._smoothed_rssi[address] == {HCI0_SOURCE_ADDRESS: -50}
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+    # A later real reading seeds the challenger cleanly.
+    inject_advertisement_with_time_and_source(
+        challenger, _rssi_adv(-45), t + 2, HCI1_SOURCE_ADDRESS
+    )
+    assert manager._smoothed_rssi[address] == {
+        HCI0_SOURCE_ADDRESS: -50,
+        HCI1_SOURCE_ADDRESS: -45,
+    }
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_rssi_deadband_does_not_slow_one_way_move(
     register_hci0_scanner: None,
     register_hci1_scanner: None,


### PR DESCRIPTION
On a bench with several co-located proxies, two stationary devices kept flapping owner; their smoothed RSSI to a single proxy was swinging 30 to 46 dB, which is impossible from geometry when the proxies sit right next to each other. The cause is on our side. When a proxy drops the RSSI on an advert, `service_info.rssi` is 0, and `rssi or NO_RSSI_VALUE` turns it into -127, which we then fold into the per-source EWMA. Because the average remembers it, one dropped reading drags the smoothed value down for several adverts (one -127 fold pulls a -17 reading to about -50, a second to about -73), manufacturing phantom weak readings that flap ownership. Smoothing made this worse than the old instantaneous path, which forgot the bad sample on the next packet.

Now a no-RSSI advert keeps the last good smoothed value and writes nothing, so it can never poison the average. A no-RSSI first cross-source sighting seeds only the existing owner and loses arbitration via NO_RSSI_VALUE rather than stealing ownership or priming the bucket with -127; the source's next real advert seeds it cleanly.

Found while validating the smoothing and hysteresis work from #584 and #585 against real bench logs. Relates to #568 and home-assistant/core#174169.
