### PR TITLE
fix(manager): damp owner reclaim across all recent owners, not just the last

### DIFF
--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -13,6 +13,7 @@ cdef double _DURABLY_GONE_STALE_FACTOR
 cdef int _STRONG_OWNER_STALE_RSSI
 cdef double _RSSI_SMOOTHING_FACTOR
 cdef int _ADV_RSSI_SWITCH_DEADBAND
+cdef frozenset _EMPTY_DEMOTED
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
 cdef object BLEDevice
@@ -52,7 +53,7 @@ cdef class BluetoothManager:
     cdef public dict _all_history
     cdef public dict _connectable_history
     cdef public dict _smoothed_rssi
-    cdef public dict _demoted_source
+    cdef public dict _demoted_sources
     cdef public dict _name_cache
     cdef public set _non_connectable_scanners
     cdef public set _connectable_scanners
@@ -100,6 +101,11 @@ cdef class BluetoothManager:
         dict smoothed,
         double new_rssi,
         bint record_demotion
+    )
+
+    @cython.locals(demoted=set)
+    cdef void _record_demotion(
+        self, str address, str new_source, str old_source
     )
 
     @cython.locals(scanner=BaseHaScanner)

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -93,6 +93,10 @@ _STRONG_OWNER_STALE_RSSI = STRONG_OWNER_STALE_RSSI
 _RSSI_SMOOTHING_FACTOR = RSSI_SMOOTHING_FACTOR
 _ADV_RSSI_SWITCH_DEADBAND = ADV_RSSI_SWITCH_DEADBAND
 
+# Shared empty set used as the default for the reclaim-hysteresis lookup, so the
+# hot path skips a None check and never allocates a throwaway set.
+_EMPTY_DEMOTED: frozenset[str] = frozenset()
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -147,7 +151,7 @@ class BluetoothManager:
         "_connectable_unavailable_callbacks",
         "_connection_history",
         "_debug",
-        "_demoted_source",
+        "_demoted_sources",
         "_disappeared_callbacks",
         "_fallback_intervals",
         "_intervals",
@@ -196,18 +200,19 @@ class BluetoothManager:
         # arbitration that uses it only runs cross-source); single-proxy
         # devices never allocate a bucket. Evicted with the device.
         self._smoothed_rssi: dict[str, dict[str, float]] = {}
-        # address -> the source that most recently lost ownership (the previous
-        # all-history owner before ownership moved to a different source). Used
-        # for asymmetric switch hysteresis: a challenger that is reclaiming the
-        # ownership it was just demoted from must clear an extra deadband, so a
-        # boundary-straddling stationary device stops ping-ponging between two
-        # proxies; a genuine one-way move is never the demoted source and pays
-        # nothing. This is a single slot holding only the most-recent loser, so
-        # the hysteresis is pairwise: it damps the two-proxy ping-pong it
-        # targets, but in N-way contention each switch overwrites the record, so
-        # an older owner reclaiming pays only the plain threshold. Evicted with
-        # the device and per source on unregister.
-        self._demoted_source: dict[str, str] = {}
+        # address -> the set of sources currently in the demoted state (each one
+        # lost ownership and is not the current owner). Used for asymmetric
+        # switch hysteresis: a challenger reclaiming ownership it recently lost
+        # must clear an extra deadband, so a stationary device stops
+        # ping-ponging between similar-signal proxies; a genuine one-way move to
+        # a source that has never recently owned the device is not in the set
+        # and pays nothing. Holding the whole set (not just the most-recent
+        # loser) damps N-way contention too: in an A->B->C->A bounce A is still
+        # in the set when it reclaims from C, so it is charged the deadband. The
+        # current owner is never in its own set (removed on each win), so the
+        # set is self-bounded by the proxy count. Evicted with the device and
+        # per source on unregister.
+        self._demoted_sources: dict[str, set[str]] = {}
         # Cross-scanner name cache: address -> best name seen across all
         # scanners. Passive scanners typically miss the device name because
         # it lives in SCAN_RSP (active-only); the cache lets a name learned
@@ -526,7 +531,7 @@ class BluetoothManager:
                     tracker.async_remove_address(address)
                     self._name_cache.pop(address, None)
                     self._smoothed_rssi.pop(address, None)
-                    self._demoted_source.pop(address, None)
+                    self._demoted_sources.pop(address, None)
                     for disappear_callback in self._disappeared_callbacks:
                         try:
                             disappear_callback(address)
@@ -621,9 +626,10 @@ class BluetoothManager:
             # have (adverts carry no timestamp), so the durably-gone wait is
             # what lets a device that truly moved into weak-only coverage
             # still hand off.
-            durably_gone = stale_seconds * _DURABLY_GONE_STALE_FACTOR
-            if durably_gone > FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS:
-                durably_gone = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
+            durably_gone = min(
+                stale_seconds * _DURABLY_GONE_STALE_FACTOR,
+                FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+            )
             comparable_or_stronger = new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
             # A strong/close owner that briefly goes quiet is almost
             # certainly still there (RF / scan-response reception jitter),
@@ -649,24 +655,28 @@ class BluetoothManager:
                         durably_gone,
                     )
                 return False
-        # Asymmetric hysteresis: a challenger normally only needs THRESHOLD, but
-        # one that is reclaiming the ownership it was just demoted from must also
-        # clear DEADBAND. This stops a heavily-multipathed stationary device
-        # whose smoothed RSSI straddles the threshold from ping-ponging between
-        # two proxies, while a genuine one-way move (never the demoted source)
-        # still hands off at THRESHOLD (see ADV_RSSI_SWITCH_DEADBAND).
+        # Only a challenger that clears the plain THRESHOLD can win, so do the
+        # cheap compare first and skip the reclaim-state lookup on every
+        # arbitration that keeps the owner (the common case).
+        if new_rssi - ADV_RSSI_SWITCH_THRESHOLD <= old_rssi:
+            return True
+        # Asymmetric hysteresis: a challenger reclaiming ownership it recently
+        # lost must also clear DEADBAND. This stops a heavily-multipathed
+        # stationary device whose smoothed RSSI straddles the threshold from
+        # ping-ponging between similar-signal proxies, while a genuine one-way
+        # move (never a recent owner) still hands off at THRESHOLD. The empty-set
+        # default keeps this a single set membership test with no None check.
         switch_margin = ADV_RSSI_SWITCH_THRESHOLD
-        if self._demoted_source.get(new.address) == new.source:
+        if new.source in self._demoted_sources.get(new.address, _EMPTY_DEMOTED):
             switch_margin += _ADV_RSSI_SWITCH_DEADBAND
         if new_rssi - switch_margin > old_rssi:
-            # The new source wins ownership on the active RSSI path. Remember the
-            # demoted owner so a quick reclaim by it faces the deadband above.
-            # Recorded only here (not the stale handoff, so a strong owner
-            # recovering from transient silence still reclaims at THRESHOLD) and
-            # only for the all-history decision (record_demotion); old.source is
-            # guaranteed registered, since _should_keep_previous_adv checked it.
+            # The new source wins ownership on the active RSSI path. Record the
+            # ownership change so a quick reclaim faces the deadband above (only
+            # for the all-history decision, and not the stale handoff, so a
+            # strong owner recovering from transient silence still reclaims at
+            # THRESHOLD).
             if record_demotion:
-                self._demoted_source[new.address] = old.source
+                self._record_demotion(new.address, new.source, old.source)
             # If new advertisement is switch_margin more, prefer the new one
             # (smoothed RSSI when available).
             if self._debug:
@@ -683,6 +693,21 @@ class BluetoothManager:
                 )
             return False
         return True
+
+    def _record_demotion(self, address: str, new_source: str, old_source: str) -> None:
+        """
+        Move ownership in the reclaim-hysteresis set for an active RSSI switch.
+
+        The new source becomes owner (leaves the demoted set) and the old owner
+        joins it. ``old_source`` is guaranteed registered by the predicate that
+        calls this. Runs only on an actual switch, so the set create is cheap.
+        """
+        demoted = self._demoted_sources.get(address)
+        if demoted is None:
+            demoted = set()
+            self._demoted_sources[address] = demoted
+        demoted.discard(new_source)
+        demoted.add(old_source)
 
     def get_bluez_mgmt_ctl(self) -> MGMTBluetoothCtl | None:
         """
@@ -1101,7 +1126,7 @@ class BluetoothManager:
         self._connectable_history.pop(address, None)
         self._name_cache.pop(address, None)
         self._smoothed_rssi.pop(address, None)
-        self._demoted_source.pop(address, None)
+        self._demoted_sources.pop(address, None)
         for scanner in self._sources.values():
             scanner._previous_service_info.pop(address, None)
 
@@ -1371,16 +1396,16 @@ class BluetoothManager:
                 emptied.append(address)
         for address in emptied:
             del self._smoothed_rssi[address]
-        # Drop any reclaim-hysteresis record pointing at this source so a
-        # re-registered scanner is not penalized for an ownership it lost before
-        # it went away.
-        demoted_here = [
-            address
-            for address, demoted in self._demoted_source.items()
-            if demoted == source
-        ]
-        for address in demoted_here:
-            del self._demoted_source[address]
+        # Drop this source from every reclaim-hysteresis set so a re-registered
+        # scanner is not penalized for an ownership it lost before it went away,
+        # and remove any set left empty.
+        emptied_demoted: list[str] = []
+        for address, demoted in self._demoted_sources.items():
+            demoted.discard(source)
+            if not demoted:
+                emptied_demoted.append(address)
+        for address in emptied_demoted:
+            del self._demoted_sources[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._allocations.pop(scanner.source, None)
         if connection_slots:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1653,11 +1653,11 @@ async def test_rssi_deadband_does_not_slow_one_way_move(
     )
     assert manager.async_ble_device_from_address(address, True) is challenger
     # hci0 was demoted, so a quick reclaim by it now faces the deadband.
-    assert manager._demoted_source[address] == HCI0_SOURCE_ADDRESS
+    assert HCI0_SOURCE_ADDRESS in manager._demoted_sources[address]
 
     # Per-address eviction clears the reclaim record.
     manager.async_clear_advertisement_history(address)
-    assert address not in manager._demoted_source
+    assert address not in manager._demoted_sources
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -1688,7 +1688,7 @@ async def test_rssi_deadband_damps_reclaim(
         challenger, _rssi_adv(-30), t + 1, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is challenger
-    assert manager._demoted_source[address] == HCI0_SOURCE_ADDRESS
+    assert HCI0_SOURCE_ADDRESS in manager._demoted_sources[address]
 
     # hci0 reclaims at a sustained 20 dB margin (smoothed converges to -10 vs
     # hci1's -30): inside the 16 + 6 deadband, so ownership stays with hci1.
@@ -1706,7 +1706,7 @@ async def test_rssi_deadband_damps_reclaim(
         )
     assert manager.async_ble_device_from_address(address, True) is owner
     # The reclaim demotes hci1 in turn.
-    assert manager._demoted_source[address] == HCI1_SOURCE_ADDRESS
+    assert HCI1_SOURCE_ADDRESS in manager._demoted_sources[address]
 
     # Per-source eviction on unregister drops the reclaim record for that source.
     for scanner in list(manager._sources.values()):
@@ -1714,7 +1714,98 @@ async def test_rssi_deadband_damps_reclaim(
             manager._async_unregister_scanner_internal(
                 manager._connectable_scanners, scanner, None
             )
-    assert address not in manager._demoted_source
+    assert address not in manager._demoted_sources
+
+
+def _assert_nway_reclaim_damped(address: str, sources: list[str]) -> None:
+    """
+    Drive ownership through every source in order, then reclaim from the first.
+
+    Each current owner is faded so the next fresh source takes over, which
+    leaves every earlier owner in the demoted set. The first source then
+    reclaims: a sustained 19 dB margin (inside 16 + 6) must not switch because
+    it is still demoted, while a sustained 25 dB margin clears the deadband and
+    wins. Single-slot hysteresis (only the most-recent loser) would let the
+    first source back at the plain 16 dB, so this fails without the set.
+    """
+    manager = get_manager()
+    devices = [generate_ble_device(address, f"dev_{source}") for source in sources]
+    now = 50.0
+    inject_advertisement_with_time_and_source(
+        devices[0], _rssi_adv(-40), now, sources[0]
+    )
+    for k in range(1, len(sources)):
+        for _ in range(12):
+            now += 1
+            inject_advertisement_with_time_and_source(
+                devices[k - 1], _rssi_adv(-60), now, sources[k - 1]
+            )
+        now += 1
+        inject_advertisement_with_time_and_source(
+            devices[k], _rssi_adv(-40), now, sources[k]
+        )
+    assert manager.async_ble_device_from_address(address, True) is devices[-1]
+    assert manager._demoted_sources[address] == set(sources[:-1])
+
+    # Reclaim inside the deadband: blocked because the first source is demoted.
+    for _ in range(15):
+        now += 1
+        inject_advertisement_with_time_and_source(
+            devices[0], _rssi_adv(-21), now, sources[0]
+        )
+    assert manager.async_ble_device_from_address(address, True) is devices[-1]
+
+    # Reclaim past the deadband: wins.
+    for _ in range(15):
+        now += 1
+        inject_advertisement_with_time_and_source(
+            devices[0], _rssi_adv(-15), now, sources[0]
+        )
+    assert manager.async_ble_device_from_address(address, True) is devices[0]
+
+
+def _register_connectable_source(source: str) -> Callable[[], None]:
+    scanner = FakeScanner(source, source)
+    scanner.connectable = True
+    return get_manager().async_register_scanner(scanner, connection_slots=5)
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_deadband_damps_three_way_reclaim(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A reclaim after a 3-way bounce is still charged the deadband."""
+    cancel = _register_connectable_source("hci2")
+    try:
+        _assert_nway_reclaim_damped(
+            "44:44:33:11:23:5C",
+            [HCI0_SOURCE_ADDRESS, HCI1_SOURCE_ADDRESS, "hci2"],
+        )
+    finally:
+        cancel()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_rssi_deadband_damps_four_way_reclaim(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A reclaim by the earliest owner after a 4-way bounce still pays the deadband."""
+    cancels = [
+        _register_connectable_source("hci2"),
+        _register_connectable_source("hci3"),
+    ]
+    try:
+        _assert_nway_reclaim_damped(
+            "44:44:33:11:23:5D",
+            [HCI0_SOURCE_ADDRESS, HCI1_SOURCE_ADDRESS, "hci2", "hci3"],
+        )
+    finally:
+        for cancel in cancels:
+            cancel()
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -1758,7 +1849,7 @@ async def test_rssi_deadband_not_charged_after_stale_handoff(
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     # The stale handoff is not an RSSI-path switch, so no reclaim penalty is set.
-    assert address not in manager._demoted_source
+    assert address not in manager._demoted_sources
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -1772,7 +1863,7 @@ async def test_rssi_deadband_connectable_recheck_records_no_demotion(
 
     When the best (all-history) advertisement stays put but the connectable
     history switches sources on RSSI, that switch must not write to
-    _demoted_source; it is not an all-history ownership change, so a future
+    _demoted_sources; it is not an all-history ownership change, so a future
     challenger of the all-history owner is not wrongly treated as a reclaim.
     """
     manager = get_manager()
@@ -1800,7 +1891,7 @@ async def test_rssi_deadband_connectable_recheck_records_no_demotion(
     assert manager.async_ble_device_from_address(address, False) is best
     assert manager.async_ble_device_from_address(address, True) is strong_conn
     # The connectable-only switch records no all-history demotion.
-    assert address not in manager._demoted_source
+    assert address not in manager._demoted_sources
 
 
 @pytest.mark.usefixtures("enable_bluetooth")


### PR DESCRIPTION
Follow up to #585. On a bench with several co-located proxies, a scan-response-only Inkbird still showed occasional spikes to old data; the ownership was doing a 3-way (and wider) bounce that the deadband missed. #585 remembered only the single most recent demoted source, so in an A to B to C to A bounce, when A reclaims from C the stored source is B, not A; A is not seen as reclaiming, pays the plain 16 dB, and the switch fires, briefly surfacing a proxy with a stale scan response.

This remembers the set of sources currently in the demoted state instead of one. A challenger reclaiming any ownership it recently lost pays the deadband; a genuinely new or moving source, never a recent owner, still switches at 16 dB. The new owner leaves the set and the old owner joins it on each switch, so the current owner is never in its own set, the set is self bounded by the proxy count, and it is evicted with the device and per source on unregister.

In sustained N-way contention every proxy eventually enters the set, so switching among them all requires 16 plus the deadband; for co-located and stationary devices that stickiness is the intended behavior, and a device moving toward a new proxy is not slowed. A reclaim whose smoothed gap genuinely exceeds 16 plus the deadband still fires, so this only removes the sub-deadband bounce. Relates to #568 and home-assistant/core#174169.
