### PR TITLE
fix(manager): damp stale handoffs per device class and give rescues an accept grace

### DIFF
--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -183,7 +183,7 @@ cdef class AutoScanScheduler:
     cpdef void _rescue_challenger_side(
         self,
         str address,
-        str challenger_source,
+        object challenger,
         set requests,
         object loop,
         double now,

--- a/src/habluetooth/auto_scheduler.pxd
+++ b/src/habluetooth/auto_scheduler.pxd
@@ -147,14 +147,15 @@ cdef class AutoScanScheduler:
         self, str address, str challenger_source, str owner_source
     )
 
-    cpdef void _record_rescue_accept(self, str address, double accept_after)
+    @cython.locals(accept_after=double)
+    cpdef void _record_rescue_accept(self, str address, double coverage_time)
 
     cpdef void _record_window_dispatch(
         self,
         str address,
         double dispatch_now,
         str source,
-        double accept_after,
+        double coverage_time,
     )
 
     @cython.locals(address=str)
@@ -164,10 +165,10 @@ cdef class AutoScanScheduler:
         list addresses,
         double dispatch_now,
         double duration,
-        double accept_after,
+        double coverage_time,
     )
 
-    @cython.locals(accept_after=double)
+    @cython.locals(coverage_time=double)
     cpdef void _record_rescue_accepts(self, list due_buckets)
 
     cpdef void _rescue_owner_side(

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -612,10 +612,13 @@ class _ScannerWorker:
             had_any_progress = True
             if fallback is None:
                 # Covered by another ACTIVE scanner: no later dispatch
-                # here, so the tick time is the window start and captures
-                # are accepted immediately. Delegated addresses are
-                # recorded below at their dispatch time.
-                self._scheduler._record_window_dispatch(address, now, None, coarse_now)
+                # here, so the tick time is the window start; the accept
+                # keeps the standard grace so the owner gets one re-hear
+                # window. Delegated addresses are recorded below at their
+                # dispatch time.
+                self._scheduler._record_window_dispatch(
+                    address, now, None, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
+                )
                 continue
             existing = fallback_groups.get(fallback.source)
             if existing is None:
@@ -812,9 +815,10 @@ class AutoScanScheduler:
         # Diagnostics-only; pruned with requests.
         self._last_window_by_address: dict[str, tuple[float, str | None]] = {}
         # address -> coarse-monotonic time after which a capture from the
-        # scanning side is trusted as an active capture (dispatch time +
-        # RESCUE_SCAN_ACCEPT_SECONDS; "already ACTIVE and scanning" counts
-        # as now). Written at every dispatch site plus trigger_rescue;
+        # scanning side is trusted as an active capture (coverage time +
+        # RESCUE_SCAN_ACCEPT_SECONDS at every site, so the owner always
+        # gets one re-hear window). Written at every dispatch site plus
+        # trigger_rescue;
         # read by the manager's stale-handoff deferral, which hands a
         # device off on the first challenger advertisement that postdates
         # this (issue #591). Coarse monotonic on purpose so it compares
@@ -1038,10 +1042,10 @@ class AutoScanScheduler:
         now and its worker woken, so the normal tick path (including
         the connecting fallback) dispatches it and records the accept
         time. The challenger side gets a delegated window so its next
-        capture carries a fresh scan response (an ACTIVE-and-scanning
-        challenger never reaches here; the manager hands off to it
-        immediately). An owner that is already ACTIVE and scanning
-        counts as covered now. The accept time lands in
+        capture carries a fresh scan response. A scanner that is already
+        ACTIVE and scanning counts as covered, with the standard accept
+        grace so the owner always gets one re-hear window before any
+        handoff. The accept time lands in
         ``_rescue_accept_after`` (coarse monotonic, comparable with
         advertisement times); the manager hands off on the first
         challenger advertisement that postdates it. A passive or
@@ -1155,9 +1159,12 @@ class AutoScanScheduler:
             owner_scanner.requested_mode is BluetoothScanningMode.ACTIVE
             and owner_scanner.scanning
         ):
-            # Already actively scanning: the owner's silence is
-            # already meaningful; count its side as covered now.
-            self._record_rescue_accept(address, coarse_now)
+            # Already actively scanning: its side is covered, with the
+            # standard accept grace so the owner still gets one re-hear
+            # window before any handoff.
+            self._record_rescue_accept(
+                address, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
+            )
 
     def _rescue_challenger_side(
         self,
@@ -1172,17 +1179,18 @@ class AutoScanScheduler:
         Delegate a rescue window to the challenger's scanner.
 
         An ACTIVE-and-scanning challenger already produces active captures,
-        so its side counts as covered now (the manager only defers a
-        materially weaker ACTIVE challenger; a comparable one was handed
-        off before the rescue was triggered). Only an AUTO challenger
-        needs (and can take) a window; a passive or mid-connect challenger
-        cannot produce an active capture right now.
+        so its side counts as covered with the standard accept grace (the
+        owner still gets one re-hear window before any handoff). Only an
+        AUTO challenger needs (and can take) a window; a passive or
+        mid-connect challenger cannot produce an active capture right now.
         """
         if (challenger := self._manager._sources.get(challenger_source)) is None:
             return
         mode = challenger.requested_mode
         if mode is BluetoothScanningMode.ACTIVE and challenger.scanning:
-            self._record_rescue_accept(address, coarse_now)
+            self._record_rescue_accept(
+                address, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
+            )
             return
         if (
             mode is not BluetoothScanningMode.AUTO

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -1033,19 +1033,23 @@ class AutoScanScheduler:
         self, address: str, challenger_source: str, owner_source: str
     ) -> None:
         """
-        Run an active window on both sides of a deferred stale handoff.
+        Serve a deferred stale handoff; scans start only on AUTO scanners.
 
         Called synchronously by the manager's advertisement arbitration
         (issue #591) when the stale handoff for a device that needs
-        active scans is deferred instead of taken. The owner side gets
-        an immediate window: its per-address due times are clamped to
-        now and its worker woken, so the normal tick path (including
-        the connecting fallback) dispatches it and records the accept
-        time. The challenger side gets a delegated window so its next
-        capture carries a fresh scan response. A scanner that is already
-        ACTIVE and scanning counts as covered, with the standard accept
-        grace so the owner always gets one re-hear window before any
-        handoff. The accept time lands in
+        active scans is deferred instead of taken. A challenger that is
+        already ACTIVE and scanning short-circuits everything: its
+        captures already carry the scan response and the owner only
+        needs to hear a bare advertisement (passive listening suffices)
+        to invalidate the episode, so no window runs anywhere and only
+        the accept grace is recorded. Otherwise the owner side gets an
+        immediate window when the owner is AUTO (due times clamped to
+        now, worker woken, so the normal tick path including the
+        connecting fallback dispatches it) or counts as covered when
+        the owner is ACTIVE, and an AUTO challenger gets a delegated
+        window so its next capture carries a fresh scan response. Every
+        accept time keeps the standard grace so the owner always gets
+        one re-hear window before any handoff, and lands in
         ``_rescue_accept_after`` (coarse monotonic, comparable with
         advertisement times); the manager hands off on the first
         challenger advertisement that postdates it. A passive or
@@ -1064,12 +1068,25 @@ class AutoScanScheduler:
             or (requests := self._requests_by_address.get(address)) is None
         ):
             return
-        now = loop.time()
         coarse_now = monotonic_time_coarse()
+        challenger = self._manager._sources.get(challenger_source)
+        if (
+            challenger is not None
+            and challenger.requested_mode is BluetoothScanningMode.ACTIVE
+            and challenger.scanning
+        ):
+            # The challenger is already actively scanning: no scan needs
+            # to start on either side; only the accept grace matters.
+            self._record_rescue_accept(
+                address, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
+            )
+            return
+        now = loop.time()
         self._rescue_owner_side(address, owner_source, requests, now, coarse_now)
-        self._rescue_challenger_side(
-            address, challenger_source, requests, loop, now, coarse_now
-        )
+        if challenger is not None:
+            self._rescue_challenger_side(
+                address, challenger, requests, loop, now, coarse_now
+            )
 
     def _record_rescue_accept(self, address: str, accept_after: float) -> None:
         """Record a rescue accept time, keeping any later pre-existing one."""
@@ -1169,7 +1186,7 @@ class AutoScanScheduler:
     def _rescue_challenger_side(
         self,
         address: str,
-        challenger_source: str,
+        challenger: BaseHaScanner,
         requests: set[ActiveScanRequest],
         loop: asyncio.AbstractEventLoop,
         now: float,
@@ -1178,22 +1195,13 @@ class AutoScanScheduler:
         """
         Delegate a rescue window to the challenger's scanner.
 
-        An ACTIVE-and-scanning challenger already produces active captures,
-        so its side counts as covered with the standard accept grace (the
-        owner still gets one re-hear window before any handoff). Only an
-        AUTO challenger needs (and can take) a window; a passive or
-        mid-connect challenger cannot produce an active capture right now.
+        Only an AUTO challenger needs (and can take) a window; a passive
+        or mid-connect challenger cannot produce an active capture right
+        now (an ACTIVE-and-scanning challenger short-circuited the rescue
+        in ``trigger_rescue`` before either side was served).
         """
-        if (challenger := self._manager._sources.get(challenger_source)) is None:
-            return
-        mode = challenger.requested_mode
-        if mode is BluetoothScanningMode.ACTIVE and challenger.scanning:
-            self._record_rescue_accept(
-                address, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
-            )
-            return
         if (
-            mode is not BluetoothScanningMode.AUTO
+            challenger.requested_mode is not BluetoothScanningMode.AUTO
             or challenger._connections_in_progress() > 0
         ):
             return
@@ -1201,7 +1209,7 @@ class AutoScanScheduler:
         # schedule's owner, so the tick path will not serve it).
         duration = self._coalesce_duration(requests)
         self._mark_delegated_dispatch(
-            challenger_source,
+            challenger.source,
             [address],
             now,
             duration,

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -138,14 +138,16 @@ gone — issue #591), it calls
 owner side is served through the normal
 schedule (due times clamped to now, worker woken, connecting
 fallback included); the challenger side gets a directly delegated
-window so its next capture carries a fresh scan response. Every
-dispatch site records the window's accept time in
-``_rescue_accept_after`` (dispatch + RESCUE_SCAN_ACCEPT_SECONDS,
-coarse monotonic so it compares with advertisement times); once a
-window has been actively scanning that long, a capture cannot be a
-delayed passive one, so the manager hands the device off on the
-first challenger advertisement that postdates the accept time while
-the owner stayed silent, without waiting for the window to close.
+window so its next capture carries a fresh scan response; sides
+that are already ACTIVE and scanning need no window and just record
+coverage, and an ACTIVE owner counts as covered. Every dispatch or
+coverage site records the accept time in ``_rescue_accept_after``
+(coverage + RESCUE_SCAN_ACCEPT_SECONDS, coarse monotonic so it
+compares with advertisement times); once a window has been actively
+scanning that long, a capture cannot be a delayed passive one, so
+the manager hands the device off on the first challenger
+advertisement that postdates the accept time while the owner stayed
+silent, without waiting for the window to close.
 
 
 Invariants
@@ -616,9 +618,7 @@ class _ScannerWorker:
                 # keeps the standard grace so the owner gets one re-hear
                 # window. Delegated addresses are recorded below at their
                 # dispatch time.
-                self._scheduler._record_window_dispatch(
-                    address, now, None, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
-                )
+                self._scheduler._record_window_dispatch(address, now, None, coarse_now)
                 continue
             existing = fallback_groups.get(fallback.source)
             if existing is None:
@@ -672,7 +672,7 @@ class _ScannerWorker:
                 [request.address for request in fb_due],
                 dispatch_now,
                 duration,
-                monotonic_time_coarse() + _RESCUE_SCAN_ACCEPT_SECONDS,
+                monotonic_time_coarse(),
             )
             try:
                 await fb.async_request_active_window(duration)
@@ -993,6 +993,12 @@ class AutoScanScheduler:
                 del self._requests_by_address[request.address]
                 self._last_window_by_address.pop(request.address, None)
                 self._rescue_accept_after.pop(request.address, None)
+                # A rescue episode's lifetime is bounded by the active-scan
+                # need. Without this upward pop, a device that never goes
+                # stale again would keep an orphaned episode alive forever,
+                # disabling the no-episode fast path for every dispatch
+                # (the manager cannot observe the unregister itself).
+                self._manager._rescue_triggered.pop(request.address, None)
         self._schedule.drop(request.address, request)
 
     def on_advertisement(self, service_info: BluetoothServiceInfoBleak) -> None:
@@ -1037,17 +1043,16 @@ class AutoScanScheduler:
 
         Called synchronously by the manager's advertisement arbitration
         (issue #591) when the stale handoff for a device that needs
-        active scans is deferred instead of taken. A challenger that is
-        already ACTIVE and scanning short-circuits everything: its
-        captures already carry the scan response and the owner only
-        needs to hear a bare advertisement (passive listening suffices)
-        to invalidate the episode, so no window runs anywhere and only
-        the accept grace is recorded. Otherwise the owner side gets an
-        immediate window when the owner is AUTO (due times clamped to
-        now, worker woken, so the normal tick path including the
-        connecting fallback dispatches it) or counts as covered when
-        the owner is ACTIVE, and an AUTO challenger gets a delegated
-        window so its next capture carries a fresh scan response. Every
+        active scans is deferred instead of taken. The owner side is
+        always served: an AUTO owner gets an immediate window (due times
+        clamped to now, worker woken, so the normal tick path including
+        the connecting fallback dispatches it and its next retained
+        capture is a fresh scan response) and an ACTIVE owner counts as
+        covered. On the challenger side a scanner that is already ACTIVE
+        and scanning needs no window (its captures already carry the
+        scan response; coverage is recorded so the accept grace starts),
+        while an AUTO challenger gets a delegated window so its next
+        capture carries a fresh scan response. Every
         accept time keeps the standard grace so the owner always gets
         one re-hear window before any handoff, and lands in
         ``_rescue_accept_after`` (coarse monotonic, comparable with
@@ -1068,28 +1073,34 @@ class AutoScanScheduler:
             or (requests := self._requests_by_address.get(address)) is None
         ):
             return
+        now = loop.time()
         coarse_now = monotonic_time_coarse()
-        challenger = self._manager._sources.get(challenger_source)
+        self._rescue_owner_side(address, owner_source, requests, now, coarse_now)
+        if (challenger := self._manager._sources.get(challenger_source)) is None:
+            return
         if (
-            challenger is not None
-            and challenger.requested_mode is BluetoothScanningMode.ACTIVE
+            challenger.requested_mode is BluetoothScanningMode.ACTIVE
             and challenger.scanning
         ):
-            # The challenger is already actively scanning: no scan needs
-            # to start on either side; only the accept grace matters.
-            self._record_rescue_accept(
-                address, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
-            )
+            # The challenger is already actively scanning: its captures
+            # already carry the scan response, so no window is needed on
+            # its side; record coverage now so the accept grace starts.
+            self._record_rescue_accept(address, coarse_now)
             return
-        now = loop.time()
-        self._rescue_owner_side(address, owner_source, requests, now, coarse_now)
-        if challenger is not None:
-            self._rescue_challenger_side(
-                address, challenger, requests, loop, now, coarse_now
-            )
+        self._rescue_challenger_side(
+            address, challenger, requests, loop, now, coarse_now
+        )
 
-    def _record_rescue_accept(self, address: str, accept_after: float) -> None:
-        """Record a rescue accept time, keeping any later pre-existing one."""
+    def _record_rescue_accept(self, address: str, coverage_time: float) -> None:
+        """
+        Record a rescue accept time from a coverage time.
+
+        The accept always sits ``RESCUE_SCAN_ACCEPT_SECONDS`` after the
+        moment coverage was confirmed; folding the grace in here (rather
+        than at the call sites) makes that invariant single-sourced.
+        Keeps any later pre-existing accept (keep-max).
+        """
+        accept_after = coverage_time + _RESCUE_SCAN_ACCEPT_SECONDS
         if self._rescue_accept_after.get(address, 0.0) < accept_after:
             self._rescue_accept_after[address] = accept_after
 
@@ -1104,16 +1115,16 @@ class AutoScanScheduler:
             # No rescue episode anywhere: nothing will read the accept
             # times, so the ordinary active-scan cadence pays nothing.
             return
-        accept_after = monotonic_time_coarse() + _RESCUE_SCAN_ACCEPT_SECONDS
+        coverage_time = monotonic_time_coarse()
         for bucket_address, _entries, _due in due_buckets:
-            self._record_rescue_accept(bucket_address, accept_after)
+            self._record_rescue_accept(bucket_address, coverage_time)
 
     def _record_window_dispatch(
         self,
         address: str,
         dispatch_now: float,
         source: str | None,
-        accept_after: float,
+        coverage_time: float,
     ) -> None:
         """
         Record one window dispatch covering ``address``.
@@ -1129,7 +1140,7 @@ class AutoScanScheduler:
         """
         self._last_window_by_address[address] = (dispatch_now, source)
         if self._manager._rescue_triggered:
-            self._record_rescue_accept(address, accept_after)
+            self._record_rescue_accept(address, coverage_time)
 
     def _mark_delegated_dispatch(
         self,
@@ -1137,7 +1148,7 @@ class AutoScanScheduler:
         addresses: list[str],
         dispatch_now: float,
         duration: float,
-        accept_after: float,
+        coverage_time: float,
     ) -> None:
         """
         Record a window delegated to ``source`` covering ``addresses``.
@@ -1149,7 +1160,7 @@ class AutoScanScheduler:
         the call site (awaited there vs fire-and-forget here).
         """
         for address in addresses:
-            self._record_window_dispatch(address, dispatch_now, source, accept_after)
+            self._record_window_dispatch(address, dispatch_now, source, coverage_time)
         if (worker := self._workers.get(source)) is not None:
             worker.note_window_dispatched(dispatch_now + duration, dispatch_now)
 
@@ -1179,9 +1190,7 @@ class AutoScanScheduler:
             # Already actively scanning: its side is covered, with the
             # standard accept grace so the owner still gets one re-hear
             # window before any handoff.
-            self._record_rescue_accept(
-                address, coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS
-            )
+            self._record_rescue_accept(address, coarse_now)
 
     def _rescue_challenger_side(
         self,
@@ -1209,11 +1218,7 @@ class AutoScanScheduler:
         # schedule's owner, so the tick path will not serve it).
         duration = self._coalesce_duration(requests)
         self._mark_delegated_dispatch(
-            challenger.source,
-            [address],
-            now,
-            duration,
-            coarse_now + _RESCUE_SCAN_ACCEPT_SECONDS,
+            challenger.source, [address], now, duration, coarse_now
         )
         task = loop.create_task(challenger.async_request_active_window(duration))
         self._rescue_tasks.add(task)

--- a/src/habluetooth/auto_scheduler.py
+++ b/src/habluetooth/auto_scheduler.py
@@ -1171,15 +1171,21 @@ class AutoScanScheduler:
         """
         Delegate a rescue window to the challenger's scanner.
 
-        Only an AUTO challenger needs (and can take) a window: the manager
-        hands off immediately for an ACTIVE-and-scanning challenger before
-        ever triggering a rescue, and a passive or mid-connect challenger
+        An ACTIVE-and-scanning challenger already produces active captures,
+        so its side counts as covered now (the manager only defers a
+        materially weaker ACTIVE challenger; a comparable one was handed
+        off before the rescue was triggered). Only an AUTO challenger
+        needs (and can take) a window; a passive or mid-connect challenger
         cannot produce an active capture right now.
         """
         if (challenger := self._manager._sources.get(challenger_source)) is None:
             return
+        mode = challenger.requested_mode
+        if mode is BluetoothScanningMode.ACTIVE and challenger.scanning:
+            self._record_rescue_accept(address, coarse_now)
+            return
         if (
-            challenger.requested_mode is not BluetoothScanningMode.AUTO
+            mode is not BluetoothScanningMode.AUTO
             or challenger._connections_in_progress() > 0
         ):
             return

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -144,7 +144,12 @@ RESCUE_SCAN_RETRY_SECONDS: Final = 30.0
 # Once the radio has been actively scanning this long, an incoming
 # advertisement cannot be a delayed passive capture that is still
 # missing its scan response, so the deferred handoff can proceed
-# without waiting for the full window to close. Derived from
+# without waiting for the full window to close. Every accept time
+# (including "already ACTIVE and scanning" coverage) sits this far
+# after coverage was confirmed, which doubles as a grace window: the
+# owner always gets one chance to re-hear the device and invalidate
+# the episode before any handoff, so a single missed advertising
+# interval can never flap ownership. Derived from
 # AUTO_WINDOW_MIN_DURATION so it can never exceed a window's length.
 RESCUE_SCAN_ACCEPT_SECONDS: Final = AUTO_WINDOW_MIN_DURATION
 

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -106,7 +106,6 @@ cdef class BluetoothManager:
         durably_gone=double,
         comparable_or_stronger=bint,
         owner_strong=bint,
-        challenger_scanner=BaseHaScanner,
     )
     cdef bint _stale_challenger_wins(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -704,7 +704,9 @@ class BluetoothManager:
         handoff flaps straight back (a materially stronger reclaim) or
         cannot flap back and ping-pongs on alternating misses (a
         comparable pair) — the stationary-device flap issues #568/#580
-        fixed. What differs per device class is everything in between:
+        fixed. A materially stronger challenger can still win at any time
+        on the smoothed RSSI path below (deadband-protected, stale or
+        not); what differs per device class is everything in between:
 
         * Passive device (no registered need): a comparable-or-stronger
           challenger of a weak owner takes over immediately (ordinary
@@ -756,51 +758,59 @@ class BluetoothManager:
             # Passive device: a comparable-or-stronger challenger of a weak
             # owner takes over immediately (ordinary roaming; its capture
             # is as good as anyone's, payloads are identical across
-            # scanners). Anything else waits for durably-gone above, and
-            # ending the episode also cleans up after an active-scan need
-            # unregistered mid-episode; a lingering entry would keep the
-            # scheduler's no-episode fast path off for every dispatch.
+            # scanners). Anything else waits for durably-gone above. The
+            # episode ends either way; it also cleans up after an
+            # active-scan need unregistered mid-episode (defense in depth,
+            # the unregister itself clears it too).
+            self._end_rescue_episode(new.address, record_demotion)
             comparable_or_stronger = new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
             owner_strong = old_rssi >= _STRONG_OWNER_STALE_RSSI
             if comparable_or_stronger and not owner_strong:
                 if self._debug:
                     _LOGGER.debug(
                         "%s (%s): Switching from %s to %s (time elapsed:%s >"
-                        " stale seconds:%s; passive roaming,"
-                        " comparable_or_stronger:%s, owner_strong:%s)",
+                        " stale seconds:%s; passive roaming, comparable"
+                        " challenger of a weak owner)",
                         new.name,
                         new.address,
                         self._async_describe_source(old),
                         self._async_describe_source(new),
                         elapsed,
                         stale_seconds,
-                        comparable_or_stronger,
-                        owner_strong,
                     )
-                self._end_rescue_episode(new.address, record_demotion)
                 return True
-            self._end_rescue_episode(new.address, record_demotion)
             return False
-        # Active-need device: never take the roaming shortcut, even for a
-        # comparable challenger of a weak owner; the challenger may be an
-        # AUTO scanner sitting in its passive phase whose capture carries
-        # no fresh scan response (issue #568). Every handoff before
-        # durably-gone goes through the rescue flow, so it lands on a
-        # capture from an address a recent active window covered. Only the
-        # all-history decision (record_demotion) drives an episode; the
-        # connectable re-check keeps the plain damping so one adv can't
-        # double-drive the episode state.
-        return record_demotion and self._rescue_stale_handoff(
-            old, new, elapsed, stale_seconds
-        )
+        if not record_demotion:
+            # Connectable re-check: connection routing cares about
+            # liveness, not scan-response freshness, so the ordinary
+            # roaming rule applies here exactly as it does for a passive
+            # device; the connectable history must repoint away from a
+            # silent scanner at the stale window rather than route a
+            # connect attempt at a dead radio until durably-gone. Only
+            # the all-history decision drives episode state.
+            return (
+                new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
+                and old_rssi < _STRONG_OWNER_STALE_RSSI
+            )
+        # Active-need all-history decision: never take the roaming
+        # shortcut, even for a comparable challenger of a weak owner; the
+        # challenger may be an AUTO scanner sitting in its passive phase
+        # whose capture carries no fresh scan response (issue #568).
+        # Every handoff before durably-gone goes through the rescue flow,
+        # so it lands on a capture from an address a recent active window
+        # covered.
+        return self._rescue_stale_handoff(old, new, elapsed, stale_seconds)
 
     def _end_rescue_episode(self, address: str, record_demotion: bool) -> None:
         """
-        End any rescue episode when a stale handoff proceeds immediately.
+        End any rescue episode on a stale arbitration outside the rescue.
 
-        Only the all-history decision (record_demotion) owns episode state,
-        and the empty-dict check keeps the common no-episode case to a
-        single branch.
+        Runs on the durably-gone handoff and on every passive stale
+        arbitration whether or not the device hands off (the passive case
+        also cleans up an episode orphaned by an unregistered active-scan
+        need). Only the all-history decision (record_demotion) owns
+        episode state, and the empty-dict check keeps the common
+        no-episode case to a single branch.
         """
         if record_demotion and self._rescue_triggered:
             self._rescue_triggered.pop(address, None)
@@ -847,7 +857,17 @@ class BluetoothManager:
                 )
             return False
         accept_after = self._auto_scheduler._rescue_accept_after.get(new.address, 0.0)
-        if accept_after >= pending and new.time > accept_after:
+        # The accept grace alone is empty for slow advertisers (a
+        # 60s-interval sensor cannot re-advertise within it), so the
+        # handoff additionally requires one full advertising interval
+        # (stale_seconds minus the wobble) since the trigger; that
+        # guarantees the owner one transmission opportunity to invalidate
+        # the episode regardless of the device's cadence.
+        if (
+            accept_after >= pending
+            and new.time > accept_after
+            and new.time - pending > stale_seconds - TRACKER_BUFFERING_WOBBLE_SECONDS
+        ):
             # A rescue window's accept time postdates the trigger and the
             # owner is still silent: hand off. The accept time is the max
             # across both sides, so a deaf owner whose window never ran

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -226,7 +226,7 @@ class BluetoothManager:
         # invalidates the episode (old.time >= trigger), so a stale
         # record can never authorize a later instant switch. Evicted
         # with the device; an entry orphaned by its active-scan need being
-        # unregistered is cleared on the device's next stale handoff.
+        # unregistered is cleared on the device's next stale arbitration.
         self._rescue_triggered: dict[str, float] = {}
         # Cross-scanner name cache: address -> best name seen across all
         # scanners. Passive scanners typically miss the device name because
@@ -752,9 +752,11 @@ class BluetoothManager:
             return True
         if self._auto_scheduler._requests_by_address.get(new.address) is None:
             # Passive device: wait for durably-gone (payloads are identical
-            # across scanners, so keeping the owner costs nothing). Any
-            # orphaned rescue episode from a deregistered active-scan need
-            # is cleaned up by the durably-gone handoff above or eviction.
+            # across scanners, so keeping the owner costs nothing). End any
+            # rescue episode orphaned by its active-scan need being
+            # unregistered mid-episode; a lingering entry would keep the
+            # scheduler's no-episode fast path off for every dispatch.
+            self._end_rescue_episode(new.address, record_demotion)
             return False
         # Active-need device with the handoff denied: run the rescue flow
         # described above. Only the all-history decision (record_demotion)

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -887,11 +887,16 @@ class BluetoothManager:
                     pending,
                 )
             return True
-        if new.time - pending > _RESCUE_SCAN_RETRY_SECONDS:
+        if accept_after < pending and new.time - pending > _RESCUE_SCAN_RETRY_SECONDS:
             # The triggered window never materialized (scanner busy,
             # dispatch lost): restart the episode and try again. Advancing
             # the trigger time spaces retries by the retry interval instead
-            # of re-triggering on every advertisement once it elapses.
+            # of re-triggering on every advertisement once it elapses. A
+            # recorded accept means the episode is merely waiting out the
+            # gates above; restarting would clobber it. Net effect of the
+            # retry cadence: the rescue only accelerates handoffs for
+            # advertisers faster than roughly the retry interval, and the
+            # durably-gone backstop governs slower ones.
             self._rescue_triggered[new.address] = new.time
             self._auto_scheduler.trigger_rescue(new.address, new.source, old.source)
         return False

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -695,9 +695,13 @@ class BluetoothManager:
         SCAN_RSP):
 
         * Passive device (no registered need): any scanning scanner hears
-          the bare advertisement, so the challenger's newer capture is
-          genuinely fresh data regardless of its signal strength; hand off
-          immediately.
+          the bare advertisement, so a comparable-or-stronger challenger's
+          newer capture takes over immediately, even against a strong
+          owner (there is no scan response to go stale). A materially
+          weaker challenger that happened to catch the one advertisement
+          the owner missed must not steal on a hair-past-stale interval
+          only to flap back on the owner's next capture; it waits for the
+          durably-gone handoff.
         * Active-need device: the owner's silence often just means nobody
           has run an active window lately (or its radio is busy with
           connections while it still reports scanning; an owner that
@@ -707,9 +711,13 @@ class BluetoothManager:
           be a stale scan response (issue #568). A comparable-or-stronger
           challenger of a weak owner still takes over immediately (ordinary
           roaming; a strong owner that briefly goes quiet is almost
-          certainly still there), and so does a challenger whose scanner
-          runs continuous ACTIVE scanning, since its capture already
-          carries the scan response. Otherwise, instead of pinning
+          certainly still there), and so does a comparable-or-stronger
+          challenger whose scanner runs continuous ACTIVE scanning, since
+          its capture already carries the scan response (a materially
+          weaker ACTIVE challenger defers like any other; its side of the
+          rescue counts as covered immediately, so it wins on its next
+          advertisement only if the owner stays silent). Otherwise,
+          instead of pinning
           ownership until the owner is durably gone (issue #591), trigger
           an active window on both the owner (a chance to re-hear the
           device) and the challenger (its next capture is a fresh scan
@@ -752,33 +760,42 @@ class BluetoothManager:
             self._end_rescue_episode(new.address, record_demotion)
             return True
         if self._auto_scheduler._requests_by_address.get(new.address) is None:
-            # Passive device: the challenger's newer capture is genuinely
-            # fresh data; hand off. Ending the episode here also cleans up
-            # after a device whose active-scan need was unregistered while
-            # an episode was in flight.
-            if self._debug:
-                _LOGGER.debug(
-                    "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
-                    " seconds:%s; passive device, newer capture wins)",
-                    new.name,
-                    new.address,
-                    self._async_describe_source(old),
-                    self._async_describe_source(new),
-                    elapsed,
-                    stale_seconds,
-                )
-            self._end_rescue_episode(new.address, record_demotion)
-            return True
+            # Passive device: a comparable-or-stronger challenger's newer
+            # capture wins immediately; a materially weaker challenger
+            # waits for the durably-gone handoff above so a single missed
+            # interval at the owner cannot flap ownership (see the
+            # docstring). Ending the episode here also cleans up after a
+            # device whose active-scan need was unregistered while an
+            # episode was in flight.
+            if comparable_or_stronger:
+                if self._debug:
+                    _LOGGER.debug(
+                        "%s (%s): Switching from %s to %s (time elapsed:%s >"
+                        " stale seconds:%s; passive device, comparable newer"
+                        " capture wins)",
+                        new.name,
+                        new.address,
+                        self._async_describe_source(old),
+                        self._async_describe_source(new),
+                        elapsed,
+                        stale_seconds,
+                    )
+                self._end_rescue_episode(new.address, record_demotion)
+                return True
+            return False
         challenger_scanner = self._sources.get(new.source)
         if (
-            challenger_scanner is not None
+            comparable_or_stronger
+            and challenger_scanner is not None
             and challenger_scanner.requested_mode is BluetoothScanningMode.ACTIVE
             and challenger_scanner.scanning
         ):
             # The challenger runs continuous active scanning, so this
             # capture already carries the device's scan response; it is as
             # fresh as active data gets and there is nothing for a rescue
-            # window to add. Hand off immediately, like passive.
+            # window to add. Hand off immediately. A materially weaker
+            # ACTIVE challenger falls through to the rescue deferral so a
+            # single missed interval at the owner cannot flap ownership.
             if self._debug:
                 _LOGGER.debug(
                     "%s (%s): Switching from %s to %s (time elapsed:%s > stale"

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -694,41 +694,32 @@ class BluetoothManager:
         need via async_register_active_scan because the device's data rides
         SCAN_RSP):
 
-        * Passive device (no registered need): any scanning scanner hears
-          the bare advertisement, so a comparable-or-stronger challenger's
-          newer capture takes over immediately, even against a strong
-          owner (there is no scan response to go stale). A materially
-          weaker challenger that happened to catch the one advertisement
-          the owner missed must not steal on a hair-past-stale interval
-          only to flap back on the owner's next capture; it waits for the
-          durably-gone handoff.
-        * Active-need device: the owner's silence often just means nobody
-          has run an active window lately (or its radio is busy with
-          connections while it still reports scanning; an owner that
-          paused scanning entirely never reaches this code, its devices
-          were handed off at the scanning gate), and a far weaker
-          challenger's capture may itself
-          be a stale scan response (issue #568). A comparable-or-stronger
-          challenger of a weak owner still takes over immediately (ordinary
-          roaming; a strong owner that briefly goes quiet is almost
-          certainly still there), and so does a comparable-or-stronger
-          challenger whose scanner runs continuous ACTIVE scanning, since
-          its capture already carries the scan response (a materially
-          weaker ACTIVE challenger defers like any other; its side of the
-          rescue counts as covered immediately, so it wins on its next
-          advertisement only if the owner stays silent). Otherwise,
-          instead of pinning
-          ownership until the owner is durably gone (issue #591), trigger
-          an active window on both the owner (a chance to re-hear the
-          device) and the challenger (its next capture is a fresh scan
-          response), and hand off on the first challenger advertisement
-          past the accept time (the window has been actively scanning long
-          enough that a capture cannot be a delayed passive one) while the
-          owner stayed silent (see _rescue_stale_handoff).
-        * Either way an owner silent past the durably-gone threshold loses
-          to any challenger: receive time is all we have (adverts carry no
-          timestamp), so the durably-gone wait is what lets a device that
-          truly moved into weak-only coverage still hand off.
+        In every case a comparable-or-stronger challenger of a weak owner
+        takes over immediately (ordinary roaming), and an owner silent
+        past the durably-gone threshold loses to any challenger: receive
+        time is all we have (adverts carry no timestamp), so the
+        durably-gone wait is what lets a device that truly moved into
+        weak-only coverage still hand off. Any other challenger of a
+        strong owner must NOT take over on a single missed interval: the
+        owner almost certainly re-hears the device on its next
+        advertisement and either the handoff flaps straight back (a
+        materially stronger reclaim) or cannot flap back and ping-pongs on
+        alternating misses (a comparable pair) — the stationary-device
+        flap issues #568/#580 fixed. What differs is how the wait ends:
+
+        * Passive device (no registered need): payloads are identical
+          across scanners, so waiting costs nothing data-wise; the
+          durably-gone handoff is the only escalation.
+        * Active-need device: instead of pinning ownership until the owner
+          is durably gone (issue #591), trigger an active window on both
+          the owner (a chance to re-hear the device) and the challenger
+          (its next capture is a fresh scan response), and hand off on the
+          first challenger advertisement past the accept time while the
+          owner stayed silent (see _rescue_stale_handoff). Accept times
+          always sit RESCUE_SCAN_ACCEPT_SECONDS after coverage so the
+          owner is guaranteed one re-hear window before any handoff. An
+          owner that paused scanning entirely never reaches this code; its
+          devices were handed off at the scanning gate.
 
         The cheap comparisons decide first; the scheduler lookup that
         classifies the device as active-need runs only when they keep the
@@ -760,56 +751,11 @@ class BluetoothManager:
             self._end_rescue_episode(new.address, record_demotion)
             return True
         if self._auto_scheduler._requests_by_address.get(new.address) is None:
-            # Passive device: a comparable-or-stronger challenger's newer
-            # capture wins immediately; a materially weaker challenger
-            # waits for the durably-gone handoff above so a single missed
-            # interval at the owner cannot flap ownership (see the
-            # docstring). Ending the episode here also cleans up after a
-            # device whose active-scan need was unregistered while an
-            # episode was in flight.
-            if comparable_or_stronger:
-                if self._debug:
-                    _LOGGER.debug(
-                        "%s (%s): Switching from %s to %s (time elapsed:%s >"
-                        " stale seconds:%s; passive device, comparable newer"
-                        " capture wins)",
-                        new.name,
-                        new.address,
-                        self._async_describe_source(old),
-                        self._async_describe_source(new),
-                        elapsed,
-                        stale_seconds,
-                    )
-                self._end_rescue_episode(new.address, record_demotion)
-                return True
+            # Passive device: wait for durably-gone (payloads are identical
+            # across scanners, so keeping the owner costs nothing). Any
+            # orphaned rescue episode from a deregistered active-scan need
+            # is cleaned up by the durably-gone handoff above or eviction.
             return False
-        challenger_scanner = self._sources.get(new.source)
-        if (
-            comparable_or_stronger
-            and challenger_scanner is not None
-            and challenger_scanner.requested_mode is BluetoothScanningMode.ACTIVE
-            and challenger_scanner.scanning
-        ):
-            # The challenger runs continuous active scanning, so this
-            # capture already carries the device's scan response; it is as
-            # fresh as active data gets and there is nothing for a rescue
-            # window to add. Hand off immediately. A materially weaker
-            # ACTIVE challenger falls through to the rescue deferral so a
-            # single missed interval at the owner cannot flap ownership.
-            if self._debug:
-                _LOGGER.debug(
-                    "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
-                    " seconds:%s; challenger is actively scanning, capture"
-                    " is fresh)",
-                    new.name,
-                    new.address,
-                    self._async_describe_source(old),
-                    self._async_describe_source(new),
-                    elapsed,
-                    stale_seconds,
-                )
-            self._end_rescue_episode(new.address, record_demotion)
-            return True
         # Active-need device with the handoff denied: run the rescue flow
         # described above. Only the all-history decision (record_demotion)
         # drives an episode; the connectable re-check keeps the plain

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -694,26 +694,30 @@ class BluetoothManager:
         need via async_register_active_scan because the device's data rides
         SCAN_RSP):
 
-        In every case a comparable-or-stronger challenger of a weak owner
-        takes over immediately (ordinary roaming), and an owner silent
-        past the durably-gone threshold loses to any challenger: receive
-        time is all we have (adverts carry no timestamp), so the
-        durably-gone wait is what lets a device that truly moved into
-        weak-only coverage still hand off. Any other challenger of a
-        strong owner must NOT take over on a single missed interval: the
-        owner almost certainly re-hears the device on its next
-        advertisement and either the handoff flaps straight back (a
-        materially stronger reclaim) or cannot flap back and ping-pongs on
-        alternating misses (a comparable pair) — the stationary-device
-        flap issues #568/#580 fixed. What differs is how the wait ends:
+        An owner silent past the durably-gone threshold loses to any
+        challenger, for every device class: receive time is all we have
+        (adverts carry no timestamp), so the durably-gone wait is what
+        lets a device that truly moved into weak-only coverage still hand
+        off. Short of that, a challenger of a strong owner must NOT take
+        over on a single missed interval: the owner almost certainly
+        re-hears the device on its next advertisement and either the
+        handoff flaps straight back (a materially stronger reclaim) or
+        cannot flap back and ping-pongs on alternating misses (a
+        comparable pair) — the stationary-device flap issues #568/#580
+        fixed. What differs per device class is everything in between:
 
-        * Passive device (no registered need): payloads are identical
-          across scanners, so waiting costs nothing data-wise; the
-          durably-gone handoff is the only escalation.
-        * Active-need device: instead of pinning ownership until the owner
-          is durably gone (issue #591), trigger an active window on both
-          the owner (a chance to re-hear the device) and the challenger
-          (its next capture is a fresh scan response), and hand off on the
+        * Passive device (no registered need): a comparable-or-stronger
+          challenger of a weak owner takes over immediately (ordinary
+          roaming; payloads are identical across scanners, so its capture
+          is as good as anyone's). Anything else waits for durably-gone,
+          which costs nothing data-wise for the same reason.
+        * Active-need device: there is no roaming shortcut at all — even a
+          comparable challenger of a weak owner may be an AUTO scanner in
+          its passive phase whose capture carries no fresh scan response
+          (issue #568). Instead of pinning ownership until the owner is
+          durably gone (issue #591), trigger an active window on both the
+          owner (a chance to re-hear the device) and the challenger (its
+          next capture is a fresh scan response), and hand off on the
           first challenger advertisement past the accept time while the
           owner stayed silent (see _rescue_stale_handoff). Accept times
           always sit RESCUE_SCAN_ACCEPT_SECONDS after coverage so the
@@ -730,38 +734,62 @@ class BluetoothManager:
             stale_seconds * _DURABLY_GONE_STALE_FACTOR,
             FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
         )
-        comparable_or_stronger = new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
-        owner_strong = old_rssi >= _STRONG_OWNER_STALE_RSSI
-        if (comparable_or_stronger and not owner_strong) or elapsed > durably_gone:
+        if elapsed > durably_gone:
+            # Unconditional backstop for every device class: someone has to
+            # own a device whose owner has been silent this long, even if
+            # the challenger's capture is not an active one.
             if self._debug:
                 _LOGGER.debug(
                     "%s (%s): Switching from %s to %s (time elapsed:%s > stale"
-                    " seconds:%s; comparable_or_stronger:%s, owner_strong:%s,"
-                    " durably-gone threshold:%s)",
+                    " seconds:%s; durably-gone threshold:%s)",
                     new.name,
                     new.address,
                     self._async_describe_source(old),
                     self._async_describe_source(new),
                     elapsed,
                     stale_seconds,
-                    comparable_or_stronger,
-                    owner_strong,
                     durably_gone,
                 )
             self._end_rescue_episode(new.address, record_demotion)
             return True
         if self._auto_scheduler._requests_by_address.get(new.address) is None:
-            # Passive device: wait for durably-gone (payloads are identical
-            # across scanners, so keeping the owner costs nothing). End any
-            # rescue episode orphaned by its active-scan need being
+            # Passive device: a comparable-or-stronger challenger of a weak
+            # owner takes over immediately (ordinary roaming; its capture
+            # is as good as anyone's, payloads are identical across
+            # scanners). Anything else waits for durably-gone above, and
+            # ending the episode also cleans up after an active-scan need
             # unregistered mid-episode; a lingering entry would keep the
             # scheduler's no-episode fast path off for every dispatch.
+            comparable_or_stronger = new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
+            owner_strong = old_rssi >= _STRONG_OWNER_STALE_RSSI
+            if comparable_or_stronger and not owner_strong:
+                if self._debug:
+                    _LOGGER.debug(
+                        "%s (%s): Switching from %s to %s (time elapsed:%s >"
+                        " stale seconds:%s; passive roaming,"
+                        " comparable_or_stronger:%s, owner_strong:%s)",
+                        new.name,
+                        new.address,
+                        self._async_describe_source(old),
+                        self._async_describe_source(new),
+                        elapsed,
+                        stale_seconds,
+                        comparable_or_stronger,
+                        owner_strong,
+                    )
+                self._end_rescue_episode(new.address, record_demotion)
+                return True
             self._end_rescue_episode(new.address, record_demotion)
             return False
-        # Active-need device with the handoff denied: run the rescue flow
-        # described above. Only the all-history decision (record_demotion)
-        # drives an episode; the connectable re-check keeps the plain
-        # damping so one adv can't double-drive the episode state.
+        # Active-need device: never take the roaming shortcut, even for a
+        # comparable challenger of a weak owner; the challenger may be an
+        # AUTO scanner sitting in its passive phase whose capture carries
+        # no fresh scan response (issue #568). Every handoff before
+        # durably-gone goes through the rescue flow, so it lands on a
+        # capture from an address a recent active window covered. Only the
+        # all-history decision (record_demotion) drives an episode; the
+        # connectable re-check keeps the plain damping so one adv can't
+        # double-drive the episode state.
         return record_demotion and self._rescue_stale_handoff(
             old, new, elapsed, stale_seconds
         )
@@ -787,9 +815,9 @@ class BluetoothManager:
         """
         Advance the rescue episode for a denied stale handoff; True = hand off.
 
-        Runs only for a device with a registered active-scan need whose
-        stale handoff was denied (strong owner / weaker challenger, not
-        durably gone). First denial starts an episode: the trigger time is
+        Runs for every stale challenger of a device with a registered
+        active-scan need that is not durably gone. First denial starts an
+        episode: the trigger time is
         recorded and the scheduler runs an active window on both the owner
         and the challenger. Later denials hand off once the rescue's accept
         time (the window has been actively scanning long enough that a

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6571,10 +6571,15 @@ async def test_trigger_rescue_active_challenger_counts_covered() -> None:
         before = monotonic_time_coarse()
         sched.trigger_rescue(address, challenger.source, owner.source)
         after = monotonic_time_coarse()
-        # Already actively scanning: no window, no task, covered now.
+        # Already actively scanning: no window, no task, covered with
+        # the standard accept grace.
         assert challenger.active_window_calls == []
         assert not sched._rescue_tasks
-        assert before <= sched._rescue_accept_after[address] <= after
+        assert (
+            before + RESCUE_SCAN_ACCEPT_SECONDS
+            <= sched._rescue_accept_after[address]
+            <= after + RESCUE_SCAN_ACCEPT_SECONDS
+        )
     finally:
         cancel()
         c_owner()
@@ -6602,10 +6607,15 @@ async def test_trigger_rescue_active_owner_counts_covered() -> None:
         before = monotonic_time_coarse()
         sched.trigger_rescue(address, challenger.source, owner.source)
         after = monotonic_time_coarse()
-        # PASSIVE challenger gets no window; the owner side still covered.
+        # PASSIVE challenger gets no window; the owner side is covered
+        # with the standard accept grace.
         assert challenger.active_window_calls == []
         assert owner.active_window_calls == []
-        assert before <= sched._rescue_accept_after[address] <= after
+        assert (
+            before + RESCUE_SCAN_ACCEPT_SECONDS
+            <= sched._rescue_accept_after[address]
+            <= after + RESCUE_SCAN_ACCEPT_SECONDS
+        )
     finally:
         cancel()
         c_owner()
@@ -6771,7 +6781,11 @@ async def test_covered_by_active_records_rescue_accept_after() -> None:
         await _run_worker_tick(sched, owner.source)
         after = monotonic_time_coarse()
         assert active.active_window_calls == []
-        assert before <= sched._rescue_accept_after[address] <= after
+        assert (
+            before + RESCUE_SCAN_ACCEPT_SECONDS
+            <= sched._rescue_accept_after[address]
+            <= after + RESCUE_SCAN_ACCEPT_SECONDS
+        )
     finally:
         owner._finished_connecting(address, connected=False)
         cancel()

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6581,12 +6581,10 @@ async def test_trigger_rescue_active_challenger_counts_covered() -> None:
             <= sched._rescue_accept_after[address]
             <= after + RESCUE_SCAN_ACCEPT_SECONDS
         )
-        # The owner side is skipped entirely: its scheduled due times are
-        # not clamped to now.
+        # The owner side is still served: its scheduled due times are
+        # clamped to now so its worker fires a window on the next tick.
         loop_now = asyncio.get_running_loop().time()
-        assert all(
-            due > loop_now + 60 for due in sched._schedule._due_at[address].values()
-        )
+        assert all(due <= loop_now for due in sched._schedule._due_at[address].values())
     finally:
         cancel()
         c_owner()
@@ -6674,14 +6672,18 @@ async def test_trigger_rescue_noop_untracked_or_not_started() -> None:
 
 @pytest.mark.asyncio
 async def test_remove_request_prunes_rescue_accept_after() -> None:
-    """The last request for an address prunes its rescue accept time."""
+    """The last request for an address prunes all rescue state."""
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:66:05"
     cancel = manager.async_register_active_scan(address, scan_interval=120.0)
     sched._rescue_accept_after[address] = 1.0
+    manager._rescue_triggered[address] = 1.0
     cancel()
     assert address not in sched._rescue_accept_after
+    # The episode's lifetime is bounded by the need: a device that never
+    # goes stale again must not keep an orphaned episode alive.
+    assert address not in manager._rescue_triggered
 
 
 @pytest.mark.asyncio
@@ -6825,7 +6827,8 @@ async def test_trigger_rescue_unregistered_sides_are_skipped() -> None:
         sched.trigger_rescue(address, "AA:00:00:00:9A:99", "AA:00:00:00:9A:98")
         assert sched._rescue_accept_after[address] == recorded
         # A later accept time is never rolled back by an earlier one: the
-        # ACTIVE owner side records "now", which loses to the later value.
+        # ACTIVE owner side records coverage plus the accept grace, which
+        # loses to the later value.
         sched.trigger_rescue(address, "AA:00:00:00:9A:99", owner.source)
         assert sched._rescue_accept_after[address] == recorded
     finally:

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6574,11 +6574,18 @@ async def test_trigger_rescue_active_challenger_counts_covered() -> None:
         # Already actively scanning: no window, no task, covered with
         # the standard accept grace.
         assert challenger.active_window_calls == []
+        assert owner.active_window_calls == []
         assert not sched._rescue_tasks
         assert (
             before + RESCUE_SCAN_ACCEPT_SECONDS
             <= sched._rescue_accept_after[address]
             <= after + RESCUE_SCAN_ACCEPT_SECONDS
+        )
+        # The owner side is skipped entirely: its scheduled due times are
+        # not clamped to now.
+        loop_now = asyncio.get_running_loop().time()
+        assert all(
+            due > loop_now + 60 for due in sched._schedule._due_at[address].values()
         )
     finally:
         cancel()
@@ -6811,11 +6818,11 @@ async def test_trigger_rescue_unregistered_sides_are_skipped() -> None:
         before = monotonic_time_coarse()
         sched.trigger_rescue(address, "AA:00:00:00:9A:99", owner.source)
         assert sched._rescue_accept_after[address] >= before
-        # Owner never registered: the owner side is skipped and an ACTIVE
-        # challenger is never delegated a window, so nothing is recorded.
+        # Neither side registered: nothing is recorded and the owner
+        # side's unregistered guard is exercised.
         recorded = sched._rescue_accept_after[address] + 1000.0
         sched._rescue_accept_after[address] = recorded
-        sched.trigger_rescue(address, owner.source, "AA:00:00:00:9A:99")
+        sched.trigger_rescue(address, "AA:00:00:00:9A:99", "AA:00:00:00:9A:98")
         assert sched._rescue_accept_after[address] == recorded
         # A later accept time is never rolled back by an earlier one: the
         # ACTIVE owner side records "now", which loses to the later value.

--- a/tests/test_auto_scheduler.py
+++ b/tests/test_auto_scheduler.py
@@ -6552,8 +6552,8 @@ async def test_trigger_rescue_auto_owner_and_auto_challenger() -> None:
 
 
 @pytest.mark.asyncio
-async def test_trigger_rescue_active_challenger_not_delegated() -> None:
-    """An ACTIVE challenger gets no window; the manager hands off before this."""
+async def test_trigger_rescue_active_challenger_counts_covered() -> None:
+    """A weaker ACTIVE challenger gets no window; its side is covered now."""
     manager = get_manager()
     sched = manager._auto_scheduler
     address = "11:22:33:44:66:02"
@@ -6568,12 +6568,13 @@ async def test_trigger_rescue_active_challenger_not_delegated() -> None:
     c_challenger = manager.async_register_scanner(challenger)
     try:
         _inject_with_rssi(owner, address, rssi=-50)
+        before = monotonic_time_coarse()
         sched.trigger_rescue(address, challenger.source, owner.source)
+        after = monotonic_time_coarse()
+        # Already actively scanning: no window, no task, covered now.
         assert challenger.active_window_calls == []
         assert not sched._rescue_tasks
-        # The AUTO owner side is served through the schedule; the accept
-        # time only lands when its worker tick dispatches the window.
-        assert address not in sched._rescue_accept_after
+        assert before <= sched._rescue_accept_after[address] <= after
     finally:
         cancel()
         c_owner()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1192,20 +1192,24 @@ async def test_stale_switches_to_weaker_scanner_once_durably_gone(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+@pytest.mark.parametrize("debug", [True, False])
 async def test_stale_switches_to_comparable_scanner_at_normal_window(
     register_hci0_scanner: None,
     register_hci1_scanner: None,
+    debug: bool,
 ) -> None:
     """
-    A comparable scanner takes over a weak owner at the normal stale window.
+    A comparable scanner takes over a weak passive owner at the stale window.
 
     The owner is weak (below STRONG_OWNER_STALE_RSSI), so its silence is
     treated as the device possibly being gone and a comparable scanner is
     allowed to take over at the normal window. A strong owner is protected
-    (see test_stale_keeps_strong_owner_against_comparable_scanner).
+    (see test_stale_keeps_strong_owner_against_comparable_scanner). Runs
+    with debug logging both on and off to cover the log branches.
     """
     address = "44:44:33:11:23:44"
     start = 50.0
+    get_manager()._debug = debug
     owner = generate_ble_device(address, "owner_hci0")
     owner_adv = generate_advertisement_data(
         local_name="owner_hci0", service_uuids=[], rssi=-90
@@ -1486,6 +1490,56 @@ async def test_stale_active_need_defers_then_switches_after_rescue_window(
     # First challenger adv past the completed window: hand off.
     inject_advertisement_with_time_and_source(
         comparable, comparable_adv, start + 25, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is comparable
+    assert address not in manager._rescue_triggered
+    cancel_active()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_active_need_no_roaming_shortcut_for_weak_owner(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    An active-need device never takes the roaming shortcut.
+
+    A comparable challenger of a weak owner switches instantly for a
+    passive device, but for an active-need device the challenger may not
+    have actively scanned recently, so the handoff defers through the
+    rescue and lands only past the accept time.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:77"
+    start = 50.0
+    cancel_active = manager.async_register_active_scan(address)
+    weak_owner = generate_ble_device(address, "weak_owner_hci0")
+    weak_owner_adv = generate_advertisement_data(
+        local_name="weak_owner_hci0", service_uuids=[], rssi=-90
+    )
+    inject_advertisement_with_time_and_source(
+        weak_owner, weak_owner_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    # stale_seconds = 15, durably-gone = 37.5
+    manager.async_set_fallback_availability_interval(address, 10)
+
+    comparable = generate_ble_device(address, "comparable_hci1")
+    comparable_adv = generate_advertisement_data(
+        local_name="comparable_hci1", service_uuids=[], rssi=-95
+    )
+    # Comparable challenger of a weak owner just past stale: deferred,
+    # episode started (no instant roaming handoff).
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 16, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is weak_owner
+    assert manager._rescue_triggered[address] == start + 16
+    # A rescue window covered the address; the first adv past the accept
+    # time hands off.
+    manager._auto_scheduler._rescue_accept_after[address] = start + 21
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 22, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     assert address not in manager._rescue_triggered

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1487,9 +1487,15 @@ async def test_stale_active_need_defers_then_switches_after_rescue_window(
         comparable, comparable_adv, start + 19, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is strong
-    # First challenger adv past the completed window: hand off.
+    # Past the accept time but within one advertising interval of the
+    # trigger: still deferred (the owner gets a full re-hear cycle).
     inject_advertisement_with_time_and_source(
         comparable, comparable_adv, start + 25, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
+    # Past the accept time and one full interval past the trigger: hand off.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 27, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     assert address not in manager._rescue_triggered
@@ -1535,11 +1541,11 @@ async def test_stale_active_need_no_roaming_shortcut_for_weak_owner(
     )
     assert manager.async_ble_device_from_address(address, True) is weak_owner
     assert manager._rescue_triggered[address] == start + 16
-    # A rescue window covered the address; the first adv past the accept
-    # time hands off.
+    # A rescue window covered the address; the handoff needs the accept
+    # time passed and one full advertising interval since the trigger.
     manager._auto_scheduler._rescue_accept_after[address] = start + 21
     inject_advertisement_with_time_and_source(
-        comparable, comparable_adv, start + 22, HCI1_SOURCE_ADDRESS
+        comparable, comparable_adv, start + 27, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     assert address not in manager._rescue_triggered
@@ -1718,9 +1724,14 @@ async def test_stale_active_need_comparable_active_challenger_defers(
         comparable, comparable_adv, now + 2, "AA:BB:CC:DD:EE:22"
     )
     assert manager.async_ble_device_from_address(address, True) is strong
-    # Past the accept time with the owner still silent: hand off.
+    # Past the accept but within one advertising interval: still deferred.
     inject_advertisement_with_time_and_source(
         comparable, comparable_adv, accept + 1, "AA:BB:CC:DD:EE:22"
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
+    # Past the accept and one full interval past the trigger: hand off.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, max(accept + 1, now + 11), "AA:BB:CC:DD:EE:22"
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     assert address not in manager._rescue_triggered
@@ -1780,9 +1791,9 @@ async def test_stale_active_need_weaker_active_challenger_defers() -> None:
         weak, weak_adv, now + 2, "AA:BB:CC:DD:EE:AA"
     )
     assert manager.async_ble_device_from_address(address, True) is strong
-    # Past the accept time with the owner still silent: hand off.
+    # Past the accept and one full interval past the trigger: hand off.
     inject_advertisement_with_time_and_source(
-        weak, weak_adv, accept + 1, "AA:BB:CC:DD:EE:AA"
+        weak, weak_adv, max(accept + 1, now + 11), "AA:BB:CC:DD:EE:AA"
     )
     assert manager.async_ble_device_from_address(address, True) is weak
     assert address not in manager._rescue_triggered
@@ -1958,9 +1969,10 @@ async def test_rescue_end_to_end_owner_mid_connect_fallback_window() -> None:
         assert fallback.active_window_calls
         accept = sched._rescue_accept_after[address]
         assert accept >= now
-        # First challenger adv past the accept time: hand off.
+        # First challenger adv past the accept time and one advertising
+        # interval past the trigger: hand off.
         inject_advertisement_with_time_and_source(
-            weak, weak_adv, accept + 1, challenger.source
+            weak, weak_adv, max(accept + 1, now + 11), challenger.source
         )
         assert manager.async_ble_device_from_address(address, True) is weak
         assert address not in manager._rescue_triggered
@@ -2013,7 +2025,7 @@ async def test_rescue_episode_is_per_address_any_challenger_completes(
         local_name="challenger_hci8", service_uuids=[], rssi=-62
     )
     inject_advertisement_with_time_and_source(
-        challenger_b, challenger_b_adv, start + 25, "AA:BB:CC:DD:EE:88"
+        challenger_b, challenger_b_adv, start + 27, "AA:BB:CC:DD:EE:88"
     )
     assert manager.async_ble_device_from_address(address, True) is challenger_b
     assert address not in manager._rescue_triggered
@@ -2070,6 +2082,58 @@ async def test_connectable_recheck_does_not_drive_rescue_episode(
     )
     assert manager.async_ble_device_from_address(address, False) is nc_device
     assert manager.async_ble_device_from_address(address, True) is connectable_owner
+    assert address not in manager._rescue_triggered
+    cancel_active()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_connectable_recheck_roams_active_need_device_at_stale(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+    register_non_connectable_scanner: None,
+) -> None:
+    """
+    The connectable re-check keeps the roaming rule for active-need devices.
+
+    Connection routing cares about liveness, not scan-response freshness:
+    when the weak connectable owner goes silent, the connectable history
+    must repoint to a comparable live challenger at the stale window
+    instead of routing connect attempts at a dead radio until durably
+    gone, and it must not drive rescue episode state.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:78"
+    start = 50.0
+    cancel_active = manager.async_register_active_scan(address)
+    connectable_owner = generate_ble_device(address, "conn_hci0")
+    connectable_owner_adv = generate_advertisement_data(
+        local_name="conn_hci0", service_uuids=[], rssi=-80
+    )
+    inject_advertisement_with_time_and_source(
+        connectable_owner, connectable_owner_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    manager.async_set_fallback_availability_interval(address, 10)
+    # A much stronger non-connectable source takes all-history on the
+    # RSSI path; the connectable history stays with hci0.
+    nc_device = generate_ble_device(address, "nc")
+    nc_adv = generate_advertisement_data(local_name="nc", service_uuids=[], rssi=-30)
+    inject_advertisement_with_time_and_source_connectable(
+        nc_device, nc_adv, start + 10, NON_CONNECTABLE_REMOTE_SOURCE_ADDRESS, False
+    )
+    assert manager.async_ble_device_from_address(address, True) is connectable_owner
+    # A comparable connectable challenger of the weak, now-stale owner:
+    # all-history keeps (fresh strong NC owner), but the connectable
+    # re-check roams to the live challenger.
+    challenger = generate_ble_device(address, "challenger_hci1")
+    challenger_adv = generate_advertisement_data(
+        local_name="challenger_hci1", service_uuids=[], rssi=-85
+    )
+    inject_advertisement_with_time_and_source(
+        challenger, challenger_adv, start + 17, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, False) is nc_device
+    assert manager.async_ble_device_from_address(address, True) is challenger
     assert address not in manager._rescue_triggered
     cancel_active()
 
@@ -2148,6 +2212,12 @@ async def test_rescue_accept_time_boundaries(
         comparable, comparable_adv, start + 20, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is strong
+    # Past the accept but within one advertising interval of the trigger:
+    # still deferred.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 24, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
     cancel_a()
 
     # Part 2: an accept time equal to the trigger time counts.
@@ -2170,7 +2240,7 @@ async def test_rescue_accept_time_boundaries(
     )
     manager_sched._rescue_accept_after[address] = start + 16
     inject_advertisement_with_time_and_source(
-        comparable2, comparable2_adv, start + 17, HCI1_SOURCE_ADDRESS
+        comparable2, comparable2_adv, start + 27, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is comparable2
     cancel_b()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -32,6 +32,7 @@ from habluetooth import (
     set_manager,
 )
 from habluetooth.central_manager import CentralBluetoothManager
+from habluetooth.const import RESCUE_SCAN_ACCEPT_SECONDS
 
 from . import (
     HCI0_SOURCE_ADDRESS,
@@ -1390,16 +1391,19 @@ async def test_stale_passive_weaker_scanner_waits_for_durably_gone(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
-@pytest.mark.parametrize("debug", [True, False])
-async def test_stale_passive_strong_owner_yields_to_comparable_scanner(
+async def test_stale_passive_strong_owner_keeps_comparable_until_durably_gone(
     register_hci0_scanner: None,
     register_hci1_scanner: None,
-    debug: bool,
 ) -> None:
-    """A passive strong owner yields to a comparable scanner at the stale window."""
+    """
+    A comparable challenger cannot steal a passive strong owner on one miss.
+
+    A comparable pair cannot reclaim on the RSSI path, so a stale steal
+    would ping-pong on alternating missed intervals (issue #580); the
+    challenger waits for the durably-gone handoff instead.
+    """
     address = "44:44:33:11:23:61"
     start = 50.0
-    get_manager()._debug = debug
     strong = generate_ble_device(address, "strong_hci0")
     strong_adv = generate_advertisement_data(
         local_name="strong_hci0", service_uuids=[], rssi=-50
@@ -1407,7 +1411,8 @@ async def test_stale_passive_strong_owner_yields_to_comparable_scanner(
     inject_advertisement_with_time_and_source(
         strong, strong_adv, start, HCI0_SOURCE_ADDRESS
     )
-    get_manager().async_set_fallback_availability_interval(address, 10)  # stale=15
+    # stale_seconds = 15, durably-gone = 37.5
+    get_manager().async_set_fallback_availability_interval(address, 10)
 
     comparable = generate_ble_device(address, "comparable_hci1")
     comparable_adv = generate_advertisement_data(
@@ -1418,6 +1423,11 @@ async def test_stale_passive_strong_owner_yields_to_comparable_scanner(
         comparable_adv,
         start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
         HCI1_SOURCE_ADDRESS,
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is strong
+    # Past durably-gone: the comparable scanner takes over.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 40, HCI1_SOURCE_ADDRESS
     )
     assert get_manager().async_ble_device_from_address(address, True) is comparable
 
@@ -1602,22 +1612,21 @@ async def test_stale_active_need_retriggers_when_window_never_ran(
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("debug", [True, False])
-async def test_stale_active_need_active_challenger_switches_immediately(
+async def test_stale_active_need_comparable_active_challenger_defers(
     register_hci0_scanner: None,
     debug: bool,
 ) -> None:
     """
-    A comparable ACTIVE-scanner challenger hands off without a rescue.
+    A comparable ACTIVE challenger of a strong owner defers with grace.
 
-    Its capture already carries the device's scan response, so there is
-    nothing for a rescue window to add; the stale handoff proceeds
-    immediately. Runs with debug logging both on and off to cover both
-    sides of the logging branch.
+    Its side of the rescue is covered immediately but the accept time
+    keeps the standard grace, so the owner gets one re-hear window; only
+    a challenger advertisement past the accept time takes ownership.
+    Runs with debug logging both on and off to cover the log branches.
     """
     manager = get_manager()
     manager._debug = debug
     address = "44:44:33:11:23:67"
-    start = 50.0
     cancel_active = manager.async_register_active_scan(address)
     active_scanner = FakeScanner(
         "AA:BB:CC:DD:EE:22",
@@ -1626,12 +1635,13 @@ async def test_stale_active_need_active_challenger_switches_immediately(
     )
     active_scanner.connectable = True
     cancel_scanner = manager.async_register_scanner(active_scanner, connection_slots=5)
+    now = monotonic_time_coarse()
     strong = generate_ble_device(address, "strong_hci0")
     strong_adv = generate_advertisement_data(
         local_name="strong_hci0", service_uuids=[], rssi=-50
     )
     inject_advertisement_with_time_and_source(
-        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+        strong, strong_adv, now - 16, HCI0_SOURCE_ADDRESS
     )
     # stale_seconds = 15, durably-gone = 37.5
     manager.async_set_fallback_availability_interval(address, 10)
@@ -1640,15 +1650,23 @@ async def test_stale_active_need_active_challenger_switches_immediately(
     comparable_adv = generate_advertisement_data(
         local_name="comparable_hci2", service_uuids=[], rssi=-60
     )
-    # A leftover episode from another challenger must be ended by the
-    # immediate handoff; the debug=False run exercises the no-episode
-    # branch.
-    if debug:
-        manager._rescue_triggered[address] = start
-    # Just past the stale window and far before durably-gone: the ACTIVE
-    # challenger wins right away, no rescue deferral.
+    # Just past the stale window: deferred, the challenger's side of the
+    # rescue is covered with the accept grace.
     inject_advertisement_with_time_and_source(
-        comparable, comparable_adv, start + 16, "AA:BB:CC:DD:EE:22"
+        comparable, comparable_adv, now, "AA:BB:CC:DD:EE:22"
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
+    assert manager._rescue_triggered[address] == now
+    accept = manager._auto_scheduler._rescue_accept_after[address]
+    assert accept >= now + RESCUE_SCAN_ACCEPT_SECONDS - 1
+    # Within the grace window: still the owner.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, now + 2, "AA:BB:CC:DD:EE:22"
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
+    # Past the accept time with the owner still silent: hand off.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, accept + 1, "AA:BB:CC:DD:EE:22"
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     assert address not in manager._rescue_triggered
@@ -1697,14 +1715,20 @@ async def test_stale_active_need_weaker_active_challenger_defers() -> None:
         local_name="weak_hci10", service_uuids=[], rssi=-90
     )
     # Far weaker ACTIVE challenger just past the stale window: deferred,
-    # its rescue side counts as covered now.
+    # its rescue side counts as covered with the accept grace.
     inject_advertisement_with_time_and_source(weak, weak_adv, now, "AA:BB:CC:DD:EE:AA")
     assert manager.async_ble_device_from_address(address, True) is strong
     assert manager._rescue_triggered[address] == now
-    assert manager._auto_scheduler._rescue_accept_after[address] >= now - 1
-    # Its next advertisement wins because the owner stayed silent.
+    accept = manager._auto_scheduler._rescue_accept_after[address]
+    assert accept >= now + RESCUE_SCAN_ACCEPT_SECONDS - 1
+    # Within the grace window: still the owner.
     inject_advertisement_with_time_and_source(
         weak, weak_adv, now + 2, "AA:BB:CC:DD:EE:AA"
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
+    # Past the accept time with the owner still silent: hand off.
+    inject_advertisement_with_time_and_source(
+        weak, weak_adv, accept + 1, "AA:BB:CC:DD:EE:AA"
     )
     assert manager.async_ble_device_from_address(address, True) is weak
     assert address not in manager._rescue_triggered

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1851,6 +1851,63 @@ async def test_owner_paused_for_connection_hands_off_immediately(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_stale_active_need_retry_does_not_clobber_matured_accept(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    The retry never restarts an episode whose window already ran.
+
+    Once an accept time is recorded, the episode is only waiting out the
+    accept and interval gates; restarting it would push the trigger time
+    forward and make the gates unreachable for slow advertisers.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:79"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-50
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    # stale_seconds = 35, durably-gone = 87.5
+    manager.async_set_fallback_availability_interval(address, 30)
+
+    comparable = generate_ble_device(address, "comparable_hci1")
+    comparable_adv = generate_advertisement_data(
+        local_name="comparable_hci1", service_uuids=[], rssi=-60
+    )
+    real_scheduler = manager._auto_scheduler
+    mock_scheduler = Mock()
+    mock_scheduler._requests_by_address = {address: {Mock()}}
+    mock_scheduler._rescue_accept_after = {}
+    manager._auto_scheduler = mock_scheduler
+    try:
+        # Episode starts.
+        inject_advertisement_with_time_and_source(
+            comparable, comparable_adv, start + 36, HCI1_SOURCE_ADDRESS
+        )
+        assert mock_scheduler.trigger_rescue.call_count == 1
+        assert manager._rescue_triggered[address] == start + 36
+        # A window ran; its accept time is still in the future.
+        mock_scheduler._rescue_accept_after[address] = start + 80
+        # Past the retry wait, but the accept exists: no restart, the
+        # trigger time is preserved so the gates can mature.
+        inject_advertisement_with_time_and_source(
+            comparable, comparable_adv, start + 70, HCI1_SOURCE_ADDRESS
+        )
+        assert mock_scheduler.trigger_rescue.call_count == 1
+        assert manager._rescue_triggered[address] == start + 36
+        assert manager.async_ble_device_from_address(address, True) is strong
+    finally:
+        manager._auto_scheduler = real_scheduler
+        manager._rescue_triggered.pop(address, None)
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_stale_active_need_durably_gone_ends_episode(
     register_hci0_scanner: None,
     register_hci1_scanner: None,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1342,17 +1342,16 @@ async def test_stale_strong_owner_yields_to_stronger_scanner(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
-async def test_stale_passive_device_switches_to_weaker_scanner(
+async def test_stale_passive_weaker_scanner_waits_for_durably_gone(
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
     """
-    A passive device hands off on stale to any challenger with a newer adv.
+    A far weaker challenger cannot steal a passive device on one missed interval.
 
-    No active-scan need is registered, so the challenger's newer capture is
-    genuinely fresh data regardless of signal strength; the stale damping
-    (strong owner / durably-gone wait) only applies to devices that need
-    active scans.
+    A hair-past-stale capture by a materially weaker scanner would flap
+    ownership right back on the owner's next advertisement, so it waits
+    for the durably-gone handoff instead.
     """
     address = "44:44:33:11:23:60"
     start = 50.0
@@ -1366,32 +1365,41 @@ async def test_stale_passive_device_switches_to_weaker_scanner(
     inject_advertisement_with_time_and_source(
         strong, strong_adv, start, HCI0_SOURCE_ADDRESS
     )
-    get_manager().async_set_fallback_availability_interval(address, 10)  # stale=15
+    # stale_seconds = 15, durably-gone = 37.5
+    get_manager().async_set_fallback_availability_interval(address, 10)
 
     weak = generate_ble_device(address, "weak_hci1")
     weak_adv = generate_advertisement_data(
         local_name="weak_hci1", service_uuids=[], rssi=-90
     )
-    # Just past the normal stale window: the far weaker scanner has the only
-    # fresh data, so it takes over immediately.
+    # Just past the normal stale window: the far weaker scanner must NOT
+    # steal ownership on a single missed interval.
     inject_advertisement_with_time_and_source(
         weak,
         weak_adv,
         start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
         HCI1_SOURCE_ADDRESS,
     )
+    assert get_manager().async_ble_device_from_address(address, True) is strong
+    # Past durably-gone: the weak scanner finally takes over.
+    inject_advertisement_with_time_and_source(
+        weak, weak_adv, start + 40, HCI1_SOURCE_ADDRESS
+    )
     assert get_manager().async_ble_device_from_address(address, True) is weak
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+@pytest.mark.parametrize("debug", [True, False])
 async def test_stale_passive_strong_owner_yields_to_comparable_scanner(
     register_hci0_scanner: None,
     register_hci1_scanner: None,
+    debug: bool,
 ) -> None:
     """A passive strong owner yields to a comparable scanner at the stale window."""
     address = "44:44:33:11:23:61"
     start = 50.0
+    get_manager()._debug = debug
     strong = generate_ble_device(address, "strong_hci0")
     strong_adv = generate_advertisement_data(
         local_name="strong_hci0", service_uuids=[], rssi=-50
@@ -1599,12 +1607,12 @@ async def test_stale_active_need_active_challenger_switches_immediately(
     debug: bool,
 ) -> None:
     """
-    A challenger on a continuously ACTIVE scanner hands off without a rescue.
+    A comparable ACTIVE-scanner challenger hands off without a rescue.
 
     Its capture already carries the device's scan response, so there is
     nothing for a rescue window to add; the stale handoff proceeds
-    immediately, like a passive device. Runs with debug logging both on
-    and off to cover both sides of the logging branch.
+    immediately. Runs with debug logging both on and off to cover both
+    sides of the logging branch.
     """
     manager = get_manager()
     manager._debug = debug
@@ -1646,6 +1654,63 @@ async def test_stale_active_need_active_challenger_switches_immediately(
     assert address not in manager._rescue_triggered
     cancel_active()
     cancel_scanner()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
+async def test_stale_active_need_weaker_active_challenger_defers() -> None:
+    """
+    A materially weaker ACTIVE challenger defers instead of stealing.
+
+    Its side of the rescue counts as covered immediately, so it wins on
+    its next advertisement only if the owner stays silent; the owner being
+    heard again keeps the device where it is.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:75"
+    cancel_active = manager.async_register_active_scan(address)
+    owner_scanner = FakeScanner("AA:BB:CC:DD:EE:99", "hci9")
+    owner_scanner.connectable = True
+    active_scanner = FakeScanner(
+        "AA:BB:CC:DD:EE:AA",
+        "hci10",
+        requested_mode=BluetoothScanningMode.ACTIVE,
+    )
+    active_scanner.connectable = True
+    cancel_owner = manager.async_register_scanner(owner_scanner, connection_slots=5)
+    cancel_challenger = manager.async_register_scanner(
+        active_scanner, connection_slots=5
+    )
+    now = monotonic_time_coarse()
+    strong = generate_ble_device(address, "strong_hci9")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci9", service_uuids=[], rssi=-50
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, now - 16, "AA:BB:CC:DD:EE:99"
+    )
+    # stale_seconds = 15, durably-gone = 37.5
+    manager.async_set_fallback_availability_interval(address, 10)
+
+    weak = generate_ble_device(address, "weak_hci10")
+    weak_adv = generate_advertisement_data(
+        local_name="weak_hci10", service_uuids=[], rssi=-90
+    )
+    # Far weaker ACTIVE challenger just past the stale window: deferred,
+    # its rescue side counts as covered now.
+    inject_advertisement_with_time_and_source(weak, weak_adv, now, "AA:BB:CC:DD:EE:AA")
+    assert manager.async_ble_device_from_address(address, True) is strong
+    assert manager._rescue_triggered[address] == now
+    assert manager._auto_scheduler._rescue_accept_after[address] >= now - 1
+    # Its next advertisement wins because the owner stayed silent.
+    inject_advertisement_with_time_and_source(
+        weak, weak_adv, now + 2, "AA:BB:CC:DD:EE:AA"
+    )
+    assert manager.async_ble_device_from_address(address, True) is weak
+    assert address not in manager._rescue_triggered
+    cancel_active()
+    cancel_owner()
+    cancel_challenger()
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -2124,6 +2124,45 @@ async def test_rescue_accept_time_boundaries(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.asyncio
+async def test_passive_stale_arbitration_clears_orphaned_episode(
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
+    """
+    A device that lost its active-scan need drops its episode on arbitration.
+
+    The orphaned entry must not linger; it would keep the scheduler's
+    no-episode fast path off for every window dispatch.
+    """
+    manager = get_manager()
+    address = "44:44:33:11:23:76"
+    start = 50.0
+    strong = generate_ble_device(address, "strong_hci0")
+    strong_adv = generate_advertisement_data(
+        local_name="strong_hci0", service_uuids=[], rssi=-50
+    )
+    inject_advertisement_with_time_and_source(
+        strong, strong_adv, start, HCI0_SOURCE_ADDRESS
+    )
+    manager.async_set_fallback_availability_interval(address, 10)
+    # Episode left behind by an active-scan need that was since unregistered.
+    manager._rescue_triggered[address] = start
+
+    weak = generate_ble_device(address, "weak_hci1")
+    weak_adv = generate_advertisement_data(
+        local_name="weak_hci1", service_uuids=[], rssi=-90
+    )
+    # Weaker passive challenger past stale: kept, and the orphaned
+    # episode is cleaned up.
+    inject_advertisement_with_time_and_source(
+        weak, weak_adv, start + 16, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is strong
+    assert address not in manager._rescue_triggered
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.asyncio
 async def test_clear_advertisement_history_clears_rescue_state(
     register_hci0_scanner: None,
     register_hci1_scanner: None,


### PR DESCRIPTION
Field data from a dev instance running 6.26.3 showed the immediate stale handoffs flapping ownership: in two minutes there were 15 passive stale steals, some exceeding the stale threshold by as little as 11ms, all by materially weaker scanners (for example -97.7 stealing from -79.8) that happened to catch the one advertisement the owner missed; the strong owner then re-heard the device within seconds and reclaimed on the RSSI path, cycling every ~10s per device. The stale path ignores the reclaim deadband, so the hysteresis never damps this. Comparable band challengers have the mirrored problem; they cannot be reclaimed on the RSSI path at all, so a stale steal ping-pongs on alternating missed intervals, the stationary device flap #568 and #580 fixed.

This removes the two immediate stale handoff fast paths #592 added (passive newer capture wins, ACTIVE challenger wins) and restructures the stale decision per device class. An owner silent past the durably gone threshold loses to any challenger, unconditionally. Short of that, a passive device keeps the pre #591 roaming rule, a comparable or stronger challenger of a weak owner switches instantly and anything else waits for durably gone; payloads are identical across scanners so waiting costs nothing. An active need device never takes the roaming shortcut on the all history decision, even a comparable challenger may be an AUTO scanner sitting in its passive phase whose capture carries no fresh scan response (the issue #568 stale capture class); every handoff before durably gone goes through the rescue flow from #592, so it lands on a capture from an address a recent active window covered. The connectable re check keeps the ordinary roaming rule for every device class; connection routing cares about liveness, not scan response freshness, so the connectable history still repoints away from a silent scanner at the stale window.

Rescue scans only ever start on AUTO scanners. The owner side is always served (an AUTO owner gets its window, an ACTIVE owner counts as covered); a challenger that is already actively scanning needs no window, its side just records coverage. Accept times uniformly sit RESCUE_SCAN_ACCEPT_SECONDS after coverage, single sourced inside the recording helper, and the handoff additionally requires one full advertising interval since the trigger: the 5s grace alone guarantees nothing for a slow advertiser that cannot re-transmit within it, so the interval requirement is what makes the owner re-hear guarantee real for every cadence and removes the race where owner and challenger both hear the next advertisement. The retry only restarts an episode whose window never materialized; a recorded accept means the episode is just waiting out the gates, and in practice the rescue accelerates handoffs for advertisers faster than roughly the retry interval while the durably gone backstop governs slower ones. A rescue episode's lifetime is bounded by the active scan need: unregistering it clears the episode, so a device that never goes stale again cannot keep the scheduler's no episode fast path disabled forever.

The smoothing from #584, the reclaim deadband from #585 and #589, and the strong owner damping from #580 are untouched and continue to apply to all device classes.

Follow up to #592, relates to #591.
