### PR TITLE
fix(manager): keep a device on its owner while the owner is paused for a connection

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -37,6 +37,7 @@ cdef class BaseHaScanner:
     cdef public unsigned int _connect_completed_total
     cdef public unsigned int _connect_failed_total
     cdef public double _last_connect_completed_time
+    cdef public double _last_scan_resume_time
 
     cpdef void _clear_connection_history(self) except *
 

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -61,6 +61,7 @@ class BaseHaScanner:
         "_expire_seconds",
         "_last_connect_completed_time",
         "_last_detection",
+        "_last_scan_resume_time",
         "_loop",
         "_manager",
         "_previous_service_info",
@@ -132,6 +133,11 @@ class BaseHaScanner:
         self._connect_completed_total: int = 0
         self._connect_failed_total: int = 0
         self._last_connect_completed_time: float = 0.0
+        # Monotonic time this scanner last resumed scanning after a connection
+        # pause (a local adapter cannot scan while connecting). 0.0 = never
+        # paused. Used to avoid handing off a device on staleness that is only
+        # the owner having been deaf during a connection.
+        self._last_scan_resume_time: float = 0.0
 
     def _on_start_success(self) -> None:
         """
@@ -149,6 +155,7 @@ class BaseHaScanner:
         self._connect_completed_total = 0
         self._connect_failed_total = 0
         self._last_connect_completed_time = 0.0
+        self._last_scan_resume_time = 0.0
 
     def _finished_connecting(self, address: str, connected: bool) -> None:
         """Finished connecting."""
@@ -370,6 +377,10 @@ class BaseHaScanner:
         finally:
             self._connecting -= 1
             self.scanning = not self._connecting
+            if not self._connecting:
+                # Fully resumed scanning; record when so a device is not treated
+                # as stale for the window it went unheard during the connection.
+                self._last_scan_resume_time = monotonic_time_coarse()
 
     @property
     def discovered_devices(self) -> list[BLEDevice]:

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -100,7 +100,8 @@ cdef class BluetoothManager:
         BluetoothServiceInfoBleak new,
         dict smoothed,
         double new_rssi,
-        bint record_demotion
+        bint record_demotion,
+        BaseHaScanner scanner
     )
 
     @cython.locals(demoted=set)

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -570,8 +570,10 @@ class BluetoothManager:
         """
         Return True when ``old_info`` should win over ``new_info``.
 
-        Only relevant when ``old_info`` came from a different still-scanning
-        source. The ``is not / !=`` ordering is a PyObject_RichCompare
+        Only relevant when ``old_info`` came from a different source that is
+        still scanning or currently paused for a connection (a local adapter
+        cannot scan while connecting but is not gone). The ``is not / !=``
+        ordering is a PyObject_RichCompare
         short-circuit that dominates this hot path; keep it intact. ``smoothed``
         is the address's per-source smoothed-RSSI bucket, which is None until
         the device is seen from more than one source; testing it first lets a
@@ -587,9 +589,13 @@ class BluetoothManager:
             and new_info.source is not old_info.source
             and new_info.source != old_info.source
             and (scanner := self._sources.get(old_info.source)) is not None
-            and scanner.scanning
+            # A local adapter paused for a connection reports scanning=False but
+            # is not gone; keep it in arbitration so its device is not handed off
+            # while it is merely deaf mid-connection (a genuinely stopped scanner
+            # has _connecting==0 and still short-circuits to a handoff).
+            and (scanner.scanning or scanner._connecting != 0)
             and self._prefer_previous_adv_from_different_source(
-                old_info, new_info, smoothed, new_rssi, record_demotion
+                old_info, new_info, smoothed, new_rssi, record_demotion, scanner
             )
         )
 
@@ -600,6 +606,7 @@ class BluetoothManager:
         smoothed: dict[str, float],
         new_rssi: float,
         record_demotion: bool,
+        scanner: BaseHaScanner,
     ) -> bool:
         """Prefer previous advertisement from a different source if it is better."""
         # Compare smoothed per-source RSSI so a momentary spike does not flip
@@ -615,7 +622,15 @@ class BluetoothManager:
         else:
             stale_seconds = FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
         elapsed = new.time - old.time
-        if elapsed > stale_seconds:
+        # Do not treat the owner as stale for silence that is only the owner
+        # being deaf while paused for a connection: a local adapter cannot scan
+        # while connecting (scanner._connecting), and for one stale window after
+        # it resumes it has not yet had a chance to re-hear the device. Bounded
+        # by stale_seconds so a device that genuinely moved away still hands off.
+        if elapsed > stale_seconds and not (
+            scanner._connecting
+            or new.time - scanner._last_scan_resume_time < stale_seconds
+        ):
             # The owner has not been heard within its expected interval.
             # Hand off immediately to a comparable-or-stronger scanner
             # (ordinary roaming), but make a materially weaker scanner wait

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from datetime import timedelta
 from typing import Any
@@ -472,6 +473,51 @@ async def test_base_scanner_connecting_behavior() -> None:
     assert len(scanner.discovered_devices) == 1
     assert len(scanner.discovered_devices_and_advertisement_data) == 1
     assert devices[0].name == "wohand"
+
+    cancel()
+    unsetup()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_scanner_records_scan_resume_time() -> None:
+    """_last_scan_resume_time is set when scanning resumes after a connection."""
+    manager = get_manager()
+    connector = HaBluetoothConnector(
+        MockBleakClient, "mock_bleak_client", lambda: False
+    )
+    scanner = FakeScanner("esp32", "esp32", connector, True)
+    unsetup = scanner.async_setup()
+    cancel = manager.async_register_scanner(scanner)
+
+    # Never paused for a connection yet.
+    assert scanner._last_scan_resume_time == 0.0
+
+    # A normal connection pause records the resume time on exit.
+    with patch_bluetooth_time(123.0), scanner.connecting():
+        assert scanner._last_scan_resume_time == 0.0  # still paused
+    assert scanner._last_scan_resume_time == 123.0
+
+    # The resume time is recorded via the finally even if the body raises.
+    boom = RuntimeError("boom")
+    with (
+        contextlib.suppress(RuntimeError),
+        patch_bluetooth_time(456.0),
+        scanner.connecting(),
+    ):
+        raise boom
+    assert scanner._last_scan_resume_time == 456.0
+
+    # Nested connects only record on the outermost resume.
+    with patch_bluetooth_time(789.0), scanner.connecting():
+        with patch_bluetooth_time(700.0), scanner.connecting():
+            pass
+        assert scanner._last_scan_resume_time == 456.0  # inner exit, still paused
+    assert scanner._last_scan_resume_time == 789.0
+
+    # Clearing connection history resets it.
+    scanner._clear_connection_history()
+    assert scanner._last_scan_resume_time == 0.0
 
     cancel()
     unsetup()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1103,6 +1103,166 @@ async def test_switching_adapters_based_on_stale_with_discovered_interval(
     )
 
 
+def _seed_stale_owner(address: str, start: float, owner_rssi: int = -100) -> BLEDevice:
+    """Register hci0 as the weak owner of a device with a 10s stale interval."""
+    manager = get_manager()
+    owner = generate_ble_device(address, "owner_hci0")
+    owner_adv = generate_advertisement_data(
+        local_name="owner_hci0", service_uuids=[], rssi=owner_rssi
+    )
+    inject_advertisement_with_time_and_source(
+        owner, owner_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    manager.async_set_fallback_availability_interval(address, 10)
+    return owner
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_no_stale_handoff_while_owner_connecting(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A device is not handed off on stale while its owner is paused connecting."""
+    manager = get_manager()
+    address = "44:44:33:11:23:60"
+    start = 50.0
+    owner = _seed_stale_owner(address, start)
+    scanner = manager._sources[HCI0_SOURCE_ADDRESS]
+
+    challenger = generate_ble_device(address, "challenger_hci1")
+    challenger_adv = generate_advertisement_data(
+        local_name="challenger_hci1", service_uuids=[], rssi=-99
+    )
+    # While hci0 holds a connection (scanning paused) a past-stale proxy advert
+    # must not steal ownership; the silence is hci0 being deaf, not the device.
+    with scanner.connecting():
+        assert scanner.scanning is False
+        inject_advertisement_with_time_and_source(
+            challenger,
+            challenger_adv,
+            start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+            HCI1_SOURCE_ADDRESS,
+        )
+        assert manager.async_ble_device_from_address(address, True) is owner
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_no_stale_handoff_within_grace_after_resume(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """For one stale window after a connection resume, no stale handoff occurs."""
+    manager = get_manager()
+    address = "44:44:33:11:23:61"
+    start = 50.0
+    owner = _seed_stale_owner(address, start)
+    scanner = manager._sources[HCI0_SOURCE_ADDRESS]
+    # Resumed scanning at start + 10; the challenger advert below is past stale
+    # (elapsed 16 > 15) but only 6s after resume (< 15 stale window), so grace
+    # suppresses the handoff.
+    scanner._last_scan_resume_time = start + 10
+
+    challenger = generate_ble_device(address, "challenger_hci1")
+    challenger_adv = generate_advertisement_data(
+        local_name="challenger_hci1", service_uuids=[], rssi=-99
+    )
+    inject_advertisement_with_time_and_source(
+        challenger,
+        challenger_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert manager.async_ble_device_from_address(address, True) is owner
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_handoff_after_grace_expires(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """Grace is bounded: past the stale window after resume, the device hands off."""
+    manager = get_manager()
+    address = "44:44:33:11:23:62"
+    start = 50.0
+    _seed_stale_owner(address, start)
+    scanner = manager._sources[HCI0_SOURCE_ADDRESS]
+    scanner._last_scan_resume_time = start + 10
+
+    challenger = generate_ble_device(address, "challenger_hci1")
+    challenger_adv = generate_advertisement_data(
+        local_name="challenger_hci1", service_uuids=[], rssi=-99
+    )
+    # One wobble past the full stale window after resume: grace expired and the
+    # advert is past stale, so the device hands off.
+    inject_advertisement_with_time_and_source(
+        challenger,
+        challenger_adv,
+        start + 10 + (10 + TRACKER_BUFFERING_WOBBLE_SECONDS) + 2,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_handoff_when_owner_never_connected(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """A never-paused scanner has no grace, so a genuinely stale device hands off."""
+    manager = get_manager()
+    address = "44:44:33:11:23:63"
+    start = 50.0
+    _seed_stale_owner(address, start)
+    scanner = manager._sources[HCI0_SOURCE_ADDRESS]
+    # Default: never paused for a connection.
+    assert scanner._last_scan_resume_time == 0.0
+
+    challenger = generate_ble_device(address, "challenger_hci1")
+    challenger_adv = generate_advertisement_data(
+        local_name="challenger_hci1", service_uuids=[], rssi=-99
+    )
+    inject_advertisement_with_time_and_source(
+        challenger,
+        challenger_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stronger_challenger_wins_during_connection_grace(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """Grace only suppresses the stale handoff; a stronger challenger still wins."""
+    manager = get_manager()
+    address = "44:44:33:11:23:64"
+    start = 50.0
+    _seed_stale_owner(address, start, owner_rssi=-90)
+    scanner = manager._sources[HCI0_SOURCE_ADDRESS]
+    scanner._last_scan_resume_time = start + 10
+
+    challenger = generate_ble_device(address, "challenger_hci1")
+    # Clearly stronger than the owner (well past ADV_RSSI_SWITCH_THRESHOLD): wins
+    # on the RSSI path even inside the connection grace window.
+    challenger_adv = generate_advertisement_data(
+        local_name="challenger_hci1", service_uuids=[], rssi=-20
+    )
+    inject_advertisement_with_time_and_source(
+        challenger,
+        challenger_adv,
+        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
+        HCI1_SOURCE_ADDRESS,
+    )
+    assert manager.async_ble_device_from_address(address, True) is challenger
+
+
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
 async def test_stale_does_not_switch_to_much_weaker_scanner(


### PR DESCRIPTION
A local BLE adapter cannot scan while it holds or establishes a connection; `connecting()` sets `scanning = not _connecting`. While paused it hears no advertisements for any device on that adapter, so the owner's last seen time ages. When it resumes, the device looks stale and a proxy steals ownership on the stale path, briefly surfacing the proxy's old scan response before the owner reclaims on RSSI. On a bench log this was a perfect 17 losses / 17 reclaims cycle on the local adapter, and on a scan response only Inkbird sensor it showed as thin vertical spikes to an old value. This is the residual of home-assistant/core#174169 that the RSSI smoothing and deadband work structurally could not reach.

Record when a scanner resumes scanning after a connection pause in `_last_scan_resume_time` (set on both connect success and failure, via the `connecting()` finally). Then keep a paused owner in arbitration rather than auto handing off on `scanning=False`, and skip the stale handoff while the owner is connecting or for one stale window after it resumes. The grace is bounded by the device's own stale interval, so a device that genuinely moved away still hands off afterward; the RSSI path is untouched, so a genuinely stronger challenger still wins; and #570 / #580 stale protections are unchanged. A never paused scanner has `_last_scan_resume_time = 0.0` and gets no grace.

Relates to #568 and home-assistant/core#174169.
