### PR TITLE
fix: notify allocation callbacks when a scanner is unregistered

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1925,7 +1925,10 @@ class BluetoothManager:
         dispatched so subscribers stop rendering its stale addresses;
         ``HaScannerRegistrationEvent.REMOVED`` on
         ``async_register_scanner_registration_callback`` disambiguates
-        removal from an empty but present scanner.
+        removal from an empty but present scanner. Registration seeds a
+        zeroed entry without dispatching: it is visible immediately via
+        ``async_current_allocations`` and the first callback fires when
+        slot information is actually reported.
         """
         self._allocations_callbacks.setdefault(source, set()).add(callback)
         return partial(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -121,6 +121,11 @@ def _dispatch_bleak_callback(
         _LOGGER.exception("Error in callback: %s", bleak_callback.callback)
 
 
+def _zeroed_allocations(source: str) -> HaBluetoothSlotAllocations:
+    """Return an empty allocations snapshot for a source."""
+    return HaBluetoothSlotAllocations(source=source, slots=0, free=0, allocated=[])
+
+
 class BleakCallback:
     """Bleak callback."""
 
@@ -1627,7 +1632,7 @@ class BluetoothManager:
         for address in emptied_demoted:
             del self._demoted_sources[address]
         self._adapter_sources.pop(scanner.adapter, None)
-        self._allocations.pop(scanner.source, None)
+        self._async_clear_allocations(source)
         if connection_slots:
             self.slot_manager.remove_adapter(scanner.adapter)
         if (idx := scanner.adapter_idx) is not None:
@@ -1646,9 +1651,10 @@ class BluetoothManager:
             scanners = self._connectable_scanners
         else:
             scanners = self._non_connectable_scanners
-            self._allocations[scanner.source] = HaBluetoothSlotAllocations(
-                source=scanner.source, slots=0, free=0, allocated=[]
-            )
+        # Seed zeroed allocations so the source is visible immediately,
+        # unless an allocation push already arrived before registration.
+        if scanner.source not in self._allocations:
+            self._allocations[scanner.source] = _zeroed_allocations(scanner.source)
         scanners.add(scanner)
         scanner._clear_connection_history()
         self._sources[scanner.source] = scanner
@@ -1823,6 +1829,22 @@ class BluetoothManager:
                 except Exception:  # pylint: disable=broad-except
                     _LOGGER.exception("Error in %s", label)
 
+    def _async_clear_allocations(self, source: str) -> None:
+        """
+        Drop stored allocations for a source and notify subscribers.
+
+        Dispatches a zeroed allocation so subscribers stop rendering the
+        removed source's stale addresses.
+        """
+        if self._allocations.pop(source, None) is None:
+            return
+        self._dispatch_source_callbacks(
+            self._allocations_callbacks,
+            source,
+            _zeroed_allocations(source),
+            "allocation callback",
+        )
+
     def async_on_allocation_changed(self, allocations: Allocations) -> None:
         """Call allocation callbacks."""
         source = self._adapter_sources.get(allocations.adapter, allocations.adapter)
@@ -1866,7 +1888,16 @@ class BluetoothManager:
         callback: Callable[[HaBluetoothSlotAllocations], None],
         source: str | None = None,
     ) -> CALLBACK_TYPE:
-        """Register a callback to be called when an allocations change."""
+        """
+        Register a callback to be called when an allocations change.
+
+        When a source's scanner is unregistered, a zeroed
+        ``HaBluetoothSlotAllocations`` (slots=0, free=0, allocated=[]) is
+        dispatched so subscribers stop rendering its stale addresses;
+        ``HaScannerRegistrationEvent.REMOVED`` on
+        ``async_register_scanner_registration_callback`` disambiguates
+        removal from an empty but present scanner.
+        """
         self._allocations_callbacks.setdefault(source, set()).add(callback)
         return partial(
             self._unregister_source_callback,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -122,7 +122,14 @@ def _dispatch_bleak_callback(
 
 
 def _zeroed_allocations(source: str) -> HaBluetoothSlotAllocations:
-    """Return an empty allocations snapshot for a source."""
+    """
+    Return an empty allocations snapshot for a source.
+
+    ``slots=0`` is the established sentinel for "no slot information
+    reported": non-connectable scanners have always been seeded with it,
+    and every consumer that reasons about exhaustion filters on
+    ``slots > 0``.
+    """
     return HaBluetoothSlotAllocations(source=source, slots=0, free=0, allocated=[])
 
 
@@ -1892,7 +1899,13 @@ class BluetoothManager:
     def async_current_allocations(
         self, source: str | None = None
     ) -> list[HaBluetoothSlotAllocations] | None:
-        """Return the current allocations."""
+        """
+        Return the current allocations.
+
+        An entry with ``slots=0`` means the source has not reported slot
+        information (yet), not that its slots are exhausted; consumers
+        should filter on ``slots > 0`` before reasoning about exhaustion.
+        """
         if source:
             if allocations := self._allocations.get(source):
                 return [allocations]

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1647,6 +1647,20 @@ class BluetoothManager:
     ) -> CALLBACK_TYPE:
         """Register a new scanner."""
         _LOGGER.debug("Registering scanner %s", scanner.name)
+        if (existing := self._sources.get(scanner.source)) is not None:
+            # Always a caller bug: the source map is last writer wins and
+            # the first unregister removes the live scanner, so the two
+            # cannot coexist. Log loudly rather than raise so a scanner
+            # setup path is not aborted in production for it.
+            _LOGGER.error(
+                "Scanner %s is being registered with source %s which is "
+                "already registered by scanner %s; a source must be unique "
+                "per registered scanner and the previous registration "
+                "should be cancelled first",
+                scanner.name,
+                scanner.source,
+                existing.name,
+            )
         if scanner.connectable:
             scanners = self._connectable_scanners
         else:

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1834,10 +1834,10 @@ class BluetoothManager:
         Drop stored allocations for a source and notify subscribers.
 
         Dispatches a zeroed allocation so subscribers stop rendering the
-        removed source's stale addresses.
+        removed source's stale addresses. Every registered scanner has an
+        entry (seeded at registration), so there is always one to drop.
         """
-        if self._allocations.pop(source, None) is None:
-            return
+        del self._allocations[source]
         self._dispatch_source_callbacks(
             self._allocations_callbacks,
             source,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1834,10 +1834,12 @@ class BluetoothManager:
         Drop stored allocations for a source and notify subscribers.
 
         Dispatches a zeroed allocation so subscribers stop rendering the
-        removed source's stale addresses. Every registered scanner has an
-        entry (seeded at registration), so there is always one to drop.
+        removed source's stale addresses. Tolerates a missing entry (two
+        scanners sharing a source, the first unregister already cleared
+        it) so teardown is never aborted midway; the zeroed dispatch is
+        still sent so subscribers converge either way.
         """
-        del self._allocations[source]
+        self._allocations.pop(source, None)
         self._dispatch_source_callbacks(
             self._allocations_callbacks,
             source,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -751,6 +751,36 @@ async def test_async_reregister_scanner_reseeds_zeroed_allocations() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_unregister_duplicate_source_completes_teardown() -> None:
+    """
+    Unregistering the second of two scanners sharing a source must not abort.
+
+    The first unregister already cleared the shared allocations entry; the
+    second must still run the rest of the teardown, including the REMOVED
+    registration event, rather than raising midway.
+    """
+    manager = get_manager()
+    scanner_a = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    scanner_a.connectable = True
+    scanner_b = FakeScanner("AA:BB:CC:DD:EE:33", "hci4")
+    scanner_b.connectable = True
+    cancel_a = manager.async_register_scanner(scanner_a)
+    cancel_b = manager.async_register_scanner(scanner_b)
+    events: list[HaScannerRegistration] = []
+    cancel_callback = manager.async_register_scanner_registration_callback(
+        events.append, None
+    )
+    cancel_a()
+    cancel_b()
+    assert [event.event for event in events] == [
+        HaScannerRegistrationEvent.REMOVED,
+        HaScannerRegistrationEvent.REMOVED,
+    ]
+    assert manager.async_current_allocations(scanner_a.source) == []
+    cancel_callback()
+
+
+@pytest.mark.asyncio
 async def test_async_unregister_scanner_notifies_zeroed_allocations() -> None:
     """Unregistering a scanner notifies subscribers with zeroed allocations."""
     manager = get_manager()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -730,7 +730,9 @@ async def test_async_register_scanner_preserves_pre_registration_allocations() -
 
 
 @pytest.mark.asyncio
-async def test_async_reregister_scanner_reseeds_zeroed_allocations() -> None:
+async def test_async_reregister_scanner_reseeds_zeroed_allocations(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """A register, unregister, re-register round-trip clears stale allocations."""
     manager = get_manager()
     hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
@@ -742,8 +744,12 @@ async def test_async_reregister_scanner_reseeds_zeroed_allocations() -> None:
     cancel()
     assert manager.async_current_allocations(hci3_scanner.source) == []
     # A reconnecting proxy re-registers under the same source and must
-    # start from a clean slate rather than the previous session's list.
-    cancel = manager.async_register_scanner(hci3_scanner)
+    # start from a clean slate rather than the previous session's list;
+    # since the previous registration was cancelled first this is not a
+    # duplicate and must not log the duplicate source error.
+    with caplog.at_level(logging.ERROR):
+        cancel = manager.async_register_scanner(hci3_scanner)
+    assert "already registered" not in caplog.text
     assert manager.async_current_allocations(hci3_scanner.source) == [
         HaBluetoothSlotAllocations(hci3_scanner.source, 0, 0, [])
     ]
@@ -751,21 +757,27 @@ async def test_async_reregister_scanner_reseeds_zeroed_allocations() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_unregister_duplicate_source_completes_teardown() -> None:
+async def test_async_unregister_duplicate_source_completes_teardown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
-    Unregistering the second of two scanners sharing a source must not abort.
+    Registering a duplicate source is a caller bug and is logged loudly.
 
-    The first unregister already cleared the shared allocations entry; the
-    second must still run the rest of the teardown, including the REMOVED
-    registration event, rather than raising midway.
+    Unregistering the second of two scanners sharing a source must still
+    not abort: the first unregister already cleared the shared allocations
+    entry, so the second must run the rest of the teardown, including the
+    REMOVED registration event, rather than raising midway.
     """
     manager = get_manager()
     scanner_a = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
     scanner_a.connectable = True
     scanner_b = FakeScanner("AA:BB:CC:DD:EE:33", "hci4")
     scanner_b.connectable = True
-    cancel_a = manager.async_register_scanner(scanner_a)
-    cancel_b = manager.async_register_scanner(scanner_b)
+    with caplog.at_level(logging.ERROR):
+        cancel_a = manager.async_register_scanner(scanner_a)
+        assert "already registered" not in caplog.text
+        cancel_b = manager.async_register_scanner(scanner_b)
+    assert "already registered by scanner hci3" in caplog.text
     events: list[HaScannerRegistration] = []
     cancel_callback = manager.async_register_scanner_registration_callback(
         events.append, None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -730,6 +730,19 @@ async def test_async_register_scanner_preserves_pre_registration_allocations() -
 
 
 @pytest.mark.asyncio
+async def test_async_clear_allocations_without_entry_is_noop() -> None:
+    """Clearing a source with no stored allocations dispatches nothing."""
+    manager = get_manager()
+    allocations: list[HaBluetoothSlotAllocations] = []
+    cancel_callback = manager.async_register_allocation_callback(
+        allocations.append, "not-a-real-source"
+    )
+    manager._async_clear_allocations("not-a-real-source")
+    assert allocations == []
+    cancel_callback()
+
+
+@pytest.mark.asyncio
 async def test_async_unregister_scanner_notifies_zeroed_allocations() -> None:
     """Unregistering a scanner notifies subscribers with zeroed allocations."""
     manager = get_manager()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -730,16 +730,24 @@ async def test_async_register_scanner_preserves_pre_registration_allocations() -
 
 
 @pytest.mark.asyncio
-async def test_async_clear_allocations_without_entry_is_noop() -> None:
-    """Clearing a source with no stored allocations dispatches nothing."""
+async def test_async_reregister_scanner_reseeds_zeroed_allocations() -> None:
+    """A register, unregister, re-register round-trip clears stale allocations."""
     manager = get_manager()
-    allocations: list[HaBluetoothSlotAllocations] = []
-    cancel_callback = manager.async_register_allocation_callback(
-        allocations.append, "not-a-real-source"
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    hci3_scanner.connectable = True
+    cancel = manager.async_register_scanner(hci3_scanner)
+    manager.async_on_allocation_changed(
+        Allocations("AA:BB:CC:DD:EE:33", 3, 2, ["44:44:33:11:23:12"])
     )
-    manager._async_clear_allocations("not-a-real-source")
-    assert allocations == []
-    cancel_callback()
+    cancel()
+    assert manager.async_current_allocations(hci3_scanner.source) == []
+    # A reconnecting proxy re-registers under the same source and must
+    # start from a clean slate rather than the previous session's list.
+    cancel = manager.async_register_scanner(hci3_scanner)
+    assert manager.async_current_allocations(hci3_scanner.source) == [
+        HaBluetoothSlotAllocations(hci3_scanner.source, 0, 0, [])
+    ]
+    cancel()
 
 
 @pytest.mark.asyncio
@@ -756,10 +764,19 @@ async def test_async_unregister_scanner_notifies_zeroed_allocations() -> None:
     cancel_callback = manager.async_register_allocation_callback(
         allocations.append, hci3_scanner.source
     )
+    # Home Assistant's websocket subscribes globally (source=None) by
+    # default; it must receive the zeroed payload as well.
+    global_allocations: list[HaBluetoothSlotAllocations] = []
+    cancel_global_callback = manager.async_register_allocation_callback(
+        global_allocations.append
+    )
     cancel()
-    assert allocations == [HaBluetoothSlotAllocations(hci3_scanner.source, 0, 0, [])]
+    zeroed = HaBluetoothSlotAllocations(hci3_scanner.source, 0, 0, [])
+    assert allocations == [zeroed]
+    assert global_allocations == [zeroed]
     assert manager.async_current_allocations(hci3_scanner.source) == []
     cancel_callback()
+    cancel_global_callback()
 
 
 @pytest.mark.asyncio

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -701,6 +701,55 @@ async def test_async_register_scanner_with_connection_slots() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_register_connectable_scanner_seeds_allocations() -> None:
+    """Registering a connectable scanner seeds a zeroed allocations entry."""
+    manager = get_manager()
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    hci3_scanner.connectable = True
+    cancel = manager.async_register_scanner(hci3_scanner)
+    assert manager.async_current_allocations(hci3_scanner.source) == [
+        HaBluetoothSlotAllocations(hci3_scanner.source, 0, 0, [])
+    ]
+    cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_register_scanner_preserves_pre_registration_allocations() -> None:
+    """An allocation push that arrives before registration is preserved."""
+    manager = get_manager()
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    hci3_scanner.connectable = True
+    manager.async_on_allocation_changed(
+        Allocations("AA:BB:CC:DD:EE:33", 3, 2, ["44:44:33:11:23:12"])
+    )
+    cancel = manager.async_register_scanner(hci3_scanner)
+    assert manager.async_current_allocations(hci3_scanner.source) == [
+        HaBluetoothSlotAllocations("AA:BB:CC:DD:EE:33", 3, 2, ["44:44:33:11:23:12"])
+    ]
+    cancel()
+
+
+@pytest.mark.asyncio
+async def test_async_unregister_scanner_notifies_zeroed_allocations() -> None:
+    """Unregistering a scanner notifies subscribers with zeroed allocations."""
+    manager = get_manager()
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    hci3_scanner.connectable = True
+    cancel = manager.async_register_scanner(hci3_scanner)
+    manager.async_on_allocation_changed(
+        Allocations("AA:BB:CC:DD:EE:33", 3, 2, ["44:44:33:11:23:12"])
+    )
+    allocations: list[HaBluetoothSlotAllocations] = []
+    cancel_callback = manager.async_register_allocation_callback(
+        allocations.append, hci3_scanner.source
+    )
+    cancel()
+    assert allocations == [HaBluetoothSlotAllocations(hci3_scanner.source, 0, 0, [])]
+    assert manager.async_current_allocations(hci3_scanner.source) == []
+    cancel_callback()
+
+
+@pytest.mark.asyncio
 async def test_async_unregister_scanner_is_idempotent(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Unregistering a scanner popped its entry from the allocations map silently, so websocket subscribers kept rendering the removed scanner's last known allocated addresses forever; connectable scanners also had no allocations entry at all until the first firmware push, which made a reconnected proxy show stale or missing state. Part of the confusing diagnostics in home-assistant/core#176516.

Unregister now drops the entry and dispatches a zeroed allocations snapshot to subscribers, so a reentrant read from inside a callback already sees it gone, and registration seeds a zeroed entry for every scanner, visible via the pull API immediately with the first callback firing when slot information is actually reported, preserving a push that legitimately arrived before registration since bleak-esphome subscribes to slot updates before the scanner is registered. A slots value of zero remains the established sentinel for no slot information reported, matching how non connectable scanners have always been seeded and how consumers filter on slots greater than zero before reasoning about exhaustion.

Registering a scanner whose source is already registered by a live scanner is always a caller bug (the source map is last writer wins and the first unregister removes the live scanner), so registration now logs an error naming both scanners rather than corrupting silently; a normal re register after unregister stays quiet.

