### PR TITLE
fix(manager): require one and a half stale windows before a roam handoff

### DIFF
--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -47,6 +47,20 @@ CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS: Final = 195
 # device that genuinely moved into weak-only coverage hand off.
 DURABLY_GONE_STALE_FACTOR: Final = 2.5
 
+# How many stale windows must elapse before the roaming rule (a
+# comparable-or-stronger challenger of a weak owner) may take a stale
+# device. Scanners duty-cycle their scan windows, so "the owner missed
+# an advertisement" is a per-scanner reception lottery, not evidence
+# the device moved; on a stationary network the first missed interval
+# routinely parks ownership on a weak scanner that the strong owner
+# then reclaims on the RSSI path, churning ownership with no data
+# benefit. Requiring one and a half stale windows means the owner must
+# effectively miss two reception opportunities before a roam, while a
+# genuinely departed device still roams well before the durably-gone
+# backstop (must stay below DURABLY_GONE_STALE_FACTOR or the roaming
+# rule can never fire).
+STALE_ROAM_FACTOR: Final = 1.5
+
 # An owner whose last advertisement was at least this strong is treated as
 # close/stationary: a brief reception gap is almost certainly RF/scan-response
 # jitter rather than the device leaving, so a merely-comparable challenger

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -14,6 +14,7 @@ cdef int _STRONG_OWNER_STALE_RSSI
 cdef double _RSSI_SMOOTHING_FACTOR
 cdef int _ADV_RSSI_SWITCH_DEADBAND
 cdef double _RESCUE_SCAN_RETRY_SECONDS
+cdef double _STALE_ROAM_FACTOR
 cdef frozenset _EMPTY_DEMOTED
 cdef object FILTER_UUIDS
 cdef object AdvertisementData
@@ -102,11 +103,7 @@ cdef class BluetoothManager:
         bint record_demotion
     )
 
-    @cython.locals(
-        durably_gone=double,
-        comparable_or_stronger=bint,
-        owner_strong=bint,
-    )
+    @cython.locals(durably_gone=double)
     cdef bint _stale_challenger_wins(
         self,
         BluetoothServiceInfoBleak old,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -46,6 +46,7 @@ from .const import (
     MIN_ACTIVE_SCAN_INTERVAL,
     RESCUE_SCAN_RETRY_SECONDS,
     RSSI_SMOOTHING_FACTOR,
+    STALE_ROAM_FACTOR,
     STRONG_OWNER_STALE_RSSI,
     UNAVAILABLE_TRACK_SECONDS,
 )
@@ -94,6 +95,7 @@ _STRONG_OWNER_STALE_RSSI = STRONG_OWNER_STALE_RSSI
 _RSSI_SMOOTHING_FACTOR = RSSI_SMOOTHING_FACTOR
 _ADV_RSSI_SWITCH_DEADBAND = ADV_RSSI_SWITCH_DEADBAND
 _RESCUE_SCAN_RETRY_SECONDS = RESCUE_SCAN_RETRY_SECONDS
+_STALE_ROAM_FACTOR = STALE_ROAM_FACTOR
 
 # Shared empty set used as the default for the reclaim-hysteresis lookup, so the
 # hot path skips a None check and never allocates a throwaway set.
@@ -709,10 +711,13 @@ class BluetoothManager:
         not); what differs per device class is everything in between:
 
         * Passive device (no registered need): a comparable-or-stronger
-          challenger of a weak owner takes over immediately (ordinary
-          roaming; payloads are identical across scanners, so its capture
-          is as good as anyone's). Anything else waits for durably-gone,
-          which costs nothing data-wise for the same reason.
+          challenger of a weak owner takes over once the owner has been
+          silent STALE_ROAM_FACTOR stale windows (ordinary roaming;
+          payloads are identical across scanners, so its capture is as
+          good as anyone's, and the extra half window keeps a per-scanner
+          reception miss from roaming a stationary device). Anything else
+          waits for durably-gone, which costs nothing data-wise for the
+          same reason.
         * Active-need device: there is no roaming shortcut at all — even a
           comparable challenger of a weak owner may be an AUTO scanner in
           its passive phase whose capture carries no fresh scan response
@@ -756,27 +761,33 @@ class BluetoothManager:
             return True
         if self._auto_scheduler._requests_by_address.get(new.address) is None:
             # Passive device: a comparable-or-stronger challenger of a weak
-            # owner takes over immediately (ordinary roaming; its capture
-            # is as good as anyone's, payloads are identical across
-            # scanners). Anything else waits for durably-gone above. The
-            # episode ends either way; it also cleans up after an
+            # owner takes over once the owner has been silent for
+            # STALE_ROAM_FACTOR stale windows (its capture is as good as
+            # anyone's, payloads are identical across scanners). The extra
+            # half window over plain stale means the owner must miss two
+            # reception opportunities, not one, before roaming; a single
+            # miss is a per-scanner duty-cycle lottery, not evidence the
+            # device moved. Anything else waits for durably-gone above.
+            # The episode ends either way; it also cleans up after an
             # active-scan need unregistered mid-episode (defense in depth,
             # the unregister itself clears it too).
             self._end_rescue_episode(new.address, record_demotion)
-            comparable_or_stronger = new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
-            owner_strong = old_rssi >= _STRONG_OWNER_STALE_RSSI
-            if comparable_or_stronger and not owner_strong:
+            if (
+                elapsed > stale_seconds * _STALE_ROAM_FACTOR
+                and new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
+                and old_rssi < _STRONG_OWNER_STALE_RSSI
+            ):
                 if self._debug:
                     _LOGGER.debug(
                         "%s (%s): Switching from %s to %s (time elapsed:%s >"
-                        " stale seconds:%s; passive roaming, comparable"
+                        " roam threshold:%s; passive roaming, comparable"
                         " challenger of a weak owner)",
                         new.name,
                         new.address,
                         self._async_describe_source(old),
                         self._async_describe_source(new),
                         elapsed,
-                        stale_seconds,
+                        stale_seconds * _STALE_ROAM_FACTOR,
                     )
                 return True
             return False
@@ -784,12 +795,13 @@ class BluetoothManager:
             # Connectable re-check: connection routing cares about
             # liveness, not scan-response freshness, so the ordinary
             # roaming rule applies here exactly as it does for a passive
-            # device; the connectable history must repoint away from a
-            # silent scanner at the stale window rather than route a
-            # connect attempt at a dead radio until durably-gone. Only
-            # the all-history decision drives episode state.
+            # device (same STALE_ROAM_FACTOR gate); the connectable
+            # history must repoint away from a silent scanner well before
+            # durably-gone rather than route a connect attempt at a dead
+            # radio. Only the all-history decision drives episode state.
             return (
-                new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
+                elapsed > stale_seconds * _STALE_ROAM_FACTOR
+                and new_rssi >= old_rssi - ADV_RSSI_SWITCH_THRESHOLD
                 and old_rssi < _STRONG_OWNER_STALE_RSSI
             )
         # Active-need all-history decision: never take the roaming

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1096,9 +1096,20 @@ async def test_switching_adapters_based_on_stale_with_discovered_interval(
         start_time_monotonic + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
         HCI1_SOURCE_ADDRESS,
     )
-    # Should switch to hci1 since the previous advertisement is stale
-    # even though the signal is poor because the device is now
-    # likely unreachable via hci0
+    # One missed interval is a per-scanner reception lottery: still hci0.
+    assert (
+        get_manager().async_ble_device_from_address(address, True)
+        is switchbot_device_poor_signal_hci0
+    )
+    inject_advertisement_with_time_and_source(
+        switchbot_device_poor_signal_hci1,
+        switchbot_adv_poor_signal_hci1,
+        start_time_monotonic + 23,
+        HCI1_SOURCE_ADDRESS,
+    )
+    # Past the roam gate (1.5 stale windows): switch to hci1 since the
+    # previous advertisement is stale even though the signal is poor
+    # because the device is now likely unreachable via hci0
     assert (
         get_manager().async_ble_device_from_address(address, True)
         is switchbot_device_poor_signal_hci1
@@ -1199,13 +1210,15 @@ async def test_stale_switches_to_comparable_scanner_at_normal_window(
     debug: bool,
 ) -> None:
     """
-    A comparable scanner takes over a weak passive owner at the stale window.
+    A comparable scanner takes over a weak passive owner after the roam gate.
 
     The owner is weak (below STRONG_OWNER_STALE_RSSI), so its silence is
-    treated as the device possibly being gone and a comparable scanner is
-    allowed to take over at the normal window. A strong owner is protected
-    (see test_stale_keeps_strong_owner_against_comparable_scanner). Runs
-    with debug logging both on and off to cover the log branches.
+    treated as the device possibly being gone, but a single missed
+    interval is a per-scanner reception lottery; the comparable scanner
+    may only take over once STALE_ROAM_FACTOR stale windows elapsed. A
+    strong owner is protected regardless (see
+    test_stale_keeps_strong_owner_against_comparable_scanner). Runs with
+    debug logging both on and off to cover the log branches.
     """
     address = "44:44:33:11:23:44"
     start = 50.0
@@ -1219,7 +1232,8 @@ async def test_stale_switches_to_comparable_scanner_at_normal_window(
     )
     get_manager().async_set_fallback_availability_interval(address, 10)
 
-    # Weak owner, comparable challenger: ordinary handoff at the normal window.
+    # Weak owner, comparable challenger: kept on a single missed interval
+    # (a per-scanner reception miss must not roam a stationary device).
     comparable = generate_ble_device(address, "comparable_hci1")
     comparable_adv = generate_advertisement_data(
         local_name="comparable_hci1", service_uuids=[], rssi=-95
@@ -1229,6 +1243,12 @@ async def test_stale_switches_to_comparable_scanner_at_normal_window(
         comparable_adv,
         start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
         HCI1_SOURCE_ADDRESS,
+    )
+    assert get_manager().async_ble_device_from_address(address, True) is owner
+    # Past STALE_ROAM_FACTOR stale windows (1.5 * 15 = 22.5): the ordinary
+    # roaming handoff proceeds.
+    inject_advertisement_with_time_and_source(
+        comparable, comparable_adv, start + 23, HCI1_SOURCE_ADDRESS
     )
     assert get_manager().async_ble_device_from_address(address, True) is comparable
 
@@ -2179,15 +2199,21 @@ async def test_connectable_recheck_roams_active_need_device_at_stale(
         nc_device, nc_adv, start + 10, NON_CONNECTABLE_REMOTE_SOURCE_ADDRESS, False
     )
     assert manager.async_ble_device_from_address(address, True) is connectable_owner
-    # A comparable connectable challenger of the weak, now-stale owner:
-    # all-history keeps (fresh strong NC owner), but the connectable
-    # re-check roams to the live challenger.
+    # A comparable connectable challenger of the weak owner within the
+    # roam gate: the connectable history is kept (single reception miss).
     challenger = generate_ble_device(address, "challenger_hci1")
     challenger_adv = generate_advertisement_data(
         local_name="challenger_hci1", service_uuids=[], rssi=-85
     )
     inject_advertisement_with_time_and_source(
         challenger, challenger_adv, start + 17, HCI1_SOURCE_ADDRESS
+    )
+    assert manager.async_ble_device_from_address(address, True) is connectable_owner
+    # Past the roam gate (1.5 * 15 = 22.5 since the connectable owner's
+    # last adv): all-history keeps (fresh strong NC owner), but the
+    # connectable re-check roams to the live challenger.
+    inject_advertisement_with_time_and_source(
+        challenger, challenger_adv, start + 24, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, False) is nc_device
     assert manager.async_ble_device_from_address(address, True) is challenger
@@ -2864,17 +2890,14 @@ async def test_rssi_deadband_not_charged_after_stale_handoff(
     )
     manager.async_set_fallback_availability_interval(address, 10)
 
-    # Weak owner goes silent; a comparable (weaker) scanner takes over on the
-    # stale path, not the active RSSI path.
+    # Weak owner goes silent; a comparable (weaker) scanner takes over on
+    # the stale path once the roam gate elapsed, not the active RSSI path.
     comparable = generate_ble_device(address, "comparable_hci1")
     comparable_adv = generate_advertisement_data(
         local_name="comparable_hci1", service_uuids=[], rssi=-95
     )
     inject_advertisement_with_time_and_source(
-        comparable,
-        comparable_adv,
-        start + 10 + TRACKER_BUFFERING_WOBBLE_SECONDS + 1,
-        HCI1_SOURCE_ADDRESS,
+        comparable, comparable_adv, start + 23, HCI1_SOURCE_ADDRESS
     )
     assert manager.async_ble_device_from_address(address, True) is comparable
     # The stale handoff is not an RSSI-path switch, so no reclaim penalty is set.

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1127,9 +1127,10 @@ async def test_stale_does_not_switch_to_much_weaker_scanner(
 
     Regression for #568: scan-response-only sensors behind many active proxies
     oscillated because a weaker proxy holding a stale capture won the receive-time
-    staleness check on a single missed interval. The damping only applies to
-    devices with a registered active-scan need; a passive device hands off on
-    stale immediately (see test_stale_passive_device_switches_to_weaker_scanner).
+    staleness check on a single missed interval. This device has a registered
+    active-scan need, so the rescue flow governs; a materially weaker passive
+    challenger instead waits for durably-gone (see
+    test_stale_passive_weaker_scanner_waits_for_durably_gone).
     """
     address = "44:44:33:11:23:42"
     start = 50.0


### PR DESCRIPTION
Field data from a fully stationary network on 6.26.4 showed the remaining ownership churn is driven by a per scanner reception lottery, not device movement. Scanners duty cycle their scan windows, so each proxy only catches a fraction of a device's advertisements; "the owner missed an interval" is a per scanner event, and on the first miss the roaming rule parked ownership on a weak scanner that the strong owner then reclaimed on the RSSI path. Most of the observed RSSI path switches were these recoveries; the switch logs consistently show a strong winner reclaiming from a much weaker owner that had just acquired the device on the stale path.

The roaming rule (a comparable or stronger challenger of a weak owner) now requires the owner to have been silent for STALE_ROAM_FACTOR (1.5) stale windows instead of one, so the owner must effectively miss two reception opportunities before a roam. A genuinely departed device still roams at one and a half intervals, well before the durably gone backstop, which stays at DURABLY_GONE_STALE_FACTOR (2.5) unchanged. The same gate applies to the connectable re check so connection routing still repoints away from a silent scanner ahead of durably gone. Active need devices are untouched; they keep the rescue flow and never take the roaming shortcut.

Note for the next core bump: the bluetooth manager tests in Home Assistant that assert a stale handoff at one stale window (test_switching_adapters_based_on_stale variants) will need their switch timings moved past the 1.5x gate, mirroring the test updates here.

Follow up to #593, relates to #591.
