### PR TITLE
fix: disconnect clients when their scanner is unregistered

### DIFF
--- a/src/habluetooth/base_scanner.pxd
+++ b/src/habluetooth/base_scanner.pxd
@@ -34,6 +34,7 @@ cdef class BaseHaScanner:
     cdef public object _cancel_track
     cdef public dict _connect_failures
     cdef public dict _connect_in_progress
+    cdef public object _clients
     cdef public unsigned int _connect_completed_total
     cdef public unsigned int _connect_failed_total
     cdef public double _last_connect_completed_time

--- a/src/habluetooth/base_scanner.py
+++ b/src/habluetooth/base_scanner.py
@@ -7,6 +7,7 @@ import logging
 import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Final, final
+from weakref import WeakSet
 
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import NO_RSSI_VALUE, Allocations
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
     from bleak.backends.scanner import AdvertisementData
 
     from .scanner_device import BluetoothScannerDevice
+    from .wrappers import HaBleakClientWrapper
 
 SCANNER_WATCHDOG_INTERVAL_SECONDS: Final = SCANNER_WATCHDOG_INTERVAL.total_seconds()
 _LOGGER = logging.getLogger(__name__)
@@ -52,6 +54,7 @@ class BaseHaScanner:
     __slots__ = (
         "_cancel_track",
         "_cancel_watchdog",
+        "_clients",
         "_connect_completed_total",
         "_connect_failed_total",
         "_connect_failures",
@@ -129,6 +132,8 @@ class BaseHaScanner:
         self._cancel_track: asyncio.TimerHandle | None = None
         self._connect_failures: dict[str, int] = {}
         self._connect_in_progress: dict[str, int] = {}
+        # Clients connected through this scanner; weak so a dropped one cannot leak.
+        self._clients: WeakSet[HaBleakClientWrapper] = WeakSet()
         self._connect_completed_total: int = 0
         self._connect_failed_total: int = 0
         self._last_connect_completed_time: float = 0.0

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -92,13 +92,13 @@ RSSI_SMOOTHING_FACTOR: Final = 0.3
 # - 30s scanner restart time * 2
 #
 SCANNER_WATCHDOG_TIMEOUT: Final = 90
+# How often to check if the scanner has reached
+# the SCANNER_WATCHDOG_TIMEOUT without seeing anything
+SCANNER_WATCHDOG_INTERVAL: Final = timedelta(seconds=30)
 
 # Bound for disconnecting a removed scanner's clients; a proxy that is gone
 # may never answer, and a pending task would strongly reference the client.
 CLIENT_DISCONNECT_TIMEOUT: Final = 10.0
-# How often to check if the scanner has reached
-# the SCANNER_WATCHDOG_TIMEOUT without seeing anything
-SCANNER_WATCHDOG_INTERVAL: Final = timedelta(seconds=30)
 
 
 UNAVAILABLE_TRACK_SECONDS: Final = 60 * 5

--- a/src/habluetooth/const.py
+++ b/src/habluetooth/const.py
@@ -92,6 +92,10 @@ RSSI_SMOOTHING_FACTOR: Final = 0.3
 # - 30s scanner restart time * 2
 #
 SCANNER_WATCHDOG_TIMEOUT: Final = 90
+
+# Bound for disconnecting a removed scanner's clients; a proxy that is gone
+# may never answer, and a pending task would strongly reference the client.
+CLIENT_DISCONNECT_TIMEOUT: Final = 10.0
 # How often to check if the scanner has reached
 # the SCANNER_WATCHDOG_TIMEOUT without seeing anything
 SCANNER_WATCHDOG_INTERVAL: Final = timedelta(seconds=30)

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -46,6 +46,8 @@ cdef class BleakCallback:
 cdef class BluetoothManager:
 
     cdef public object _cancel_unavailable_tracking
+    cdef public dict _clients
+    cdef public set _disconnect_tasks
     cdef public AdvertisementTracker _advertisement_tracker
     cdef public dict _fallback_intervals
     cdef public dict _intervals

--- a/src/habluetooth/manager.pxd
+++ b/src/habluetooth/manager.pxd
@@ -46,8 +46,7 @@ cdef class BleakCallback:
 cdef class BluetoothManager:
 
     cdef public object _cancel_unavailable_tracking
-    cdef public dict _clients
-    cdef public set _disconnect_tasks
+    cdef public set _background_tasks
     cdef public AdvertisementTracker _advertisement_tracker
     cdef public dict _fallback_intervals
     cdef public dict _intervals

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -64,7 +64,7 @@ from .usage import install_multiple_bleak_catcher, uninstall_multiple_bleak_catc
 from .util import async_reset_adapter, coalesce_concurrent_future
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Coroutine, Iterable
 
     from bleak.backends.device import BLEDevice
     from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
@@ -1667,17 +1667,21 @@ class BluetoothManager:
         self._auto_scheduler.remove_scanner(scanner)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.REMOVED)
 
+    def async_add_background_task(self, coro: Coroutine[Any, Any, None]) -> None:
+        """Run a coroutine as a background task that is cancelled on stop."""
+        if TYPE_CHECKING:
+            assert self._loop is not None
+        task = self._loop.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
     def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
         """Disconnect the clients still connected through a removed scanner."""
         clients = list(scanner._clients)
         scanner._clients.clear()
         if not clients:
             return
-        if TYPE_CHECKING:
-            assert self._loop is not None
-        task = self._loop.create_task(self._async_disconnect_all(clients, scanner))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        self.async_add_background_task(self._async_disconnect_all(clients, scanner))
 
     async def _async_disconnect_all(
         self, clients: list[HaBleakClientWrapper], scanner: BaseHaScanner

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1669,11 +1669,13 @@ class BluetoothManager:
         # just cleared has forgotten them.
         self._async_disconnect_clients(scanner)
 
-    def async_add_background_task(self, coro: Coroutine[Any, Any, None]) -> None:
+    def async_add_background_task(
+        self, coro: Coroutine[Any, Any, None], name: str
+    ) -> None:
         """Run a coroutine as a background task that is cancelled on stop."""
         if TYPE_CHECKING:
             assert self._loop is not None
-        task = self._loop.create_task(coro)
+        task = self._loop.create_task(coro, name=name)
         self._background_tasks.add(task)
         task.add_done_callback(self._on_background_task_done)
 
@@ -1689,7 +1691,10 @@ class BluetoothManager:
             return
         clients = list(scanner._clients)
         scanner._clients.clear()
-        self.async_add_background_task(self._async_disconnect_all(clients, scanner))
+        self.async_add_background_task(
+            self._async_disconnect_all(clients, scanner),
+            f"disconnect clients of {scanner.source}",
+        )
 
     async def _async_disconnect_all(
         self, clients: list[HaBleakClientWrapper], scanner: BaseHaScanner

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -475,6 +475,14 @@ class BluetoothManager:
             self._cancel_unavailable_tracking.cancel()
             self._cancel_unavailable_tracking = None
         self._auto_scheduler.stop()
+        if self._background_tasks:
+            # The cancel is fire and forget; log here so an unregister that
+            # raced shutdown leaves a trace even if the task never started.
+            _LOGGER.debug(
+                "Cancelling %d background task(s) at stop: %s",
+                len(self._background_tasks),
+                [task.get_name() for task in self._background_tasks],
+            )
         for task in list(self._background_tasks):
             task.cancel()
         uninstall_multiple_bleak_catcher()

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1677,7 +1677,13 @@ class BluetoothManager:
             assert self._loop is not None
         task = self._loop.create_task(coro)
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        task.add_done_callback(self._on_background_task_done)
+
+    def _on_background_task_done(self, task: asyncio.Task[None]) -> None:
+        """Drop a finished background task, logging an escaped exception."""
+        self._background_tasks.discard(task)
+        if not task.cancelled() and (exc := task.exception()) is not None:
+            _LOGGER.error("Background task failed", exc_info=exc)
 
     def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
         """Disconnect the clients still connected through a removed scanner."""
@@ -1714,6 +1720,14 @@ class BluetoothManager:
                 return
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                 await client.disconnect()
+        except TimeoutError:
+            # The expected shape for a proxy that went away; no traceback.
+            device = client._connected_device
+            _LOGGER.warning(
+                "Timed out disconnecting client %s from removed scanner %s",
+                device.address if device else "unknown",
+                scanner.source,
+            )
         except Exception:  # pylint: disable=broad-except
             device = client._connected_device
             _LOGGER.exception(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -10,7 +10,6 @@ import platform
 from dataclasses import asdict
 from functools import partial
 from typing import TYPE_CHECKING, Any
-from weakref import WeakSet
 
 from bleak_retry_connector import (
     NO_RSSI_VALUE,
@@ -162,11 +161,11 @@ class BluetoothManager:
         "_allocations",
         "_allocations_callbacks",
         "_auto_scheduler",
+        "_background_tasks",
         "_bleak_callbacks",
         "_bluetooth_adapters",
         "_cancel_allocation_callbacks",
         "_cancel_unavailable_tracking",
-        "_clients",
         "_connectable_history",
         "_connectable_scanners",
         "_connectable_unavailable_callbacks",
@@ -174,7 +173,6 @@ class BluetoothManager:
         "_debug",
         "_demoted_sources",
         "_disappeared_callbacks",
-        "_disconnect_tasks",
         "_fallback_intervals",
         "_intervals",
         "_loop",
@@ -203,9 +201,7 @@ class BluetoothManager:
     ) -> None:
         """Init bluetooth manager."""
         self._cancel_unavailable_tracking: asyncio.TimerHandle | None = None
-        # Connected clients per source; weak so a dropped client cannot leak.
-        self._clients: dict[str, WeakSet[HaBleakClientWrapper]] = {}
-        self._disconnect_tasks: set[asyncio.Task[None]] = set()
+        self._background_tasks: set[asyncio.Task[None]] = set()
 
         self._advertisement_tracker = AdvertisementTracker()
         self._fallback_intervals = self._advertisement_tracker.fallback_intervals
@@ -1655,9 +1651,9 @@ class BluetoothManager:
             del self._demoted_sources[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._async_clear_allocations(source)
-        # Nothing else disconnects clients of a removed scanner; BlueZ keeps
-        # the link up and the slot bookkeeping just cleared forgets it.
-        self._async_disconnect_clients(source)
+        # BlueZ keeps a removed adapter's links up and the slot bookkeeping
+        # just cleared has forgotten them.
+        self._async_disconnect_clients(scanner)
         if connection_slots:
             self.slot_manager.remove_adapter(scanner.adapter)
         if (idx := scanner.adapter_idx) is not None:
@@ -1665,53 +1661,35 @@ class BluetoothManager:
         self._auto_scheduler.remove_scanner(scanner)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.REMOVED)
 
-    def async_register_client(
-        self, scanner: BaseHaScanner, client: HaBleakClientWrapper
-    ) -> None:
-        """Track a connected client so it is torn down with its scanner."""
-        source = scanner.source
-        if (clients := self._clients.get(source)) is None:
-            clients = self._clients[source] = WeakSet()
-        clients.add(client)
-
-    def async_unregister_client(
-        self, scanner: BaseHaScanner | None, client: HaBleakClientWrapper
-    ) -> None:
-        """Stop tracking a client; scanner is None if it never connected."""
-        if scanner is None:
-            return
-        if (clients := self._clients.get(scanner.source)) is not None:
-            clients.discard(client)
-            if not clients:
-                del self._clients[scanner.source]
-
-    def _async_disconnect_clients(self, source: str) -> None:
-        """Disconnect every client still connected through source."""
-        if not (clients := self._clients.pop(source, None)):
+    def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
+        """Disconnect the clients still connected through a removed scanner."""
+        clients = [client for client in scanner._clients if client.is_connected]
+        scanner._clients.clear()
+        if not clients:
             return
         if TYPE_CHECKING:
             assert self._loop is not None
-        loop = self._loop
-        for client in list(clients):
-            if not client.is_connected:
-                continue
-            task = loop.create_task(self._async_disconnect_client(client, source))
-            self._disconnect_tasks.add(task)
-            task.add_done_callback(self._disconnect_tasks.discard)
+        task = self._loop.create_task(
+            self._async_disconnect_all(clients, scanner.source)
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
-    async def _async_disconnect_client(
-        self, client: HaBleakClientWrapper, source: str
+    async def _async_disconnect_all(
+        self, clients: list[HaBleakClientWrapper], source: str
     ) -> None:
-        """Disconnect one client, logging rather than raising on failure."""
-        try:
-            await client.disconnect()
-        except Exception:  # pylint: disable=broad-except
-            # client.address resolves through the failed backend; do not read it.
-            _LOGGER.warning(
-                "Error disconnecting client from removed scanner %s",
-                source,
-                exc_info=True,
-            )
+        """Disconnect clients, logging failures instead of raising."""
+        results = await asyncio.gather(
+            *(client.disconnect() for client in clients), return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                # client.address resolves through the failed backend; do not read it.
+                _LOGGER.warning(
+                    "Error disconnecting client from removed scanner %s",
+                    source,
+                    exc_info=result,
+                )
 
     def async_register_scanner(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1680,11 +1680,11 @@ class BluetoothManager:
         """Drop a finished background task, logging an escaped exception."""
         self._background_tasks.discard(task)
         if not task.cancelled() and (exc := task.exception()) is not None:
-            _LOGGER.error("Background task failed", exc_info=exc)
+            _LOGGER.error("Background task %s failed", task.get_name(), exc_info=exc)
 
     def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
         """Disconnect the clients still connected through a removed scanner."""
-        if not scanner._clients:
+        if self.shutdown or not scanner._clients:
             return
         clients = list(scanner._clients)
         scanner._clients.clear()
@@ -1727,6 +1727,8 @@ class BluetoothManager:
                 scanner.source,
             )
         except Exception:  # pylint: disable=broad-except
+            # Deliberate give-up: the scanner is gone and will never be
+            # unregistered again, so re-tracking the client has no reader.
             _LOGGER.exception(
                 "Error disconnecting client %s from removed scanner %s",
                 address,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1728,7 +1728,10 @@ class BluetoothManager:
             for client, result in zip(clients, results, strict=True):
                 if isinstance(result, BaseException):
                     # Only a BaseException can escape the child's handlers.
-                    client._give_up(notify=True)
+                    # This runs after every sibling settled, so re-check the
+                    # client did not reconnect elsewhere in the meantime.
+                    if client._connected_scanner is scanner:
+                        client._give_up(notify=True)
                     _LOGGER.error(
                         "Unexpected error disconnecting client from removed scanner %s",
                         scanner.source,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1742,8 +1742,16 @@ class BluetoothManager:
         device = client._connected_device
         address = device.address if device else "unknown"
         try:
-            if client._connected_scanner is not scanner or not client.is_connected:
+            if client._connected_scanner is not scanner:
                 # Reconnected through another scanner since this was scheduled.
+                return
+            if not client.is_connected:
+                _LOGGER.debug(
+                    "Client %s already down; not disconnecting from removed scanner %s",
+                    address,
+                    scanner.source,
+                )
+                client._untrack()
                 return
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                 await client.disconnect()

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -203,9 +203,7 @@ class BluetoothManager:
     ) -> None:
         """Init bluetooth manager."""
         self._cancel_unavailable_tracking: asyncio.TimerHandle | None = None
-        # Clients connected through each source, so a scanner going away can
-        # take its connections with it. Weak so a client that is dropped
-        # without an explicit disconnect cannot leak.
+        # Connected clients per source; weak so a dropped client cannot leak.
         self._clients: dict[str, WeakSet[HaBleakClientWrapper]] = {}
         self._disconnect_tasks: set[asyncio.Task[None]] = set()
 
@@ -1657,12 +1655,8 @@ class BluetoothManager:
             del self._demoted_sources[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._async_clear_allocations(source)
-        # The scanner is going away, so the transport its clients connected
-        # through is going away too, and nothing else will ever disconnect
-        # them: for a local adapter the kernel keeps the link up and BlueZ is
-        # happy to hold it. Without this the device keeps working through an
-        # adapter the user removed, and the allocation bookkeeping just
-        # cleared forgets a connection that still occupies a real slot.
+        # Nothing else disconnects clients of a removed scanner; BlueZ keeps
+        # the link up and the slot bookkeeping just cleared forgets it.
         self._async_disconnect_clients(source)
         if connection_slots:
             self.slot_manager.remove_adapter(scanner.adapter)
@@ -1674,14 +1668,7 @@ class BluetoothManager:
     def async_register_client(
         self, scanner: BaseHaScanner, client: HaBleakClientWrapper
     ) -> None:
-        """
-        Track a connected client so it can be torn down with its scanner.
-
-        Called by the client wrapper once a connection is established. The
-        client is held weakly: dropping it without disconnecting must not keep
-        it alive, and a stale entry is harmless because disconnecting an
-        already-disconnected client is a no-op.
-        """
+        """Track a connected client so it is torn down with its scanner."""
         source = scanner.source
         if (clients := self._clients.get(source)) is None:
             clients = self._clients[source] = WeakSet()
@@ -1690,13 +1677,7 @@ class BluetoothManager:
     def async_unregister_client(
         self, scanner: BaseHaScanner | None, client: HaBleakClientWrapper
     ) -> None:
-        """
-        Stop tracking a client that has disconnected.
-
-        Takes the scanner rather than a source so a client that never finished
-        connecting -- and so never recorded one -- can be passed straight
-        through without the caller having to test for it.
-        """
+        """Stop tracking a client; scanner is None if it never connected."""
         if scanner is None:
             return
         if (clients := self._clients.get(scanner.source)) is not None:
@@ -1725,10 +1706,7 @@ class BluetoothManager:
         try:
             await client.disconnect()
         except Exception:  # pylint: disable=broad-except
-            # Deliberately does not log client.address: that resolves through
-            # the backend, which is exactly what just failed, so reading it
-            # here could raise inside the error handler. exc_info carries the
-            # detail instead.
+            # client.address resolves through the failed backend; do not read it.
             _LOGGER.warning(
                 "Error disconnecting client from removed scanner %s",
                 source,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1669,7 +1669,7 @@ class BluetoothManager:
         # just cleared has forgotten them.
         self._async_disconnect_clients(scanner)
 
-    def async_add_background_task(
+    def _async_add_background_task(
         self, coro: Coroutine[Any, Any, None], name: str
     ) -> None:
         """Run a coroutine as a background task that is cancelled on stop."""
@@ -1690,11 +1690,12 @@ class BluetoothManager:
         if self.shutdown or not scanner._clients:
             return
         clients = list(scanner._clients)
-        scanner._clients.clear()
-        self.async_add_background_task(
+        self._async_add_background_task(
             self._async_disconnect_all(clients, scanner),
             f"disconnect clients of {scanner.source}",
         )
+        # After scheduling, so a failure to schedule keeps the entries.
+        scanner._clients.clear()
 
     async def _async_disconnect_all(
         self, clients: list[HaBleakClientWrapper], scanner: BaseHaScanner
@@ -1730,19 +1731,32 @@ class BluetoothManager:
                 await client.disconnect()
         except TimeoutError:
             # The expected shape for a proxy that went away; no traceback.
+            self._async_give_up_client(client)
             _LOGGER.warning(
                 "Timed out disconnecting client %s from removed scanner %s",
                 address,
                 scanner.source,
             )
         except Exception:  # pylint: disable=broad-except
-            # Deliberate give-up: the scanner is gone and will never be
-            # unregistered again, so re-tracking the client has no reader.
+            self._async_give_up_client(client)
             _LOGGER.exception(
                 "Error disconnecting client %s from removed scanner %s",
                 address,
                 scanner.source,
             )
+
+    def _async_give_up_client(self, client: HaBleakClientWrapper) -> None:
+        """
+        Drop a client whose teardown failed.
+
+        The link leaks to BlueZ (logged by the caller), but the wrapper must
+        not keep reporting connected: the scanner is gone and will never be
+        unregistered again, so nothing else would ever tear it down, and the
+        next establish_connection retry must re-resolve a backend instead of
+        short circuiting on is_connected.
+        """
+        client._backend = None
+        client._untrack()
 
     def async_register_scanner(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1693,7 +1693,7 @@ class BluetoothManager:
             # Abandoned to BlueZ/the kernel; scheduling after stop would
             # leak tasks past the loop's lifetime.
             _LOGGER.debug(
-                "Shutdown; not disconnecting %d client(s) of removed scanner %s",
+                "Shutdown; not disconnecting %d client(s) from removed scanner %s",
                 len(scanner._clients),
                 scanner.source,
             )
@@ -1720,7 +1720,7 @@ class BluetoothManager:
             for client, result in zip(clients, results, strict=True):
                 if isinstance(result, BaseException):
                     # Only a BaseException can escape the child's handlers.
-                    self._async_give_up_client(client)
+                    client._give_up()
                     _LOGGER.error(
                         "Unexpected error disconnecting client from removed scanner %s",
                         scanner.source,
@@ -1739,50 +1739,37 @@ class BluetoothManager:
         self, client: HaBleakClientWrapper, scanner: BaseHaScanner
     ) -> None:
         """Disconnect one client, logging failures instead of raising."""
+        if client._connected_scanner is not scanner:
+            # Reconnected through another scanner since this was scheduled.
+            return
         device = client._connected_device
         address = device.address if device else "unknown"
+        if not client.is_connected:
+            _LOGGER.debug(
+                "Client %s already down; not disconnecting from removed scanner %s",
+                address,
+                scanner.source,
+            )
+            client._untrack()
+            return
         try:
-            if client._connected_scanner is not scanner:
-                # Reconnected through another scanner since this was scheduled.
-                return
-            if not client.is_connected:
-                _LOGGER.debug(
-                    "Client %s already down; not disconnecting from removed scanner %s",
-                    address,
-                    scanner.source,
-                )
-                client._untrack()
-                return
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                 await client.disconnect()
         except TimeoutError:
             # The expected shape for a proxy that went away; no traceback.
-            self._async_give_up_client(client)
+            client._give_up()
             _LOGGER.warning(
                 "Timed out disconnecting client %s from removed scanner %s",
                 address,
                 scanner.source,
             )
         except Exception:  # pylint: disable=broad-except
-            self._async_give_up_client(client)
+            client._give_up()
             _LOGGER.exception(
                 "Error disconnecting client %s from removed scanner %s",
                 address,
                 scanner.source,
             )
-
-    def _async_give_up_client(self, client: HaBleakClientWrapper) -> None:
-        """
-        Drop a client whose teardown failed.
-
-        The link leaks to BlueZ (logged by the caller), but the wrapper must
-        not keep reporting connected: the scanner is gone and will never be
-        unregistered again, so nothing else would ever tear it down, and the
-        next establish_connection retry must re-resolve a backend instead of
-        short circuiting on is_connected.
-        """
-        client._backend = None
-        client._untrack()
 
     def async_register_scanner(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1728,7 +1728,7 @@ class BluetoothManager:
             for client, result in zip(clients, results, strict=True):
                 if isinstance(result, BaseException):
                     # Only a BaseException can escape the child's handlers.
-                    client._give_up()
+                    client._give_up(notify=True)
                     _LOGGER.error(
                         "Unexpected error disconnecting client from removed scanner %s",
                         scanner.source,
@@ -1761,18 +1761,26 @@ class BluetoothManager:
             client._untrack()
             return
         try:
-            async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
+            async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT) as timed_out:
                 await client.disconnect()
         except TimeoutError:
-            # The expected shape for a proxy that went away; no traceback.
-            client._give_up()
-            _LOGGER.warning(
-                "Timed out disconnecting client %s from removed scanner %s",
-                address,
-                scanner.source,
-            )
+            client._give_up(notify=True)
+            if timed_out.expired():
+                # The expected shape for a proxy that went away; no traceback.
+                _LOGGER.warning(
+                    "Timed out disconnecting client %s from removed scanner %s",
+                    address,
+                    scanner.source,
+                )
+            else:
+                # The backend raised its own TimeoutError inside the bound.
+                _LOGGER.exception(
+                    "Error disconnecting client %s from removed scanner %s",
+                    address,
+                    scanner.source,
+                )
         except Exception:  # pylint: disable=broad-except
-            client._give_up()
+            client._give_up(notify=True)
             _LOGGER.exception(
                 "Error disconnecting client %s from removed scanner %s",
                 address,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1663,7 +1663,9 @@ class BluetoothManager:
         self._auto_scheduler.remove_scanner(scanner)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.REMOVED)
 
-    def async_register_client(self, source: str, client: HaBleakClientWrapper) -> None:
+    def async_register_client(
+        self, scanner: BaseHaScanner, client: HaBleakClientWrapper
+    ) -> None:
         """
         Track a connected client so it can be torn down with its scanner.
 
@@ -1672,26 +1674,35 @@ class BluetoothManager:
         it alive, and a stale entry is harmless because disconnecting an
         already-disconnected client is a no-op.
         """
+        source = scanner.source
         if (clients := self._clients.get(source)) is None:
             clients = self._clients[source] = WeakSet()
         clients.add(client)
 
     def async_unregister_client(
-        self, source: str, client: HaBleakClientWrapper
+        self, scanner: BaseHaScanner | None, client: HaBleakClientWrapper
     ) -> None:
-        """Stop tracking a client that has disconnected."""
-        if (clients := self._clients.get(source)) is not None:
+        """
+        Stop tracking a client that has disconnected.
+
+        Takes the scanner rather than a source so a client that never finished
+        connecting -- and so never recorded one -- can be passed straight
+        through without the caller having to test for it.
+        """
+        if scanner is None:
+            return
+        if (clients := self._clients.get(scanner.source)) is not None:
             clients.discard(client)
             if not clients:
-                del self._clients[source]
+                del self._clients[scanner.source]
 
     def _async_disconnect_clients(self, source: str) -> None:
         """Disconnect every client still connected through source."""
         if not (clients := self._clients.pop(source, None)):
             return
-        if (loop := self._loop) is None:
-            # Never set up, so nothing can have connected through it.
-            return
+        if TYPE_CHECKING:
+            assert self._loop is not None
+        loop = self._loop
         for client in list(clients):
             if not client.is_connected:
                 continue
@@ -1706,9 +1717,12 @@ class BluetoothManager:
         try:
             await client.disconnect()
         except Exception:  # pylint: disable=broad-except
+            # Deliberately does not log client.address: that resolves through
+            # the backend, which is exactly what just failed, so reading it
+            # here could raise inside the error handler. exc_info carries the
+            # detail instead.
             _LOGGER.warning(
-                "%s: Error disconnecting client from removed scanner %s",
-                client.address,
+                "Error disconnecting client from removed scanner %s",
                 source,
                 exc_info=True,
             )

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1658,15 +1658,16 @@ class BluetoothManager:
             del self._demoted_sources[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._async_clear_allocations(source)
-        # BlueZ keeps a removed adapter's links up and the slot bookkeeping
-        # just cleared has forgotten them.
-        self._async_disconnect_clients(scanner)
         if connection_slots:
             self.slot_manager.remove_adapter(scanner.adapter)
         if (idx := scanner.adapter_idx) is not None:
             self._side_channel_scanners.pop(idx, None)
         self._auto_scheduler.remove_scanner(scanner)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.REMOVED)
+        # Last so a failure to schedule cannot strand the teardown above.
+        # BlueZ keeps a removed adapter's links up and the slot bookkeeping
+        # just cleared has forgotten them.
+        self._async_disconnect_clients(scanner)
 
     def async_add_background_task(self, coro: Coroutine[Any, Any, None]) -> None:
         """Run a coroutine as a background task that is cancelled on stop."""
@@ -1695,8 +1696,11 @@ class BluetoothManager:
     ) -> None:
         """Disconnect clients concurrently."""
         try:
+            # Each child logs its own failures; return_exceptions keeps one
+            # misbehaving client from abandoning its siblings mid gather.
             await asyncio.gather(
-                *(self._async_disconnect_client(client, scanner) for client in clients)
+                *(self._async_disconnect_client(client, scanner) for client in clients),
+                return_exceptions=True,
             )
         except asyncio.CancelledError:
             # Shutdown; the links are abandoned to BlueZ/the kernel.

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1767,7 +1767,9 @@ class BluetoothManager:
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT) as timed_out:
                 await client.disconnect()
         except Exception as exc:  # pylint: disable=broad-except
-            client._give_up(notify=True)
+            if client._connected_scanner is scanner:
+                # Not given up if it reconnected elsewhere while this hung.
+                client._give_up(notify=True)
             if isinstance(exc, TimeoutError) and timed_out.expired():
                 # The expected shape for a proxy that went away; no traceback.
                 _LOGGER.warning(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -81,6 +81,10 @@ IS_LINUX = SYSTEM == "Linux"
 FILTER_UUIDS = "UUIDs"
 
 APPLE_MFR_ID = 76
+
+# Bound for disconnecting a removed scanner's clients; a proxy that is gone
+# may never answer, and a pending task would strongly reference the client.
+CLIENT_DISCONNECT_TIMEOUT = 10.0
 APPLE_IBEACON_START_BYTE = 0x02  # iBeacon (tilt_ble)
 APPLE_HOMEKIT_START_BYTE = 0x06  # homekit_controller
 APPLE_DEVICE_ID_START_BYTE = 0x10  # bluetooth_le_tracker
@@ -470,6 +474,8 @@ class BluetoothManager:
             self._cancel_unavailable_tracking.cancel()
             self._cancel_unavailable_tracking = None
         self._auto_scheduler.stop()
+        for task in list(self._background_tasks):
+            task.cancel()
         uninstall_multiple_bleak_catcher()
         self._cancel_allocation_callbacks()
         if self._mgmt_ctl:
@@ -1663,33 +1669,43 @@ class BluetoothManager:
 
     def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
         """Disconnect the clients still connected through a removed scanner."""
-        clients = [client for client in scanner._clients if client.is_connected]
+        clients = list(scanner._clients)
         scanner._clients.clear()
         if not clients:
             return
         if TYPE_CHECKING:
             assert self._loop is not None
-        task = self._loop.create_task(
-            self._async_disconnect_all(clients, scanner.source)
-        )
+        task = self._loop.create_task(self._async_disconnect_all(clients, scanner))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
     async def _async_disconnect_all(
-        self, clients: list[HaBleakClientWrapper], source: str
+        self, clients: list[HaBleakClientWrapper], scanner: BaseHaScanner
     ) -> None:
-        """Disconnect clients, logging failures instead of raising."""
-        results = await asyncio.gather(
-            *(client.disconnect() for client in clients), return_exceptions=True
+        """Disconnect clients concurrently."""
+        await asyncio.gather(
+            *(self._async_disconnect_client(client, scanner) for client in clients)
         )
-        for result in results:
-            if isinstance(result, Exception):
-                # client.address resolves through the failed backend; do not read it.
-                _LOGGER.warning(
-                    "Error disconnecting client from removed scanner %s",
-                    source,
-                    exc_info=result,
-                )
+
+    async def _async_disconnect_client(
+        self, client: HaBleakClientWrapper, scanner: BaseHaScanner
+    ) -> None:
+        """Disconnect one client, logging failures instead of raising."""
+        if client._connected_scanner is not scanner or not client.is_connected:
+            # Reconnected through another scanner since this was scheduled.
+            return
+        try:
+            async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
+                await client.disconnect()
+        except Exception:  # pylint: disable=broad-except
+            # client.address resolves through the failed backend; do not read it.
+            device = client._connected_device
+            _LOGGER.warning(
+                "Error disconnecting client %s from removed scanner %s",
+                device.address if device else "unknown",
+                scanner.source,
+                exc_info=True,
+            )
 
     def async_register_scanner(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1687,27 +1687,35 @@ class BluetoothManager:
         self, clients: list[HaBleakClientWrapper], scanner: BaseHaScanner
     ) -> None:
         """Disconnect clients concurrently."""
-        await asyncio.gather(
-            *(self._async_disconnect_client(client, scanner) for client in clients)
-        )
+        try:
+            await asyncio.gather(
+                *(self._async_disconnect_client(client, scanner) for client in clients)
+            )
+        except asyncio.CancelledError:
+            # Shutdown; the links are abandoned to BlueZ/the kernel.
+            _LOGGER.debug(
+                "Cancelled disconnecting %d client(s) from removed scanner %s",
+                len(clients),
+                scanner.source,
+            )
+            raise
 
     async def _async_disconnect_client(
         self, client: HaBleakClientWrapper, scanner: BaseHaScanner
     ) -> None:
         """Disconnect one client, logging failures instead of raising."""
-        if client._connected_scanner is not scanner or not client.is_connected:
-            # Reconnected through another scanner since this was scheduled.
-            return
         try:
+            if client._connected_scanner is not scanner or not client.is_connected:
+                # Reconnected through another scanner since this was scheduled.
+                return
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                 await client.disconnect()
         except Exception:  # pylint: disable=broad-except
             device = client._connected_device
-            _LOGGER.warning(
+            _LOGGER.exception(
                 "Error disconnecting client %s from removed scanner %s",
                 device.address if device else "unknown",
                 scanner.source,
-                exc_info=True,
             )
 
     def async_register_scanner(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1687,7 +1687,16 @@ class BluetoothManager:
 
     def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
         """Disconnect the clients still connected through a removed scanner."""
-        if self.shutdown or not scanner._clients:
+        if not scanner._clients:
+            return
+        if self.shutdown:
+            # Abandoned to BlueZ/the kernel; scheduling after stop would
+            # leak tasks past the loop's lifetime.
+            _LOGGER.debug(
+                "Shutdown; not disconnecting %d client(s) of removed scanner %s",
+                len(scanner._clients),
+                scanner.source,
+            )
             return
         clients = list(scanner._clients)
         self._async_add_background_task(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1763,9 +1763,9 @@ class BluetoothManager:
         try:
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT) as timed_out:
                 await client.disconnect()
-        except TimeoutError:
+        except Exception as exc:  # pylint: disable=broad-except
             client._give_up(notify=True)
-            if timed_out.expired():
+            if isinstance(exc, TimeoutError) and timed_out.expired():
                 # The expected shape for a proxy that went away; no traceback.
                 _LOGGER.warning(
                     "Timed out disconnecting client %s from removed scanner %s",
@@ -1773,19 +1773,11 @@ class BluetoothManager:
                     scanner.source,
                 )
             else:
-                # The backend raised its own TimeoutError inside the bound.
                 _LOGGER.exception(
                     "Error disconnecting client %s from removed scanner %s",
                     address,
                     scanner.source,
                 )
-        except Exception:  # pylint: disable=broad-except
-            client._give_up(notify=True)
-            _LOGGER.exception(
-                "Error disconnecting client %s from removed scanner %s",
-                address,
-                scanner.source,
-            )
 
     def async_register_scanner(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -205,7 +205,6 @@ class BluetoothManager:
     ) -> None:
         """Init bluetooth manager."""
         self._cancel_unavailable_tracking: asyncio.TimerHandle | None = None
-        self._background_tasks: set[asyncio.Task[None]] = set()
 
         self._advertisement_tracker = AdvertisementTracker()
         self._fallback_intervals = self._advertisement_tracker.fallback_intervals
@@ -275,6 +274,7 @@ class BluetoothManager:
         )
         self._debug = _LOGGER.isEnabledFor(logging.DEBUG)
         self.shutdown = False
+        self._background_tasks: set[asyncio.Task[None]] = set()
         self.has_advertising_side_channel = False
         self._side_channel_scanners: dict[int, BaseHaScanner] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -1698,7 +1698,6 @@ class BluetoothManager:
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                 await client.disconnect()
         except Exception:  # pylint: disable=broad-except
-            # client.address resolves through the failed backend; do not read it.
             device = client._connected_device
             _LOGGER.warning(
                 "Error disconnecting client %s from removed scanner %s",

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -10,6 +10,7 @@ import platform
 from dataclasses import asdict
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final
+from weakref import WeakSet
 
 from bleak_retry_connector import (
     NO_RSSI_VALUE,
@@ -70,6 +71,7 @@ if TYPE_CHECKING:
     from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
 
     from .base_scanner import BaseHaScanner
+    from .wrappers import HaBleakClientWrapper
 
 
 SYSTEM = platform.system()
@@ -162,6 +164,7 @@ class BluetoothManager:
         "_bluetooth_adapters",
         "_cancel_allocation_callbacks",
         "_cancel_unavailable_tracking",
+        "_clients",
         "_connectable_history",
         "_connectable_scanners",
         "_connectable_unavailable_callbacks",
@@ -169,6 +172,7 @@ class BluetoothManager:
         "_debug",
         "_demoted_sources",
         "_disappeared_callbacks",
+        "_disconnect_tasks",
         "_fallback_intervals",
         "_intervals",
         "_loop",
@@ -197,6 +201,11 @@ class BluetoothManager:
     ) -> None:
         """Init bluetooth manager."""
         self._cancel_unavailable_tracking: asyncio.TimerHandle | None = None
+        # Clients connected through each source, so a scanner going away can
+        # take its connections with it. Weak so a client that is dropped
+        # without an explicit disconnect cannot leak.
+        self._clients: dict[str, WeakSet[HaBleakClientWrapper]] = {}
+        self._disconnect_tasks: set[asyncio.Task[None]] = set()
 
         self._advertisement_tracker = AdvertisementTracker()
         self._fallback_intervals = self._advertisement_tracker.fallback_intervals
@@ -1640,12 +1649,69 @@ class BluetoothManager:
             del self._demoted_sources[address]
         self._adapter_sources.pop(scanner.adapter, None)
         self._async_clear_allocations(source)
+        # The scanner is going away, so the transport its clients connected
+        # through is going away too, and nothing else will ever disconnect
+        # them: for a local adapter the kernel keeps the link up and BlueZ is
+        # happy to hold it. Without this the device keeps working through an
+        # adapter the user removed, and the allocation bookkeeping just
+        # cleared forgets a connection that still occupies a real slot.
+        self._async_disconnect_clients(source)
         if connection_slots:
             self.slot_manager.remove_adapter(scanner.adapter)
         if (idx := scanner.adapter_idx) is not None:
             self._side_channel_scanners.pop(idx, None)
         self._auto_scheduler.remove_scanner(scanner)
         self._async_on_scanner_registration(scanner, HaScannerRegistrationEvent.REMOVED)
+
+    def async_register_client(self, source: str, client: HaBleakClientWrapper) -> None:
+        """
+        Track a connected client so it can be torn down with its scanner.
+
+        Called by the client wrapper once a connection is established. The
+        client is held weakly: dropping it without disconnecting must not keep
+        it alive, and a stale entry is harmless because disconnecting an
+        already-disconnected client is a no-op.
+        """
+        if (clients := self._clients.get(source)) is None:
+            clients = self._clients[source] = WeakSet()
+        clients.add(client)
+
+    def async_unregister_client(
+        self, source: str, client: HaBleakClientWrapper
+    ) -> None:
+        """Stop tracking a client that has disconnected."""
+        if (clients := self._clients.get(source)) is not None:
+            clients.discard(client)
+            if not clients:
+                del self._clients[source]
+
+    def _async_disconnect_clients(self, source: str) -> None:
+        """Disconnect every client still connected through source."""
+        if not (clients := self._clients.pop(source, None)):
+            return
+        if (loop := self._loop) is None:
+            # Never set up, so nothing can have connected through it.
+            return
+        for client in list(clients):
+            if not client.is_connected:
+                continue
+            task = loop.create_task(self._async_disconnect_client(client, source))
+            self._disconnect_tasks.add(task)
+            task.add_done_callback(self._disconnect_tasks.discard)
+
+    async def _async_disconnect_client(
+        self, client: HaBleakClientWrapper, source: str
+    ) -> None:
+        """Disconnect one client, logging rather than raising on failure."""
+        try:
+            await client.disconnect()
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "%s: Error disconnecting client from removed scanner %s",
+                client.address,
+                source,
+                exc_info=True,
+            )
 
     def async_register_scanner(
         self,

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1704,10 +1704,19 @@ class BluetoothManager:
         try:
             # Each child logs its own failures; return_exceptions keeps one
             # misbehaving client from abandoning its siblings mid gather.
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *(self._async_disconnect_client(client, scanner) for client in clients),
                 return_exceptions=True,
             )
+            for client, result in zip(clients, results, strict=True):
+                if isinstance(result, BaseException):
+                    # Only a BaseException can escape the child's handlers.
+                    self._async_give_up_client(client)
+                    _LOGGER.error(
+                        "Unexpected error disconnecting client from removed scanner %s",
+                        scanner.source,
+                        exc_info=result,
+                    )
         except asyncio.CancelledError:
             # Shutdown; the links are abandoned to BlueZ/the kernel.
             _LOGGER.debug(

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -36,6 +36,7 @@ from .const import (
     ADV_RSSI_SWITCH_DEADBAND,
     ADV_RSSI_SWITCH_THRESHOLD,
     CALLBACK_TYPE,
+    CLIENT_DISCONNECT_TIMEOUT,
     DEFAULT_ACTIVE_SCAN_DURATION,
     DEFAULT_ACTIVE_SCAN_INTERVAL,
     DEFAULT_ON_DEMAND_SWEEP_DURATION,
@@ -81,10 +82,6 @@ IS_LINUX = SYSTEM == "Linux"
 FILTER_UUIDS = "UUIDs"
 
 APPLE_MFR_ID = 76
-
-# Bound for disconnecting a removed scanner's clients; a proxy that is gone
-# may never answer, and a pending task would strongly reference the client.
-CLIENT_DISCONNECT_TIMEOUT = 10.0
 APPLE_IBEACON_START_BYTE = 0x02  # iBeacon (tilt_ble)
 APPLE_HOMEKIT_START_BYTE = 0x06  # homekit_controller
 APPLE_DEVICE_ID_START_BYTE = 0x10  # bluetooth_le_tracker
@@ -1687,10 +1684,10 @@ class BluetoothManager:
 
     def _async_disconnect_clients(self, scanner: BaseHaScanner) -> None:
         """Disconnect the clients still connected through a removed scanner."""
+        if not scanner._clients:
+            return
         clients = list(scanner._clients)
         scanner._clients.clear()
-        if not clients:
-            return
         self.async_add_background_task(self._async_disconnect_all(clients, scanner))
 
     async def _async_disconnect_all(
@@ -1714,6 +1711,8 @@ class BluetoothManager:
         self, client: HaBleakClientWrapper, scanner: BaseHaScanner
     ) -> None:
         """Disconnect one client, logging failures instead of raising."""
+        device = client._connected_device
+        address = device.address if device else "unknown"
         try:
             if client._connected_scanner is not scanner or not client.is_connected:
                 # Reconnected through another scanner since this was scheduled.
@@ -1722,17 +1721,15 @@ class BluetoothManager:
                 await client.disconnect()
         except TimeoutError:
             # The expected shape for a proxy that went away; no traceback.
-            device = client._connected_device
             _LOGGER.warning(
                 "Timed out disconnecting client %s from removed scanner %s",
-                device.address if device else "unknown",
+                address,
                 scanner.source,
             )
         except Exception:  # pylint: disable=broad-except
-            device = client._connected_device
             _LOGGER.exception(
                 "Error disconnecting client %s from removed scanner %s",
-                device.address if device else "unknown",
+                address,
                 scanner.source,
             )
 

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -514,6 +514,10 @@ class HaBleakClientWrapper(BleakClient):
             self._connected_device = device
             # Disconnected by the manager if the scanner is unregistered.
             scanner._clients.add(self)
+            if manager.async_scanner_by_source(scanner.source) is not scanner:
+                # The scanner was unregistered while this connect was in
+                # flight; its teardown already ran, so run it again for us.
+                manager._async_disconnect_clients(scanner)
             self._load_conn_params(
                 scanner,
                 device,

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -680,6 +680,13 @@ class HaBleakClientWrapper(BleakClient):
         """Disconnect from the device."""
         if self._backend is None:
             return
-        await self._backend.disconnect()
-        if (scanner := self._connected_scanner) is not None:
-            scanner._clients.discard(self)
+        try:
+            await self._backend.disconnect()
+        finally:
+            # A raise may leave the link up; keep the client tracked then so
+            # scanner unregister can still tear it down.
+            if (
+                not self.is_connected
+                and (scanner := self._connected_scanner) is not None
+            ):
+                scanner._clients.discard(self)

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -509,9 +509,7 @@ class HaBleakClientWrapper(BleakClient):
         if connected:
             self._connected_scanner = scanner
             self._connected_device = device
-            # Let the manager tear this connection down if the scanner it was
-            # made through is unregistered; otherwise the link outlives the
-            # adapter that owns it.
+            # Torn down by the manager if the scanner is unregistered.
             manager.async_register_client(scanner, self)
             self._load_conn_params(
                 scanner,

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -509,6 +509,10 @@ class HaBleakClientWrapper(BleakClient):
         if connected:
             self._connected_scanner = scanner
             self._connected_device = device
+            # Let the manager tear this connection down if the scanner it was
+            # made through is unregistered; otherwise the link outlives the
+            # adapter that owns it.
+            manager.async_register_client(scanner.source, self)
             self._load_conn_params(
                 scanner,
                 device,
@@ -675,4 +679,6 @@ class HaBleakClientWrapper(BleakClient):
         """Disconnect from the device."""
         if self._backend is None:
             return
+        if (scanner := self._connected_scanner) is not None:
+            self.__manager.async_unregister_client(scanner.source, self)
         await self._backend.disconnect()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -507,13 +507,7 @@ class HaBleakClientWrapper(BleakClient):
 
         # Load medium connection parameters after successful connection
         if connected:
-            if (previous := self._connected_scanner) is not None:
-                # Reconnect may have landed on a different scanner.
-                previous._clients.discard(self)
-            self._connected_scanner = scanner
-            self._connected_device = device
-            # Disconnected by the manager if the scanner is unregistered.
-            scanner._clients.add(self)
+            self._track(scanner, device)
             if manager.async_scanner_by_source(scanner.source) is not scanner:
                 # The scanner was unregistered while this connect was in
                 # flight; its teardown already ran, so run it again for us
@@ -686,6 +680,30 @@ class HaBleakClientWrapper(BleakClient):
             msg = f"{msg}: {diagnostics}"
         raise BleakError(msg)
 
+    def _track(self, scanner: BaseHaScanner, device: BLEDevice) -> None:
+        """Record the connected path; the scanner set follows the pointer."""
+        if (previous := self._connected_scanner) is not None and (
+            previous is not scanner
+        ):
+            # Reconnect landed on a different scanner.
+            previous._clients.discard(self)
+        self._connected_scanner = scanner
+        self._connected_device = device
+        # Disconnected by the manager if the scanner is unregistered.
+        scanner._clients.add(self)
+
+    def _untrack(self) -> None:
+        """
+        Drop the connected path once the link is confirmed down.
+
+        A raise may leave the link up; keep the client tracked then so
+        scanner unregister can still tear it down.
+        """
+        if not self.is_connected and (scanner := self._connected_scanner) is not None:
+            scanner._clients.discard(self)
+            self._connected_scanner = None
+            self._connected_device = None
+
     async def disconnect(self) -> None:
         """Disconnect from the device."""
         if self._backend is None:
@@ -693,10 +711,4 @@ class HaBleakClientWrapper(BleakClient):
         try:
             await self._backend.disconnect()
         finally:
-            # A raise may leave the link up; keep the client tracked then so
-            # scanner unregister can still tear it down.
-            if (
-                not self.is_connected
-                and (scanner := self._connected_scanner) is not None
-            ):
-                scanner._clients.discard(self)
+            self._untrack()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -357,6 +357,12 @@ class HaBleakClientWrapper(BleakClient):
         timeout: int,
     ) -> None:
         """Set BLE connection parameters on a connected device."""
+        if not self.is_connected:
+            _LOGGER.debug(
+                "%s: not setting connection params; client is not connected",
+                self.__address,
+            )
+            return
         if self._backend is not None and hasattr(
             self._backend, "set_connection_params"
         ):
@@ -719,25 +725,29 @@ class HaBleakClientWrapper(BleakClient):
         scanner._clients.add(self)
 
     def _untrack(self) -> None:
-        """
-        Drop the connected path once the link is confirmed down.
-
-        A raise may leave the link up; keep the client tracked then so
-        scanner unregister can still tear it down.
-        """
-        if not self.is_connected and (scanner := self._connected_scanner) is not None:
+        """Drop the connected path."""
+        if (scanner := self._connected_scanner) is not None:
             scanner._clients.discard(self)
             self._connected_scanner = None
             self._connected_device = None
+
+    def _untrack_if_down(self) -> None:
+        """Drop the connected path unless the link may still be up."""
+        if not self.is_connected:
+            self._untrack()
 
     async def disconnect(self) -> None:
         """Disconnect from the device."""
         if self._backend is None:
             # No backend, but pointers from an earlier failed teardown may
-            # remain; _untrack is a no-op when the link is genuinely up.
-            self._untrack()
+            # remain.
+            self._untrack_if_down()
             return
         try:
             await self._backend.disconnect()
-        finally:
-            self._untrack()
+        except BaseException:
+            # A raise may leave the link up; keep the client tracked then so
+            # scanner unregister can still tear it down.
+            self._untrack_if_down()
+            raise
+        self._untrack()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -516,8 +516,14 @@ class HaBleakClientWrapper(BleakClient):
             scanner._clients.add(self)
             if manager.async_scanner_by_source(scanner.source) is not scanner:
                 # The scanner was unregistered while this connect was in
-                # flight; its teardown already ran, so run it again for us.
+                # flight; its teardown already ran, so run it again for us
+                # and fail the connect so the caller retries elsewhere.
                 manager._async_disconnect_clients(scanner)
+                msg = (
+                    f"{self.__address}: scanner {scanner.name} was"
+                    " unregistered during connect"
+                )
+                raise BleakError(msg)
             self._load_conn_params(
                 scanner,
                 device,

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -21,7 +21,13 @@ from bleak_retry_connector import (
 )
 
 from .central_manager import get_manager
-from .const import BDADDR_LE_PUBLIC, BDADDR_LE_RANDOM, CALLBACK_TYPE, ConnectParams
+from .const import (
+    BDADDR_LE_PUBLIC,
+    BDADDR_LE_RANDOM,
+    CALLBACK_TYPE,
+    CLIENT_DISCONNECT_TIMEOUT,
+    ConnectParams,
+)
 from .models import BluetoothReachabilityIntent
 
 FILTER_UUIDS: Final = "UUIDs"
@@ -510,9 +516,11 @@ class HaBleakClientWrapper(BleakClient):
             self._track(scanner, device)
             if manager.async_scanner_by_source(scanner.source) is not scanner:
                 # The scanner was unregistered while this connect was in
-                # flight; its teardown already ran, so run it again for us
-                # and fail the connect so the caller retries elsewhere.
-                manager._async_disconnect_clients(scanner)
+                # flight; tear the link down inline so the wrapper reports
+                # disconnected and the caller can retry elsewhere.
+                with contextlib.suppress(Exception):
+                    async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
+                        await self.disconnect()
                 msg = (
                     f"{self.__address}: scanner {scanner.name} was"
                     " unregistered during connect"

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -528,6 +528,14 @@ class HaBleakClientWrapper(BleakClient):
                 try:
                     async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                         await self.disconnect()
+                except asyncio.CancelledError:
+                    _LOGGER.debug(
+                        "%s: cancelled disconnecting after scanner %s was"
+                        " unregistered mid connect",
+                        self.__address,
+                        scanner.name,
+                    )
+                    raise
                 except TimeoutError:
                     _LOGGER.warning(
                         "%s: timed out disconnecting after scanner %s was"

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -521,9 +521,7 @@ class HaBleakClientWrapper(BleakClient):
         # Load medium connection parameters after successful connection
         if connected:
             if manager.async_scanner_by_source(scanner.source) is not scanner:
-                await self._async_abort_unregistered_mid_connect(
-                    scanner, device, not wrapped_backend.source
-                )
+                await self._async_abort_unregistered_mid_connect(scanner)
             self._track(scanner, device)
             self._load_conn_params(
                 scanner,
@@ -713,14 +711,14 @@ class HaBleakClientWrapper(BleakClient):
 
     def _give_up(self, notify: bool = False) -> None:
         """
-        Drop the backend and tracking for a link nothing can tear down.
+        Drop the backend and tracking for a link this wrapper no longer owns.
 
-        The link leaks to BlueZ (logged by the caller), but the wrapper
-        must not keep reporting connected: nothing would ever tear it
-        down, and the next establish_connection retry must re-resolve a
-        backend instead of short circuiting on is_connected. With notify,
-        the consumer's disconnected callback fires so integrations that
-        wait for it schedule their reconnect.
+        When the teardown failed the link leaks to BlueZ (logged by the
+        caller), but the wrapper must not keep reporting connected: the
+        next establish_connection retry must re-resolve a backend instead
+        of short circuiting on is_connected. With notify, the consumer's
+        disconnected callback fires so integrations that wait for it
+        schedule their reconnect.
         """
         if (backend := self._backend) is not None:
             # The orphaned backend must not fire the consumer's disconnected
@@ -735,17 +733,28 @@ class HaBleakClientWrapper(BleakClient):
                 )
         self._backend = None
         self._untrack()
-        if notify and (callback := self.__disconnected_callback) is not None:
-            asyncio.get_running_loop().call_soon(callback, self)
+        if (
+            notify
+            and (
+                callback := self._make_disconnected_callback(
+                    self.__disconnected_callback
+                )
+            )
+            is not None
+        ):
+            asyncio.get_running_loop().call_soon(callback)
 
     async def _async_abort_unregistered_mid_connect(
-        self, scanner: BaseHaScanner, device: BLEDevice, is_local: bool
+        self, scanner: BaseHaScanner
     ) -> NoReturn:
         """
         Fail a connect whose scanner was unregistered while in flight.
 
         Tears the link down inline, without ever tracking it, so the
         wrapper reports disconnected and the caller can retry elsewhere.
+        The slot needs no explicit release: it stays occupied while the
+        link is up, and the slot manager's device watcher (or the
+        adapter's removal) already covers the other exits.
         """
         try:
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT) as timed_out:
@@ -758,8 +767,8 @@ class HaBleakClientWrapper(BleakClient):
                 scanner.name,
             )
             raise
-        except TimeoutError:
-            if timed_out.expired():
+        except Exception as exc:  # pylint: disable=broad-except
+            if isinstance(exc, TimeoutError) and timed_out.expired():
                 _LOGGER.warning(
                     "%s: timed out disconnecting after scanner %s was"
                     " unregistered mid connect",
@@ -767,26 +776,16 @@ class HaBleakClientWrapper(BleakClient):
                     scanner.name,
                 )
             else:
-                # The backend raised its own TimeoutError inside the bound.
                 _LOGGER.exception(
                     "%s: error disconnecting after scanner %s was"
                     " unregistered mid connect",
                     self.__address,
                     scanner.name,
                 )
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception(
-                "%s: error disconnecting after scanner %s was unregistered mid connect",
-                self.__address,
-                scanner.name,
-            )
         finally:
             # On every exit, including cancellation, the wrapper must not
-            # keep a handle to the doomed link, and a local adapter's slot
-            # must not stay allocated (release_slot no-ops on a live link).
+            # keep a handle to the doomed link.
             self._give_up()
-            if is_local:
-                self.__manager.async_release_connection_slot(device)
         msg = (
             f"{self.__address}: scanner {scanner.name} was unregistered during connect"
         )

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -721,17 +721,7 @@ class HaBleakClientWrapper(BleakClient):
         schedule their reconnect.
         """
         was_up = self.is_connected
-        if (backend := self._backend) is not None:
-            # The orphaned backend must not fire the consumer's disconnected
-            # callback against a later reconnect when the leaked link drops.
-            try:
-                backend.set_disconnected_callback(None)
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.debug(
-                    "%s: could not detach the disconnected callback",
-                    self.__address,
-                    exc_info=True,
-                )
+        self._detach_disconnected_callback()
         self._backend = None
         self._untrack()
         if (
@@ -747,6 +737,26 @@ class HaBleakClientWrapper(BleakClient):
         ):
             asyncio.get_running_loop().call_soon(callback)
 
+    def _detach_disconnected_callback(self) -> None:
+        """
+        Silence the backend's disconnected callback.
+
+        An orphaned or aborting backend must not fire the consumer's
+        callback: against a later reconnect when a leaked link drops, or
+        for a connect that is about to raise.
+        """
+        if (backend := self._backend) is None:
+            return
+        try:
+            backend.set_disconnected_callback(None)
+        except Exception:  # pylint: disable=broad-except
+            # A stale backend that later fires will reach the consumer.
+            _LOGGER.warning(
+                "%s: could not detach the disconnected callback",
+                self.__address,
+                exc_info=True,
+            )
+
     async def _async_abort_unregistered_mid_connect(
         self, scanner: BaseHaScanner
     ) -> NoReturn:
@@ -759,6 +769,9 @@ class HaBleakClientWrapper(BleakClient):
         link is up, and the slot manager's device watcher (or the
         adapter's removal) already covers the other exits.
         """
+        # The caller learns about this through the BleakError; silence the
+        # callback first or a clean teardown would fire it mid connect.
+        self._detach_disconnected_callback()
         try:
             async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT) as timed_out:
                 await self.disconnect()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -528,7 +528,6 @@ class HaBleakClientWrapper(BleakClient):
                     async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                         await self.disconnect()
                 except TimeoutError:
-                    self._backend = None
                     _LOGGER.warning(
                         "%s: timed out disconnecting after scanner %s was"
                         " unregistered mid connect",
@@ -536,7 +535,6 @@ class HaBleakClientWrapper(BleakClient):
                         scanner.name,
                     )
                 except Exception:  # pylint: disable=broad-except
-                    self._backend = None
                     _LOGGER.warning(
                         "%s: error disconnecting after scanner %s was"
                         " unregistered mid connect",
@@ -544,6 +542,10 @@ class HaBleakClientWrapper(BleakClient):
                         scanner.name,
                         exc_info=True,
                     )
+                finally:
+                    # On every exit, including cancellation, the wrapper
+                    # must not keep a handle to the doomed link.
+                    self._backend = None
                 msg = (
                     f"{self.__address}: scanner {scanner.name} was"
                     " unregistered during connect"

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -733,6 +733,9 @@ class HaBleakClientWrapper(BleakClient):
     async def disconnect(self) -> None:
         """Disconnect from the device."""
         if self._backend is None:
+            # No backend, but pointers from an earlier failed teardown may
+            # remain; _untrack is a no-op when the link is genuinely up.
+            self._untrack()
             return
         try:
             await self._backend.disconnect()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -720,6 +720,7 @@ class HaBleakClientWrapper(BleakClient):
         disconnected callback fires so integrations that wait for it
         schedule their reconnect.
         """
+        was_up = self.is_connected
         if (backend := self._backend) is not None:
             # The orphaned backend must not fire the consumer's disconnected
             # callback against a later reconnect when the leaked link drops.
@@ -735,6 +736,8 @@ class HaBleakClientWrapper(BleakClient):
         self._untrack()
         if (
             notify
+            # The backend already fired the callback if the link was down.
+            and was_up
             and (
                 callback := self._make_disconnected_callback(
                     self.__disconnected_callback

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -509,8 +509,8 @@ class HaBleakClientWrapper(BleakClient):
         if connected:
             self._connected_scanner = scanner
             self._connected_device = device
-            # Torn down by the manager if the scanner is unregistered.
-            manager.async_register_client(scanner, self)
+            # Disconnected by the manager if the scanner is unregistered.
+            scanner._clients.add(self)
             self._load_conn_params(
                 scanner,
                 device,
@@ -677,5 +677,6 @@ class HaBleakClientWrapper(BleakClient):
         """Disconnect from the device."""
         if self._backend is None:
             return
-        self.__manager.async_unregister_client(self._connected_scanner, self)
+        if (scanner := self._connected_scanner) is not None:
+            scanner._clients.discard(self)
         await self._backend.disconnect()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -513,15 +513,24 @@ class HaBleakClientWrapper(BleakClient):
 
         # Load medium connection parameters after successful connection
         if connected:
-            self._track(scanner, device)
             if manager.async_scanner_by_source(scanner.source) is not scanner:
                 # The scanner was unregistered while this connect was in
-                # flight; tear the link down inline so the wrapper reports
-                # disconnected and the caller can retry elsewhere.
+                # flight; tear the link down inline, without ever tracking
+                # it, so the wrapper reports disconnected and the caller
+                # can retry elsewhere.
                 try:
                     async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                         await self.disconnect()
+                except TimeoutError:
+                    self._backend = None
+                    _LOGGER.warning(
+                        "%s: timed out disconnecting after scanner %s was"
+                        " unregistered mid connect",
+                        self.__address,
+                        scanner.name,
+                    )
                 except Exception:  # pylint: disable=broad-except
+                    self._backend = None
                     _LOGGER.warning(
                         "%s: error disconnecting after scanner %s was"
                         " unregistered mid connect",
@@ -534,6 +543,7 @@ class HaBleakClientWrapper(BleakClient):
                     " unregistered during connect"
                 )
                 raise BleakError(msg)
+            self._track(scanner, device)
             self._load_conn_params(
                 scanner,
                 device,

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -512,7 +512,7 @@ class HaBleakClientWrapper(BleakClient):
             # Let the manager tear this connection down if the scanner it was
             # made through is unregistered; otherwise the link outlives the
             # adapter that owns it.
-            manager.async_register_client(scanner.source, self)
+            manager.async_register_client(scanner, self)
             self._load_conn_params(
                 scanner,
                 device,
@@ -679,6 +679,5 @@ class HaBleakClientWrapper(BleakClient):
         """Disconnect from the device."""
         if self._backend is None:
             return
-        if (scanner := self._connected_scanner) is not None:
-            self.__manager.async_unregister_client(scanner.source, self)
+        self.__manager.async_unregister_client(self._connected_scanner, self)
         await self._backend.disconnect()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -749,11 +749,10 @@ class HaBleakClientWrapper(BleakClient):
                 scanner.name,
             )
         except Exception:  # pylint: disable=broad-except
-            _LOGGER.warning(
+            _LOGGER.exception(
                 "%s: error disconnecting after scanner %s was unregistered mid connect",
                 self.__address,
                 scanner.name,
-                exc_info=True,
             )
         finally:
             # On every exit, including cancellation, the wrapper must not

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -718,6 +718,11 @@ class HaBleakClientWrapper(BleakClient):
         down, and the next establish_connection retry must re-resolve a
         backend instead of short circuiting on is_connected.
         """
+        if (backend := self._backend) is not None:
+            # The orphaned backend must not fire the consumer's disconnected
+            # callback against a later reconnect when the leaked link drops.
+            with contextlib.suppress(Exception):
+                backend.set_disconnected_callback(None)
         self._backend = None
         self._untrack()
 

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -357,17 +357,18 @@ class HaBleakClientWrapper(BleakClient):
         timeout: int,
     ) -> None:
         """Set BLE connection parameters on a connected device."""
+        if self._backend is not None and hasattr(
+            self._backend, "set_connection_params"
+        ):
+            # The backend owns its own not-connected handling.
+            await self._backend.set_connection_params(
+                min_interval, max_interval, latency, timeout
+            )
+            return
         if not self.is_connected:
             _LOGGER.debug(
                 "%s: not setting connection params; client is not connected",
                 self.__address,
-            )
-            return
-        if self._backend is not None and hasattr(
-            self._backend, "set_connection_params"
-        ):
-            await self._backend.set_connection_params(
-                min_interval, max_interval, latency, timeout
             )
             return
         # BlueZ local path - use mgmt API

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -521,7 +521,9 @@ class HaBleakClientWrapper(BleakClient):
         # Load medium connection parameters after successful connection
         if connected:
             if manager.async_scanner_by_source(scanner.source) is not scanner:
-                await self._async_abort_unregistered_mid_connect(scanner)
+                await self._async_abort_unregistered_mid_connect(
+                    scanner, device, not wrapped_backend.source
+                )
             self._track(scanner, device)
             self._load_conn_params(
                 scanner,
@@ -709,25 +711,35 @@ class HaBleakClientWrapper(BleakClient):
         if not self.is_connected:
             self._untrack()
 
-    def _give_up(self) -> None:
+    def _give_up(self, notify: bool = False) -> None:
         """
         Drop the backend and tracking for a link nothing can tear down.
 
         The link leaks to BlueZ (logged by the caller), but the wrapper
-        must not keep reporting connected: nothing else would ever tear it
+        must not keep reporting connected: nothing would ever tear it
         down, and the next establish_connection retry must re-resolve a
-        backend instead of short circuiting on is_connected.
+        backend instead of short circuiting on is_connected. With notify,
+        the consumer's disconnected callback fires so integrations that
+        wait for it schedule their reconnect.
         """
         if (backend := self._backend) is not None:
             # The orphaned backend must not fire the consumer's disconnected
             # callback against a later reconnect when the leaked link drops.
-            with contextlib.suppress(Exception):
+            try:
                 backend.set_disconnected_callback(None)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.debug(
+                    "%s: could not detach the disconnected callback",
+                    self.__address,
+                    exc_info=True,
+                )
         self._backend = None
         self._untrack()
+        if notify and (callback := self.__disconnected_callback) is not None:
+            asyncio.get_running_loop().call_soon(callback, self)
 
     async def _async_abort_unregistered_mid_connect(
-        self, scanner: BaseHaScanner
+        self, scanner: BaseHaScanner, device: BLEDevice, is_local: bool
     ) -> NoReturn:
         """
         Fail a connect whose scanner was unregistered while in flight.
@@ -736,7 +748,7 @@ class HaBleakClientWrapper(BleakClient):
         wrapper reports disconnected and the caller can retry elsewhere.
         """
         try:
-            async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
+            async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT) as timed_out:
                 await self.disconnect()
         except asyncio.CancelledError:
             _LOGGER.debug(
@@ -747,12 +759,21 @@ class HaBleakClientWrapper(BleakClient):
             )
             raise
         except TimeoutError:
-            _LOGGER.warning(
-                "%s: timed out disconnecting after scanner %s was"
-                " unregistered mid connect",
-                self.__address,
-                scanner.name,
-            )
+            if timed_out.expired():
+                _LOGGER.warning(
+                    "%s: timed out disconnecting after scanner %s was"
+                    " unregistered mid connect",
+                    self.__address,
+                    scanner.name,
+                )
+            else:
+                # The backend raised its own TimeoutError inside the bound.
+                _LOGGER.exception(
+                    "%s: error disconnecting after scanner %s was"
+                    " unregistered mid connect",
+                    self.__address,
+                    scanner.name,
+                )
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception(
                 "%s: error disconnecting after scanner %s was unregistered mid connect",
@@ -761,8 +782,11 @@ class HaBleakClientWrapper(BleakClient):
             )
         finally:
             # On every exit, including cancellation, the wrapper must not
-            # keep a handle to the doomed link.
+            # keep a handle to the doomed link, and a local adapter's slot
+            # must not stay allocated (release_slot no-ops on a live link).
             self._give_up()
+            if is_local:
+                self.__manager.async_release_connection_slot(device)
         msg = (
             f"{self.__address}: scanner {scanner.name} was unregistered during connect"
         )

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -518,9 +518,17 @@ class HaBleakClientWrapper(BleakClient):
                 # The scanner was unregistered while this connect was in
                 # flight; tear the link down inline so the wrapper reports
                 # disconnected and the caller can retry elsewhere.
-                with contextlib.suppress(Exception):
+                try:
                     async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
                         await self.disconnect()
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.warning(
+                        "%s: error disconnecting after scanner %s was"
+                        " unregistered mid connect",
+                        self.__address,
+                        scanner.name,
+                        exc_info=True,
+                    )
                 msg = (
                     f"{self.__address}: scanner {scanner.name} was"
                     " unregistered during connect"

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -507,6 +507,9 @@ class HaBleakClientWrapper(BleakClient):
 
         # Load medium connection parameters after successful connection
         if connected:
+            if (previous := self._connected_scanner) is not None:
+                # Reconnect may have landed on a different scanner.
+                previous._clients.discard(self)
             self._connected_scanner = scanner
             self._connected_device = device
             # Disconnected by the manager if the scanner is unregistered.
@@ -677,6 +680,6 @@ class HaBleakClientWrapper(BleakClient):
         """Disconnect from the device."""
         if self._backend is None:
             return
+        await self._backend.disconnect()
         if (scanner := self._connected_scanner) is not None:
             scanner._clients.discard(self)
-        await self._backend.disconnect()

--- a/src/habluetooth/wrappers.py
+++ b/src/habluetooth/wrappers.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Final, Literal, Self, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, Self, overload
 
 from bleak import BleakClient, BleakError, normalize_uuid_str
 from bleak.backends.client import BaseBleakClient, get_platform_client_backend_type
@@ -521,45 +521,7 @@ class HaBleakClientWrapper(BleakClient):
         # Load medium connection parameters after successful connection
         if connected:
             if manager.async_scanner_by_source(scanner.source) is not scanner:
-                # The scanner was unregistered while this connect was in
-                # flight; tear the link down inline, without ever tracking
-                # it, so the wrapper reports disconnected and the caller
-                # can retry elsewhere.
-                try:
-                    async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
-                        await self.disconnect()
-                except asyncio.CancelledError:
-                    _LOGGER.debug(
-                        "%s: cancelled disconnecting after scanner %s was"
-                        " unregistered mid connect",
-                        self.__address,
-                        scanner.name,
-                    )
-                    raise
-                except TimeoutError:
-                    _LOGGER.warning(
-                        "%s: timed out disconnecting after scanner %s was"
-                        " unregistered mid connect",
-                        self.__address,
-                        scanner.name,
-                    )
-                except Exception:  # pylint: disable=broad-except
-                    _LOGGER.warning(
-                        "%s: error disconnecting after scanner %s was"
-                        " unregistered mid connect",
-                        self.__address,
-                        scanner.name,
-                        exc_info=True,
-                    )
-                finally:
-                    # On every exit, including cancellation, the wrapper
-                    # must not keep a handle to the doomed link.
-                    self._backend = None
-                msg = (
-                    f"{self.__address}: scanner {scanner.name} was"
-                    " unregistered during connect"
-                )
-                raise BleakError(msg)
+                await self._async_abort_unregistered_mid_connect(scanner)
             self._track(scanner, device)
             self._load_conn_params(
                 scanner,
@@ -747,12 +709,67 @@ class HaBleakClientWrapper(BleakClient):
         if not self.is_connected:
             self._untrack()
 
+    def _give_up(self) -> None:
+        """
+        Drop the backend and tracking for a link nothing can tear down.
+
+        The link leaks to BlueZ (logged by the caller), but the wrapper
+        must not keep reporting connected: nothing else would ever tear it
+        down, and the next establish_connection retry must re-resolve a
+        backend instead of short circuiting on is_connected.
+        """
+        self._backend = None
+        self._untrack()
+
+    async def _async_abort_unregistered_mid_connect(
+        self, scanner: BaseHaScanner
+    ) -> NoReturn:
+        """
+        Fail a connect whose scanner was unregistered while in flight.
+
+        Tears the link down inline, without ever tracking it, so the
+        wrapper reports disconnected and the caller can retry elsewhere.
+        """
+        try:
+            async with asyncio.timeout(CLIENT_DISCONNECT_TIMEOUT):
+                await self.disconnect()
+        except asyncio.CancelledError:
+            _LOGGER.debug(
+                "%s: cancelled disconnecting after scanner %s was"
+                " unregistered mid connect",
+                self.__address,
+                scanner.name,
+            )
+            raise
+        except TimeoutError:
+            _LOGGER.warning(
+                "%s: timed out disconnecting after scanner %s was"
+                " unregistered mid connect",
+                self.__address,
+                scanner.name,
+            )
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "%s: error disconnecting after scanner %s was unregistered mid connect",
+                self.__address,
+                scanner.name,
+                exc_info=True,
+            )
+        finally:
+            # On every exit, including cancellation, the wrapper must not
+            # keep a handle to the doomed link.
+            self._give_up()
+        msg = (
+            f"{self.__address}: scanner {scanner.name} was unregistered during connect"
+        )
+        raise BleakError(msg)
+
     async def disconnect(self) -> None:
         """Disconnect from the device."""
         if self._backend is None:
-            # No backend, but pointers from an earlier failed teardown may
-            # remain.
-            self._untrack_if_down()
+            # No backend means not connected; drop any pointers left by an
+            # earlier failed teardown.
+            self._untrack()
             return
         try:
             await self._backend.disconnect()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,12 +6,14 @@ import asyncio
 import gc
 import logging
 import sys
+from collections.abc import AsyncGenerator, Callable
 from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import bleak
 import pytest
+import pytest_asyncio
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 from bleak_retry_connector import Allocations
@@ -39,11 +41,15 @@ from . import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Generator
+    from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 
     from bleak.backends.scanner import AdvertisementData
 
     from habluetooth.manager import BluetoothManager
+
+    ConnectedClient = tuple[
+        bleak.BleakClient, dict[str, Any], dict[str, Callable[[], None]]
+    ]
 
 
 @contextmanager
@@ -252,87 +258,58 @@ def _generate_scanners_with_fake_devices():
     return hci0_device_advs, cancel_hci0, cancel_hci1
 
 
-@pytest.mark.asyncio
-async def test_unregister_scanner_disconnects_its_clients(
+@pytest_asyncio.fixture
+async def connected_client(
     two_adapters: None,
     enable_bluetooth: None,
     install_bleak_catcher: None,
     mock_platform_client: None,
-) -> None:
-    """A scanner going away takes the connections made through it with it."""
+) -> AsyncGenerator[ConnectedClient, None]:
+    """A client connected through hci0 plus the scanner cancel callbacks."""
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-
-    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
     with patch.object(FakeBleakClient, "is_connected", return_value=True):
-        client = bleak.BleakClient(ble_device)
+        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
         await client.connect()
-
-        with patch.object(
-            FakeBleakClient, "disconnect", new_callable=AsyncMock
-        ) as disconnect_mock:
-            cancel_hci0()
-            # The disconnect is scheduled on the loop, not awaited inline.
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            assert disconnect_mock.call_count == 1
-
+        yield client, hci0_device_advs, {"hci0": cancel_hci0, "hci1": cancel_hci1}
+    cancel_hci0()
     cancel_hci1()
 
 
+async def _settle_disconnects() -> None:
+    """Wait for the manager's scheduled disconnects."""
+    await asyncio.gather(*_get_manager()._background_tasks)
+
+
 @pytest.mark.asyncio
-async def test_unregister_scanner_leaves_other_sources_connected(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
+@pytest.mark.parametrize(("removed", "disconnects"), [("hci0", 1), ("hci1", 0)])
+async def test_unregister_scanner_disconnects_only_its_clients(
+    connected_client: ConnectedClient, removed: str, disconnects: int
 ) -> None:
-    """Removing one scanner must not disconnect clients of another."""
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-
-    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
-    with patch.object(FakeBleakClient, "is_connected", return_value=True):
-        client = bleak.BleakClient(ble_device)
-        await client.connect()
-
-        with patch.object(
-            FakeBleakClient, "disconnect", new_callable=AsyncMock
-        ) as disconnect_mock:
-            cancel_hci1()
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            assert disconnect_mock.call_count == 0
-
-    cancel_hci0()
+    """Removing a scanner disconnects its clients and nobody else's."""
+    _, _, cancel = connected_client
+    with patch.object(
+        FakeBleakClient, "disconnect", new_callable=AsyncMock
+    ) as disconnect_mock:
+        cancel[removed]()
+        await _settle_disconnects()
+    assert disconnect_mock.call_count == disconnects
 
 
 @pytest.mark.asyncio
 async def test_disconnected_client_is_not_disconnected_again(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
+    connected_client: ConnectedClient,
 ) -> None:
-    """A client that already disconnected is not tracked any more."""
-    manager = _get_manager()
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-
-    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
-    with patch.object(FakeBleakClient, "is_connected", return_value=True):
-        client = bleak.BleakClient(ble_device)
-        await client.connect()
-        source = client._connected_scanner.source
-        await client.disconnect()
-        assert source not in manager._clients
-
-        with patch.object(
-            FakeBleakClient, "disconnect", new_callable=AsyncMock
-        ) as disconnect_mock:
-            cancel_hci0()
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            assert disconnect_mock.call_count == 0
-
-    cancel_hci1()
+    """A client that already disconnected is no longer tracked."""
+    client, _, cancel = connected_client
+    scanner = client._connected_scanner
+    await client.disconnect()
+    assert client not in scanner._clients
+    with patch.object(
+        FakeBleakClient, "disconnect", new_callable=AsyncMock
+    ) as disconnect_mock:
+        cancel["hci0"]()
+        await _settle_disconnects()
+    assert disconnect_mock.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -343,83 +320,48 @@ async def test_client_tracking_does_not_keep_client_alive(
     mock_platform_client: None,
 ) -> None:
     """Tracked clients are held weakly so a dropped client cannot leak."""
-    manager = _get_manager()
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-
-    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
     with patch.object(FakeBleakClient, "is_connected", return_value=True):
-        client = bleak.BleakClient(ble_device)
+        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
         await client.connect()
-        source = client._connected_scanner.source
-        assert len(manager._clients[source]) == 1
-
+        scanner = client._connected_scanner
+        assert len(scanner._clients) == 1
         del client
         gc.collect()
-        assert len(manager._clients[source]) == 0
-
+        assert len(scanner._clients) == 0
     cancel_hci0()
     cancel_hci1()
 
 
 @pytest.mark.asyncio
 async def test_disconnect_error_on_unregister_is_logged_not_raised(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
-    caplog: pytest.LogCaptureFixture,
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A client that fails to disconnect must not break scanner teardown."""
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-
-    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
-    with patch.object(FakeBleakClient, "is_connected", return_value=True):
-        client = bleak.BleakClient(ble_device)
-        await client.connect()
-
-        with patch.object(
-            FakeBleakClient,
-            "disconnect",
-            new_callable=AsyncMock,
-            side_effect=BleakError("nope"),
-        ):
-            cancel_hci0()
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-
+    _, _, cancel = connected_client
+    with patch.object(
+        FakeBleakClient,
+        "disconnect",
+        new_callable=AsyncMock,
+        side_effect=BleakError("nope"),
+    ):
+        cancel["hci0"]()
+        await _settle_disconnects()
     assert "Error disconnecting client from removed scanner" in caplog.text
-
-    cancel_hci1()
 
 
 @pytest.mark.asyncio
-async def test_unregister_client_keeps_source_with_other_clients(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
+async def test_disconnect_keeps_other_clients_tracked(
+    connected_client: ConnectedClient,
 ) -> None:
-    """Untracking one client leaves the source's other clients tracked."""
-    manager = _get_manager()
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-
-    with patch.object(FakeBleakClient, "is_connected", return_value=True):
-        first = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
-        await first.connect()
-        second = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:02"][0])
-        await second.connect()
-        source = first._connected_scanner.source
-        assert len(manager._clients[source]) == 2
-
-        await first.disconnect()
-        assert source in manager._clients
-        assert len(manager._clients[source]) == 1
-
-        manager.async_unregister_client(None, second)
-        assert len(manager._clients[source]) == 1
-
-    cancel_hci0()
-    cancel_hci1()
+    """Untracking one client leaves the scanner's other clients tracked."""
+    first, hci0_device_advs, _ = connected_client
+    second = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:02"][0])
+    await second.connect()
+    scanner = first._connected_scanner
+    assert len(scanner._clients) == 2
+    await first.disconnect()
+    assert set(scanner._clients) == {second}
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -483,6 +483,23 @@ async def test_connect_in_flight_when_scanner_unregisters(
 
 
 @pytest.mark.asyncio
+async def test_dropped_link_is_not_disconnected_on_unregister(
+    connected_client: ConnectedClient,
+) -> None:
+    """A client whose link already dropped is skipped at unregister."""
+    _, _, cancel = connected_client
+    with (
+        patch.object(FakeBleakClient, "is_connected", False),
+        patch.object(
+            FakeBleakClient, "disconnect", new_callable=AsyncMock
+        ) as disconnect_mock,
+    ):
+        cancel["hci0"]()
+        await _settle_disconnects()
+    assert disconnect_mock.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_track_moves_client_between_scanners(
     connected_client: ConnectedClient,
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -447,24 +447,6 @@ async def test_stop_cancels_pending_disconnects(
 
 
 @pytest.mark.asyncio
-async def test_abort_mid_connect_remote_does_not_release_local_slot(
-    connected_client: ConnectedClient,
-) -> None:
-    """The abort only releases a slot for a local adapter."""
-    client, _, _ = connected_client
-    scanner = client._connected_scanner
-    device = client._connected_device
-    manager = _get_manager()
-    with (
-        patch.object(manager.slot_manager, "release_slot") as release_slot_mock,
-        patch.object(FakeBleakClient, "disconnect", new_callable=AsyncMock),
-        pytest.raises(BleakError, match="unregistered during connect"),
-    ):
-        await client._async_abort_unregistered_mid_connect(scanner, device, False)
-    assert release_slot_mock.call_count == 0
-
-
-@pytest.mark.asyncio
 async def test_manager_backend_timeout_is_not_misreported(
     connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -484,11 +466,11 @@ async def test_manager_backend_timeout_is_not_misreported(
 
 @pytest.mark.asyncio
 async def test_give_up_detaches_the_disconnected_callback(
-    connected_client: ConnectedClient,
+    install_bleak_catcher: None,
 ) -> None:
     """Give up silences the orphaned backend's disconnected callback."""
-    client, _, _ = connected_client
-    backend = Mock()
+    client = HaBleakClientWrapper(generate_ble_device("00:00:00:00:00:0E", "x"))
+    backend: Any = Mock()
     client._backend = backend
     client._give_up()
     backend.set_disconnected_callback.assert_called_once_with(None)
@@ -497,8 +479,15 @@ async def test_give_up_detaches_the_disconnected_callback(
     # Idempotent with no backend left.
     client._give_up()
     backend.set_disconnected_callback.assert_called_once_with(None)
-    # A backend that refuses to detach is logged, not fatal.
-    refusing = Mock()
+
+
+@pytest.mark.asyncio
+async def test_give_up_survives_a_backend_that_refuses_to_detach(
+    install_bleak_catcher: None,
+) -> None:
+    """A backend that refuses to detach is logged, not fatal."""
+    client = HaBleakClientWrapper(generate_ble_device("00:00:00:00:00:0E", "x"))
+    refusing: Any = Mock()
     refusing.set_disconnected_callback.side_effect = ValueError("no")
     client._backend = refusing
     client._give_up()
@@ -593,7 +582,6 @@ async def test_connect_in_flight_when_scanner_unregisters(
 
     timeout = 0.0 if zero_timeout else CLIENT_DISCONNECT_TIMEOUT
     with (
-        patch.object(_get_manager().slot_manager, "release_slot") as release_slot_mock,
         patch("habluetooth.wrappers.CLIENT_DISCONNECT_TIMEOUT", timeout),
         patch.object(FakeBleakClient, "is_connected", return_value=True),
         patch.object(FakeBleakClient, "connect", _connect_and_unregister),
@@ -609,7 +597,6 @@ async def test_connect_in_flight_when_scanner_unregisters(
             await client.connect()
         assert client._backend is None
     assert disconnect_mock.call_count == 1
-    assert release_slot_mock.call_count == 1
     if log_fragment is not None:
         assert log_fragment in caplog.text
     cancel_hci1()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -398,7 +398,7 @@ async def test_disconnect_timeout_on_unregister_is_logged(
     connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A hanging disconnect is bounded and logged, not pending forever."""
-    _, _, cancel = connected_client
+    client, _, cancel = connected_client
 
     with (
         patch("habluetooth.manager.CLIENT_DISCONNECT_TIMEOUT", 0.0),
@@ -406,6 +406,7 @@ async def test_disconnect_timeout_on_unregister_is_logged(
     ):
         cancel["hci0"]()
         await _settle_disconnects()
+        assert client._backend is None
     assert "Timed out disconnecting client 00:00:00:00:00:01" in caplog.text
 
 
@@ -607,10 +608,9 @@ async def test_background_task_exception_is_logged(
         msg = "boom"
         raise ValueError(msg)
 
-    manager.async_add_background_task(_boom(), "boom task")
+    manager._async_add_background_task(_boom(), "boom task")
     await _settle_disconnects()
-    assert "Background task" in caplog.text
-    assert "failed" in caplog.text
+    assert "Background task boom task failed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -484,6 +484,25 @@ async def test_connect_in_flight_when_scanner_unregisters(
 
 
 @pytest.mark.asyncio
+async def test_background_task_exception_is_logged(
+    two_adapters: None,
+    enable_bluetooth: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An exception escaping a background task is logged, not lost."""
+    manager = _get_manager()
+
+    async def _boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    manager.async_add_background_task(_boom())
+    await asyncio.gather(*manager._background_tasks, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert "Background task failed" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_disconnect_without_connected_scanner(
     install_bleak_catcher: None,
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -303,7 +303,8 @@ async def test_disconnected_client_is_not_disconnected_again(
     """A client that already disconnected is no longer tracked."""
     client, _, cancel = connected_client
     scanner = client._connected_scanner
-    await client.disconnect()
+    with patch.object(FakeBleakClient, "is_connected", False):
+        await client.disconnect()
     assert client not in scanner._clients
     with patch.object(
         FakeBleakClient, "disconnect", new_callable=AsyncMock
@@ -428,6 +429,26 @@ async def test_stop_cancels_pending_disconnects(
 
 
 @pytest.mark.asyncio
+async def test_failed_disconnect_keeps_client_tracked(
+    connected_client: ConnectedClient,
+) -> None:
+    """A disconnect that raises with the link still up keeps the client tracked."""
+    client, _, _ = connected_client
+    scanner = client._connected_scanner
+    with (
+        patch.object(
+            FakeBleakClient,
+            "disconnect",
+            new_callable=AsyncMock,
+            side_effect=BleakError("nope"),
+        ),
+        pytest.raises(BleakError),
+    ):
+        await client.disconnect()
+    assert client in scanner._clients
+
+
+@pytest.mark.asyncio
 async def test_disconnect_without_connected_scanner(
     install_bleak_catcher: None,
 ) -> None:
@@ -448,7 +469,8 @@ async def test_disconnect_keeps_other_clients_tracked(
     await second.connect()
     scanner = first._connected_scanner
     assert len(scanner._clients) == 2
-    await first.disconnect()
+    with patch.object(FakeBleakClient, "is_connected", False):
+        await first.disconnect()
     assert set(scanner._clients) == {second}
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -412,11 +412,9 @@ async def test_unregister_client_keeps_source_with_other_clients(
         assert len(manager._clients[source]) == 2
 
         await first.disconnect()
-        # The source must survive: the second client is still connected.
         assert source in manager._clients
         assert len(manager._clients[source]) == 1
 
-        # A client that never recorded a scanner is passed straight through.
         manager.async_unregister_client(None, second)
         assert len(manager._clients[source]) == 1
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -495,6 +495,23 @@ async def test_give_up_survives_a_backend_that_refuses_to_detach(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(("link_up", "notified"), [(True, True), (False, False)])
+async def test_give_up_notifies_only_when_the_link_was_up(
+    install_bleak_catcher: None, link_up: bool, notified: bool
+) -> None:
+    """The consumer hears about a give up once, not twice."""
+    client = HaBleakClientWrapper(generate_ble_device("00:00:00:00:00:0E", "x"))
+    disconnected: list[bleak.BleakClient] = []
+    client.set_disconnected_callback(disconnected.append)
+    backend: Any = Mock()
+    backend.is_connected = link_up
+    client._backend = backend
+    client._give_up(notify=True)
+    await asyncio.sleep(0)
+    assert (disconnected == [client]) is notified
+
+
+@pytest.mark.asyncio
 async def test_failed_disconnect_with_link_down_untracks(
     connected_client: ConnectedClient,
 ) -> None:
@@ -683,10 +700,13 @@ async def test_disconnect_untracks_even_if_backend_still_reports_connected(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reconnected_elsewhere", [False, True])
 async def test_base_exception_from_disconnect_gives_up_client(
-    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
+    connected_client: ConnectedClient,
+    caplog: pytest.LogCaptureFixture,
+    reconnected_elsewhere: bool,
 ) -> None:
-    """A BaseException escaping a child is logged and the client given up."""
+    """A BaseException escaping a child is logged; give up re-checks identity."""
     client, _, cancel = connected_client
     with patch.object(
         FakeBleakClient,
@@ -694,9 +714,12 @@ async def test_base_exception_from_disconnect_gives_up_client(
         new_callable=AsyncMock,
         side_effect=asyncio.CancelledError,
     ):
+        if reconnected_elsewhere:
+            # The late results pass must not give up a client that moved on.
+            client._connected_scanner = MagicMock()
         cancel["hci0"]()
         await _settle_disconnects()
-        assert client._backend is None
+        assert (client._backend is None) is not reconnected_elsewhere
     assert "Unexpected error disconnecting client" in caplog.text
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -513,7 +513,40 @@ async def test_connect_in_flight_unregister_teardown_failure_is_logged(
         client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
         with pytest.raises(BleakError, match="unregistered during connect"):
             await client.connect()
-    assert "unregistered mid connect" in caplog.text
+        assert client._backend is None
+    assert "error disconnecting after scanner" in caplog.text
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
+async def test_connect_in_flight_unregister_teardown_timeout_is_logged(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hanging inline teardown is bounded, logged without a traceback."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+    original_connect = FakeBleakClient.connect
+
+    async def _connect_and_unregister(
+        self: FakeBleakClient, *args: Any, **kwargs: Any
+    ) -> None:
+        await original_connect(self, *args, **kwargs)
+        cancel_hci0()
+
+    with (
+        patch("habluetooth.wrappers.CLIENT_DISCONNECT_TIMEOUT", 0.0),
+        patch.object(FakeBleakClient, "is_connected", return_value=True),
+        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
+        patch.object(FakeBleakClient, "disconnect", side_effect=_hang),
+    ):
+        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
+        with pytest.raises(BleakError, match="unregistered during connect"):
+            await client.connect()
+        assert client._backend is None
+    assert "timed out disconnecting after scanner" in caplog.text
     cancel_hci1()
 
 
@@ -574,7 +607,7 @@ async def test_background_task_exception_is_logged(
         msg = "boom"
         raise ValueError(msg)
 
-    manager.async_add_background_task(_boom())
+    manager.async_add_background_task(_boom(), "boom task")
     await _settle_disconnects()
     assert "Background task" in caplog.text
     assert "failed" in caplog.text

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -406,6 +406,11 @@ async def test_disconnect_timeout_on_unregister_is_logged(
     """A hanging disconnect is bounded and logged, not pending forever."""
     client, _, cancel = connected_client
 
+    disconnected: list[bleak.BleakClient] = []
+    with patch.object(
+        FakeBleakClient, "set_disconnected_callback", Mock(), create=True
+    ):
+        client.set_disconnected_callback(disconnected.append)
     with (
         patch("habluetooth.manager.CLIENT_DISCONNECT_TIMEOUT", 0.0),
         patch.object(FakeBleakClient, "disconnect", side_effect=_hang),
@@ -415,6 +420,8 @@ async def test_disconnect_timeout_on_unregister_is_logged(
         assert client._backend is None
         assert client._connected_scanner is None
         assert not client.is_connected
+        await asyncio.sleep(0)
+    assert disconnected == [client]
     assert "Timed out disconnecting client 00:00:00:00:00:01" in caplog.text
 
 
@@ -440,6 +447,42 @@ async def test_stop_cancels_pending_disconnects(
 
 
 @pytest.mark.asyncio
+async def test_abort_mid_connect_remote_does_not_release_local_slot(
+    connected_client: ConnectedClient,
+) -> None:
+    """The abort only releases a slot for a local adapter."""
+    client, _, _ = connected_client
+    scanner = client._connected_scanner
+    device = client._connected_device
+    manager = _get_manager()
+    with (
+        patch.object(manager.slot_manager, "release_slot") as release_slot_mock,
+        patch.object(FakeBleakClient, "disconnect", new_callable=AsyncMock),
+        pytest.raises(BleakError, match="unregistered during connect"),
+    ):
+        await client._async_abort_unregistered_mid_connect(scanner, device, False)
+    assert release_slot_mock.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_manager_backend_timeout_is_not_misreported(
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A backend raised TimeoutError logs as an error, not the deadline."""
+    _, _, cancel = connected_client
+    with patch.object(
+        FakeBleakClient,
+        "disconnect",
+        new_callable=AsyncMock,
+        side_effect=TimeoutError("backend"),
+    ):
+        cancel["hci0"]()
+        await _settle_disconnects()
+    assert "Error disconnecting client" in caplog.text
+    assert "Timed out disconnecting client" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_give_up_detaches_the_disconnected_callback(
     connected_client: ConnectedClient,
 ) -> None:
@@ -454,6 +497,12 @@ async def test_give_up_detaches_the_disconnected_callback(
     # Idempotent with no backend left.
     client._give_up()
     backend.set_disconnected_callback.assert_called_once_with(None)
+    # A backend that refuses to detach is logged, not fatal.
+    refusing = Mock()
+    refusing.set_disconnected_callback.side_effect = ValueError("no")
+    client._backend = refusing
+    client._give_up()
+    assert client._backend is None
 
 
 @pytest.mark.asyncio
@@ -505,6 +554,12 @@ async def test_failed_disconnect_keeps_client_tracked(
         (None, False, BleakError, None),
         (BleakError("nope"), False, BleakError, "error disconnecting after scanner"),
         (
+            TimeoutError("backend"),
+            False,
+            BleakError,
+            "error disconnecting after scanner",
+        ),
+        (
             asyncio.CancelledError,
             False,
             asyncio.CancelledError,
@@ -512,7 +567,7 @@ async def test_failed_disconnect_keeps_client_tracked(
         ),
         (_hang, True, BleakError, "timed out disconnecting after scanner"),
     ],
-    ids=["clean", "error", "cancelled", "timeout"],
+    ids=["clean", "error", "backend_timeout", "cancelled", "timeout"],
 )
 async def test_connect_in_flight_when_scanner_unregisters(
     two_adapters: None,
@@ -538,6 +593,7 @@ async def test_connect_in_flight_when_scanner_unregisters(
 
     timeout = 0.0 if zero_timeout else CLIENT_DISCONNECT_TIMEOUT
     with (
+        patch.object(_get_manager().slot_manager, "release_slot") as release_slot_mock,
         patch("habluetooth.wrappers.CLIENT_DISCONNECT_TIMEOUT", timeout),
         patch.object(FakeBleakClient, "is_connected", return_value=True),
         patch.object(FakeBleakClient, "connect", _connect_and_unregister),
@@ -553,6 +609,7 @@ async def test_connect_in_flight_when_scanner_unregisters(
             await client.connect()
         assert client._backend is None
     assert disconnect_mock.call_count == 1
+    assert release_slot_mock.call_count == 1
     if log_fragment is not None:
         assert log_fragment in caplog.text
     cancel_hci1()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -448,6 +448,38 @@ async def test_failed_disconnect_keeps_client_tracked(
 
 
 @pytest.mark.asyncio
+async def test_connect_in_flight_when_scanner_unregisters(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """A connect that finishes after its scanner unregistered is torn down."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+    original_connect = FakeBleakClient.connect
+
+    async def _connect_and_unregister(
+        self: FakeBleakClient, *args: Any, **kwargs: Any
+    ) -> None:
+        await original_connect(self, *args, **kwargs)
+        # The scanner goes away while the connect is still in flight.
+        cancel_hci0()
+
+    with (
+        patch.object(FakeBleakClient, "is_connected", return_value=True),
+        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
+    ):
+        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
+        with patch.object(
+            FakeBleakClient, "disconnect", new_callable=AsyncMock
+        ) as disconnect_mock:
+            await client.connect()
+            await _settle_disconnects()
+        assert disconnect_mock.call_count == 1
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
 async def test_disconnect_without_connected_scanner(
     install_bleak_catcher: None,
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -404,12 +404,12 @@ async def test_disconnect_timeout_on_unregister_is_logged(
     ):
         cancel["hci0"]()
         await _settle_disconnects()
-    assert "Error disconnecting client 00:00:00:00:00:01" in caplog.text
+    assert "Timed out disconnecting client 00:00:00:00:00:01" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_stop_cancels_pending_disconnects(
-    connected_client: ConnectedClient,
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     """async_stop cancels disconnect tasks still in flight."""
     _, _, cancel = connected_client
@@ -427,6 +427,7 @@ async def test_stop_cancels_pending_disconnects(
         manager.async_stop()
         await asyncio.wait(tasks, timeout=1)
     assert all(task.cancelled() for task in tasks)
+    assert "Cancelled disconnecting 1 client(s)" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -475,7 +476,8 @@ async def test_connect_in_flight_when_scanner_unregisters(
         with patch.object(
             FakeBleakClient, "disconnect", new_callable=AsyncMock
         ) as disconnect_mock:
-            await client.connect()
+            with pytest.raises(BleakError, match="unregistered during connect"):
+                await client.connect()
             await _settle_disconnects()
         assert disconnect_mock.call_count == 1
     cancel_hci1()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -276,8 +276,13 @@ async def connected_client(
 
 
 async def _settle_disconnects() -> None:
-    """Wait for the manager's scheduled disconnects."""
-    await asyncio.gather(*_get_manager()._background_tasks)
+    """Wait for the manager's background tasks to finish."""
+    await asyncio.gather(*_get_manager()._background_tasks, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+async def _hang() -> None:
+    await asyncio.Event().wait()
 
 
 @pytest.mark.asyncio
@@ -395,9 +400,6 @@ async def test_disconnect_timeout_on_unregister_is_logged(
     """A hanging disconnect is bounded and logged, not pending forever."""
     _, _, cancel = connected_client
 
-    async def _hang() -> None:
-        await asyncio.Event().wait()
-
     with (
         patch("habluetooth.manager.CLIENT_DISCONNECT_TIMEOUT", 0.0),
         patch.object(FakeBleakClient, "disconnect", side_effect=_hang),
@@ -414,9 +416,6 @@ async def test_stop_cancels_pending_disconnects(
     """async_stop cancels disconnect tasks still in flight."""
     _, _, cancel = connected_client
     manager = _get_manager()
-
-    async def _hang() -> None:
-        await asyncio.Event().wait()
 
     with patch.object(FakeBleakClient, "disconnect", side_effect=_hang):
         cancel["hci0"]()
@@ -497,8 +496,7 @@ async def test_background_task_exception_is_logged(
         raise ValueError(msg)
 
     manager.async_add_background_task(_boom())
-    await asyncio.gather(*manager._background_tasks, return_exceptions=True)
-    await asyncio.sleep(0)
+    await _settle_disconnects()
     assert "Background task failed" in caplog.text
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -344,7 +344,7 @@ async def test_disconnect_error_on_unregister_is_logged_not_raised(
     connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A client that fails to disconnect must not break scanner teardown."""
-    _, _, cancel = connected_client
+    client, _, cancel = connected_client
     with patch.object(
         FakeBleakClient,
         "disconnect",
@@ -353,6 +353,8 @@ async def test_disconnect_error_on_unregister_is_logged_not_raised(
     ):
         cancel["hci0"]()
         await _settle_disconnects()
+        assert client._backend is None
+        assert client._connected_scanner is None
     assert "from removed scanner" in caplog.text
 
 
@@ -407,6 +409,8 @@ async def test_disconnect_timeout_on_unregister_is_logged(
         cancel["hci0"]()
         await _settle_disconnects()
         assert client._backend is None
+        assert client._connected_scanner is None
+        assert not client.is_connected
     assert "Timed out disconnecting client 00:00:00:00:00:01" in caplog.text
 
 
@@ -611,6 +615,22 @@ async def test_background_task_exception_is_logged(
     manager._async_add_background_task(_boom(), "boom task")
     await _settle_disconnects()
     assert "Background task boom task failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_disconnect_without_backend_untracks_stale_pointers(
+    connected_client: ConnectedClient,
+) -> None:
+    """Disconnect with no backend clears pointers left by a failed teardown."""
+    client, _, _ = connected_client
+    scanner = client._connected_scanner
+    assert client in scanner._clients
+    with patch.object(FakeBleakClient, "is_connected", False):
+        client._backend = None
+        await client.disconnect()
+    assert client not in scanner._clients
+    assert client._connected_scanner is None
+    assert client._connected_device is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -435,7 +435,25 @@ async def test_stop_cancels_pending_disconnects(
         manager.async_stop()
         await asyncio.wait(tasks, timeout=1)
     assert all(task.cancelled() for task in tasks)
+    assert "Cancelling 1 background task(s) at stop" in caplog.text
     assert "Cancelled disconnecting 1 client(s)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_give_up_detaches_the_disconnected_callback(
+    connected_client: ConnectedClient,
+) -> None:
+    """Give up silences the orphaned backend's disconnected callback."""
+    client, _, _ = connected_client
+    backend = Mock()
+    client._backend = backend
+    client._give_up()
+    backend.set_disconnected_callback.assert_called_once_with(None)
+    assert client._backend is None
+    assert client._connected_scanner is None
+    # Idempotent with no backend left.
+    client._give_up()
+    backend.set_disconnected_callback.assert_called_once_with(None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -9,6 +9,7 @@ import sys
 from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import call as mock_call
 
 import bleak
 import pytest
@@ -483,7 +484,7 @@ async def test_give_up_detaches_the_disconnected_callback(
 
 @pytest.mark.asyncio
 async def test_give_up_survives_a_backend_that_refuses_to_detach(
-    install_bleak_catcher: None,
+    install_bleak_catcher: None, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A backend that refuses to detach is logged, not fatal."""
     client = HaBleakClientWrapper(generate_ble_device("00:00:00:00:00:0E", "x"))
@@ -492,6 +493,28 @@ async def test_give_up_survives_a_backend_that_refuses_to_detach(
     client._backend = refusing
     client._give_up()
     assert client._backend is None
+    assert "could not detach the disconnected callback" in caplog.text
+    assert caplog.records[-1].levelname == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_abort_detaches_the_callback_before_disconnecting(
+    install_bleak_catcher: None,
+) -> None:
+    """A clean abort cannot fire the consumer callback mid connect."""
+    client = HaBleakClientWrapper(generate_ble_device("00:00:00:00:00:0E", "x"))
+    backend: Any = Mock()
+    backend.disconnect = AsyncMock()
+    backend.is_connected = False
+    client._backend = backend
+    aborted = False
+    try:
+        await client._async_abort_unregistered_mid_connect(MagicMock())
+    except BleakError as err:
+        aborted = "unregistered during connect" in str(err)
+    assert aborted
+    assert backend.mock_calls[0] == mock_call.set_disconnected_callback(None)
+    assert mock_call.disconnect() in backend.mock_calls
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -439,6 +439,28 @@ async def test_stop_cancels_pending_disconnects(
 
 
 @pytest.mark.asyncio
+async def test_failed_disconnect_with_link_down_untracks(
+    connected_client: ConnectedClient,
+) -> None:
+    """A raising disconnect still untracks when the link actually dropped."""
+    client, _, _ = connected_client
+    scanner = client._connected_scanner
+    with (
+        patch.object(FakeBleakClient, "is_connected", False),
+        patch.object(
+            FakeBleakClient,
+            "disconnect",
+            new_callable=AsyncMock,
+            side_effect=BleakError("nope"),
+        ),
+        pytest.raises(BleakError),
+    ):
+        await client.disconnect()
+    assert client not in scanner._clients
+    assert client._connected_scanner is None
+
+
+@pytest.mark.asyncio
 async def test_failed_disconnect_keeps_client_tracked(
     connected_client: ConnectedClient,
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 import sys
 from contextlib import contextmanager, suppress
@@ -249,6 +250,115 @@ def _generate_scanners_with_fake_devices():
     cancel_hci1 = manager.async_register_scanner(scanner_hci1, connection_slots=1)
 
     return hci0_device_advs, cancel_hci0, cancel_hci1
+
+
+@pytest.mark.asyncio
+async def test_unregister_scanner_disconnects_its_clients(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """A scanner going away takes the connections made through it with it."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+    with patch.object(FakeBleakClient, "is_connected", return_value=True):
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+
+        with patch.object(
+            FakeBleakClient, "disconnect", new_callable=AsyncMock
+        ) as disconnect_mock:
+            cancel_hci0()
+            # The disconnect is scheduled on the loop, not awaited inline.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert disconnect_mock.call_count == 1
+
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
+async def test_unregister_scanner_leaves_other_sources_connected(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """Removing one scanner must not disconnect clients of another."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+    with patch.object(FakeBleakClient, "is_connected", return_value=True):
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+
+        with patch.object(
+            FakeBleakClient, "disconnect", new_callable=AsyncMock
+        ) as disconnect_mock:
+            cancel_hci1()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert disconnect_mock.call_count == 0
+
+    cancel_hci0()
+
+
+@pytest.mark.asyncio
+async def test_disconnected_client_is_not_disconnected_again(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """A client that already disconnected is not tracked any more."""
+    manager = _get_manager()
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+    with patch.object(FakeBleakClient, "is_connected", return_value=True):
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+        source = client._connected_scanner.source
+        await client.disconnect()
+        assert source not in manager._clients
+
+        with patch.object(
+            FakeBleakClient, "disconnect", new_callable=AsyncMock
+        ) as disconnect_mock:
+            cancel_hci0()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert disconnect_mock.call_count == 0
+
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
+async def test_client_tracking_does_not_keep_client_alive(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """Tracked clients are held weakly so a dropped client cannot leak."""
+    manager = _get_manager()
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+    with patch.object(FakeBleakClient, "is_connected", return_value=True):
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+        source = client._connected_scanner.source
+        assert len(manager._clients[source]) == 1
+
+        del client
+        gc.collect()
+        assert len(manager._clients[source]) == 0
+
+    cancel_hci0()
+    cancel_hci1()
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -362,6 +362,69 @@ async def test_client_tracking_does_not_keep_client_alive(
 
 
 @pytest.mark.asyncio
+async def test_disconnect_error_on_unregister_is_logged_not_raised(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A client that fails to disconnect must not break scanner teardown."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    ble_device = hci0_device_advs["00:00:00:00:00:01"][0]
+    with patch.object(FakeBleakClient, "is_connected", return_value=True):
+        client = bleak.BleakClient(ble_device)
+        await client.connect()
+
+        with patch.object(
+            FakeBleakClient,
+            "disconnect",
+            new_callable=AsyncMock,
+            side_effect=BleakError("nope"),
+        ):
+            cancel_hci0()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+    assert "Error disconnecting client from removed scanner" in caplog.text
+
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
+async def test_unregister_client_keeps_source_with_other_clients(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+) -> None:
+    """Untracking one client leaves the source's other clients tracked."""
+    manager = _get_manager()
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+
+    with patch.object(FakeBleakClient, "is_connected", return_value=True):
+        first = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
+        await first.connect()
+        second = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:02"][0])
+        await second.connect()
+        source = first._connected_scanner.source
+        assert len(manager._clients[source]) == 2
+
+        await first.disconnect()
+        # The source must survive: the second client is still connected.
+        assert source in manager._clients
+        assert len(manager._clients[source]) == 1
+
+        # A client that never recorded a scanner is passed straight through.
+        manager.async_unregister_client(None, second)
+        assert len(manager._clients[source]) == 1
+
+    cancel_hci0()
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
 async def test_test_switch_adapters_when_out_of_slots(
     two_adapters: None,
     enable_bluetooth: None,

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -524,6 +524,42 @@ async def test_connect_in_flight_unregister_teardown_failure_is_logged(
 
 
 @pytest.mark.asyncio
+async def test_connect_in_flight_unregister_teardown_cancelled_is_logged(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cancellation during the inline teardown is logged and propagates."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+    original_connect = FakeBleakClient.connect
+
+    async def _connect_and_unregister(
+        self: FakeBleakClient, *args: Any, **kwargs: Any
+    ) -> None:
+        await original_connect(self, *args, **kwargs)
+        cancel_hci0()
+
+    with (
+        patch.object(FakeBleakClient, "is_connected", return_value=True),
+        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
+        patch.object(
+            FakeBleakClient,
+            "disconnect",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError,
+        ),
+    ):
+        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
+        with pytest.raises(asyncio.CancelledError):
+            await client.connect()
+        assert client._backend is None
+    assert "cancelled disconnecting after scanner" in caplog.text
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
 async def test_connect_in_flight_unregister_teardown_timeout_is_logged(
     two_adapters: None,
     enable_bluetooth: None,
@@ -557,10 +593,10 @@ async def test_connect_in_flight_unregister_teardown_timeout_is_logged(
 
 @pytest.mark.asyncio
 async def test_dropped_link_is_not_disconnected_on_unregister(
-    connected_client: ConnectedClient,
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A client whose link already dropped is skipped at unregister."""
-    _, _, cancel = connected_client
+    """A client whose link already dropped is untracked, not disconnected."""
+    client, _, cancel = connected_client
     with (
         patch.object(FakeBleakClient, "is_connected", False),
         patch.object(
@@ -569,7 +605,9 @@ async def test_dropped_link_is_not_disconnected_on_unregister(
     ):
         cancel["hci0"]()
         await _settle_disconnects()
+        assert client._connected_scanner is None
     assert disconnect_mock.call_count == 0
+    assert "already down; not disconnecting" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,7 +6,6 @@ import asyncio
 import gc
 import logging
 import sys
-from collections.abc import AsyncGenerator, Callable
 from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -708,15 +708,20 @@ async def test_base_exception_from_disconnect_gives_up_client(
 ) -> None:
     """A BaseException escaping a child is logged; give up re-checks identity."""
     client, _, cancel = connected_client
+
+    async def _cancel_mid_disconnect(*args: Any, **kwargs: Any) -> None:
+        if reconnected_elsewhere:
+            # The client moves on while the gather is still settling; the
+            # late results pass must not give it up.
+            client._connected_scanner = MagicMock()
+        raise asyncio.CancelledError
+
     with patch.object(
         FakeBleakClient,
         "disconnect",
         new_callable=AsyncMock,
-        side_effect=asyncio.CancelledError,
+        side_effect=_cancel_mid_disconnect,
     ):
-        if reconnected_elsewhere:
-            # The late results pass must not give up a client that moved on.
-            client._connected_scanner = MagicMock()
         cancel["hci0"]()
         await _settle_disconnects()
         assert (client._backend is None) is not reconnected_elsewhere

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -9,7 +9,7 @@ import sys
 from collections.abc import AsyncGenerator, Callable
 from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import bleak
 import pytest
@@ -27,6 +27,7 @@ from habluetooth.usage import (
 )
 from habluetooth.wrappers import (
     FILTER_UUIDS,
+    HaBleakClientWrapper,
     HaBleakScannerWrapper,
     _get_device_address_type,
 )
@@ -347,7 +348,94 @@ async def test_disconnect_error_on_unregister_is_logged_not_raised(
     ):
         cancel["hci0"]()
         await _settle_disconnects()
-    assert "Error disconnecting client from removed scanner" in caplog.text
+    assert "from removed scanner" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_client_reconnected_elsewhere_is_not_disconnected(
+    connected_client: ConnectedClient,
+) -> None:
+    """A client that moved to another scanner survives the old one's removal."""
+    client, _, cancel = connected_client
+    other_scanner = MagicMock()
+    with (
+        patch.object(client, "_connected_scanner", other_scanner),
+        patch.object(
+            FakeBleakClient, "disconnect", new_callable=AsyncMock
+        ) as disconnect_mock,
+    ):
+        cancel["hci0"]()
+        await _settle_disconnects()
+    assert disconnect_mock.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_reconnect_untracks_from_previous_scanner(
+    connected_client: ConnectedClient,
+) -> None:
+    """Reconnecting drops the stale entry on the previous scanner."""
+    client, _, cancel = connected_client
+    first_scanner = client._connected_scanner
+    assert client in first_scanner._clients
+    cancel["hci0"]()
+    await _settle_disconnects()
+    # The old link is gone; reconnect resolves to the remaining scanner.
+    with patch.object(FakeBleakClient, "is_connected", False):
+        await client.connect()
+    second_scanner = client._connected_scanner
+    assert second_scanner is not first_scanner
+    assert client not in first_scanner._clients
+    assert client in second_scanner._clients
+
+
+@pytest.mark.asyncio
+async def test_disconnect_timeout_on_unregister_is_logged(
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A hanging disconnect is bounded and logged, not pending forever."""
+    _, _, cancel = connected_client
+
+    async def _hang() -> None:
+        await asyncio.Event().wait()
+
+    with (
+        patch("habluetooth.manager.CLIENT_DISCONNECT_TIMEOUT", 0.0),
+        patch.object(FakeBleakClient, "disconnect", side_effect=_hang),
+    ):
+        cancel["hci0"]()
+        await _settle_disconnects()
+    assert "Error disconnecting client 00:00:00:00:00:01" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pending_disconnects(
+    connected_client: ConnectedClient,
+) -> None:
+    """async_stop cancels disconnect tasks still in flight."""
+    _, _, cancel = connected_client
+    manager = _get_manager()
+
+    async def _hang() -> None:
+        await asyncio.Event().wait()
+
+    with patch.object(FakeBleakClient, "disconnect", side_effect=_hang):
+        cancel["hci0"]()
+        tasks = list(manager._background_tasks)
+        assert tasks
+        manager.async_stop()
+        await asyncio.sleep(0)
+    assert all(task.cancelled() for task in tasks)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_without_connected_scanner(
+    install_bleak_catcher: None,
+) -> None:
+    """Disconnect with a backend but no recorded scanner is a no-op untrack."""
+    client = HaBleakClientWrapper(generate_ble_device("00:00:00:00:00:0F", "x"))
+    client._backend = FakeBleakClient(generate_ble_device("00:00:00:00:00:0F", "x"))
+    assert client._connected_scanner is None
+    await client.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -483,6 +483,41 @@ async def test_connect_in_flight_when_scanner_unregisters(
 
 
 @pytest.mark.asyncio
+async def test_connect_in_flight_unregister_teardown_failure_is_logged(
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher: None,
+    mock_platform_client: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing inline teardown is logged and the connect still fails."""
+    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
+    original_connect = FakeBleakClient.connect
+
+    async def _connect_and_unregister(
+        self: FakeBleakClient, *args: Any, **kwargs: Any
+    ) -> None:
+        await original_connect(self, *args, **kwargs)
+        cancel_hci0()
+
+    with (
+        patch.object(FakeBleakClient, "is_connected", return_value=True),
+        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
+        patch.object(
+            FakeBleakClient,
+            "disconnect",
+            new_callable=AsyncMock,
+            side_effect=BleakError("nope"),
+        ),
+    ):
+        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
+        with pytest.raises(BleakError, match="unregistered during connect"):
+            await client.connect()
+    assert "unregistered mid connect" in caplog.text
+    cancel_hci1()
+
+
+@pytest.mark.asyncio
 async def test_dropped_link_is_not_disconnected_on_unregister(
     connected_client: ConnectedClient,
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -345,21 +345,34 @@ async def test_client_tracking_does_not_keep_client_alive(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reconnected_elsewhere", [False, True])
 async def test_disconnect_error_on_unregister_is_logged_not_raised(
-    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
+    connected_client: ConnectedClient,
+    caplog: pytest.LogCaptureFixture,
+    reconnected_elsewhere: bool,
 ) -> None:
-    """A client that fails to disconnect must not break scanner teardown."""
+    """A failed disconnect is logged; give up re-checks identity first."""
     client, _, cancel = connected_client
+
+    async def _fail_mid_disconnect(*args: Any, **kwargs: Any) -> None:
+        if reconnected_elsewhere:
+            # The client moves on while its disconnect is failing; the
+            # handler must not give up the fresh backend.
+            client._connected_scanner = MagicMock()
+        msg = "nope"
+        raise BleakError(msg)
+
     with patch.object(
         FakeBleakClient,
         "disconnect",
         new_callable=AsyncMock,
-        side_effect=BleakError("nope"),
+        side_effect=_fail_mid_disconnect,
     ):
         cancel["hci0"]()
         await _settle_disconnects()
-        assert client._backend is None
-        assert client._connected_scanner is None
+        assert (client._backend is None) is not reconnected_elsewhere
+        if not reconnected_elsewhere:
+            assert client._connected_scanner is None
     assert "from removed scanner" in caplog.text
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -483,6 +483,33 @@ async def test_connect_in_flight_when_scanner_unregisters(
 
 
 @pytest.mark.asyncio
+async def test_track_moves_client_between_scanners(
+    connected_client: ConnectedClient,
+) -> None:
+    """Tracking follows the client when it roams to another scanner."""
+    client, _, _ = connected_client
+    manager = _get_manager()
+    first = client._connected_scanner
+    second = next(s for s in manager._sources.values() if s is not first)
+    client._track(second, client._connected_device)
+    assert client not in first._clients
+    assert client in second._clients
+    assert client._connected_scanner is second
+
+
+@pytest.mark.asyncio
+async def test_no_disconnects_scheduled_after_stop(
+    connected_client: ConnectedClient,
+) -> None:
+    """A scanner unregistering after async_stop schedules nothing."""
+    _, _, cancel = connected_client
+    manager = _get_manager()
+    manager.async_stop()
+    cancel["hci0"]()
+    assert not manager._background_tasks
+
+
+@pytest.mark.asyncio
 async def test_background_task_exception_is_logged(
     two_adapters: None,
     enable_bluetooth: None,
@@ -497,7 +524,8 @@ async def test_background_task_exception_is_logged(
 
     manager.async_add_background_task(_boom())
     await _settle_disconnects()
-    assert "Background task failed" in caplog.text
+    assert "Background task" in caplog.text
+    assert "failed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -618,6 +618,52 @@ async def test_background_task_exception_is_logged(
 
 
 @pytest.mark.asyncio
+async def test_disconnect_untracks_even_if_backend_still_reports_connected(
+    connected_client: ConnectedClient,
+) -> None:
+    """A clean disconnect untracks even when the backend clears state late."""
+    client, _, _ = connected_client
+    scanner = client._connected_scanner
+    # The fixture pins is_connected True, simulating a backend that only
+    # clears its state asynchronously; the clean return must still untrack.
+    with patch.object(FakeBleakClient, "disconnect", new_callable=AsyncMock):
+        await client.disconnect()
+    assert client not in scanner._clients
+    assert client._connected_scanner is None
+
+
+@pytest.mark.asyncio
+async def test_base_exception_from_disconnect_gives_up_client(
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A BaseException escaping a child is logged and the client given up."""
+    client, _, cancel = connected_client
+    with patch.object(
+        FakeBleakClient,
+        "disconnect",
+        new_callable=AsyncMock,
+        side_effect=asyncio.CancelledError,
+    ):
+        cancel["hci0"]()
+        await _settle_disconnects()
+        assert client._backend is None
+    assert "Unexpected error disconnecting client" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_set_connection_params_disconnected_is_quiet(
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No upgrade-the-backend warning for a client that is not connected."""
+    client, _, _ = connected_client
+    with patch.object(FakeBleakClient, "is_connected", False):
+        await client.disconnect()
+        await client.set_connection_params(6, 6, 0, 1000)
+    assert "Upgrade the backend library" not in caplog.text
+    assert "not setting connection params" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_disconnect_without_backend_untracks_stale_pointers(
     connected_client: ConnectedClient,
 ) -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -422,8 +422,10 @@ async def test_stop_cancels_pending_disconnects(
         cancel["hci0"]()
         tasks = list(manager._background_tasks)
         assert tasks
-        manager.async_stop()
+        # Let the disconnect task start and block on the hung disconnect.
         await asyncio.sleep(0)
+        manager.async_stop()
+        await asyncio.wait(tasks, timeout=1)
     assert all(task.cancelled() for task in tasks)
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -19,7 +19,11 @@ from bleak_retry_connector import Allocations
 
 from habluetooth import HaBluetoothConnector
 from habluetooth import get_manager as _get_manager
-from habluetooth.const import BDADDR_LE_PUBLIC, BDADDR_LE_RANDOM
+from habluetooth.const import (
+    BDADDR_LE_PUBLIC,
+    BDADDR_LE_RANDOM,
+    CLIENT_DISCONNECT_TIMEOUT,
+)
 from habluetooth.usage import (
     install_multiple_bleak_catcher,
     uninstall_multiple_bleak_catcher,
@@ -455,11 +459,31 @@ async def test_failed_disconnect_keeps_client_tracked(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("disconnect_effect", "zero_timeout", "expected_exc", "log_fragment"),
+    [
+        (None, False, BleakError, None),
+        (BleakError("nope"), False, BleakError, "error disconnecting after scanner"),
+        (
+            asyncio.CancelledError,
+            False,
+            asyncio.CancelledError,
+            "cancelled disconnecting after scanner",
+        ),
+        (_hang, True, BleakError, "timed out disconnecting after scanner"),
+    ],
+    ids=["clean", "error", "cancelled", "timeout"],
+)
 async def test_connect_in_flight_when_scanner_unregisters(
     two_adapters: None,
     enable_bluetooth: None,
     install_bleak_catcher: None,
     mock_platform_client: None,
+    caplog: pytest.LogCaptureFixture,
+    disconnect_effect: Any,
+    zero_timeout: bool,
+    expected_exc: type[BaseException],
+    log_fragment: str | None,
 ) -> None:
     """A connect that finishes after its scanner unregistered is torn down."""
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
@@ -472,122 +496,25 @@ async def test_connect_in_flight_when_scanner_unregisters(
         # The scanner goes away while the connect is still in flight.
         cancel_hci0()
 
+    timeout = 0.0 if zero_timeout else CLIENT_DISCONNECT_TIMEOUT
     with (
-        patch.object(FakeBleakClient, "is_connected", return_value=True),
-        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
-    ):
-        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
-        with patch.object(
-            FakeBleakClient, "disconnect", new_callable=AsyncMock
-        ) as disconnect_mock:
-            with pytest.raises(BleakError, match="unregistered during connect"):
-                await client.connect()
-            await _settle_disconnects()
-        assert disconnect_mock.call_count == 1
-    cancel_hci1()
-
-
-@pytest.mark.asyncio
-async def test_connect_in_flight_unregister_teardown_failure_is_logged(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A failing inline teardown is logged and the connect still fails."""
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-    original_connect = FakeBleakClient.connect
-
-    async def _connect_and_unregister(
-        self: FakeBleakClient, *args: Any, **kwargs: Any
-    ) -> None:
-        await original_connect(self, *args, **kwargs)
-        cancel_hci0()
-
-    with (
+        patch("habluetooth.wrappers.CLIENT_DISCONNECT_TIMEOUT", timeout),
         patch.object(FakeBleakClient, "is_connected", return_value=True),
         patch.object(FakeBleakClient, "connect", _connect_and_unregister),
         patch.object(
             FakeBleakClient,
             "disconnect",
             new_callable=AsyncMock,
-            side_effect=BleakError("nope"),
-        ),
+            side_effect=disconnect_effect,
+        ) as disconnect_mock,
     ):
         client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
-        with pytest.raises(BleakError, match="unregistered during connect"):
+        with pytest.raises(expected_exc):
             await client.connect()
         assert client._backend is None
-    assert "error disconnecting after scanner" in caplog.text
-    cancel_hci1()
-
-
-@pytest.mark.asyncio
-async def test_connect_in_flight_unregister_teardown_cancelled_is_logged(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Cancellation during the inline teardown is logged and propagates."""
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-    original_connect = FakeBleakClient.connect
-
-    async def _connect_and_unregister(
-        self: FakeBleakClient, *args: Any, **kwargs: Any
-    ) -> None:
-        await original_connect(self, *args, **kwargs)
-        cancel_hci0()
-
-    with (
-        patch.object(FakeBleakClient, "is_connected", return_value=True),
-        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
-        patch.object(
-            FakeBleakClient,
-            "disconnect",
-            new_callable=AsyncMock,
-            side_effect=asyncio.CancelledError,
-        ),
-    ):
-        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
-        with pytest.raises(asyncio.CancelledError):
-            await client.connect()
-        assert client._backend is None
-    assert "cancelled disconnecting after scanner" in caplog.text
-    cancel_hci1()
-
-
-@pytest.mark.asyncio
-async def test_connect_in_flight_unregister_teardown_timeout_is_logged(
-    two_adapters: None,
-    enable_bluetooth: None,
-    install_bleak_catcher: None,
-    mock_platform_client: None,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A hanging inline teardown is bounded, logged without a traceback."""
-    hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices()
-    original_connect = FakeBleakClient.connect
-
-    async def _connect_and_unregister(
-        self: FakeBleakClient, *args: Any, **kwargs: Any
-    ) -> None:
-        await original_connect(self, *args, **kwargs)
-        cancel_hci0()
-
-    with (
-        patch("habluetooth.wrappers.CLIENT_DISCONNECT_TIMEOUT", 0.0),
-        patch.object(FakeBleakClient, "is_connected", return_value=True),
-        patch.object(FakeBleakClient, "connect", _connect_and_unregister),
-        patch.object(FakeBleakClient, "disconnect", side_effect=_hang),
-    ):
-        client = bleak.BleakClient(hci0_device_advs["00:00:00:00:00:01"][0])
-        with pytest.raises(BleakError, match="unregistered during connect"):
-            await client.connect()
-        assert client._backend is None
-    assert "timed out disconnecting after scanner" in caplog.text
+    assert disconnect_mock.call_count == 1
+    if log_fragment is not None:
+        assert log_fragment in caplog.text
     cancel_hci1()
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -589,7 +589,7 @@ async def test_track_moves_client_between_scanners(
 
 @pytest.mark.asyncio
 async def test_no_disconnects_scheduled_after_stop(
-    connected_client: ConnectedClient,
+    connected_client: ConnectedClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A scanner unregistering after async_stop schedules nothing."""
     _, _, cancel = connected_client
@@ -597,6 +597,7 @@ async def test_no_disconnects_scheduled_after_stop(
     manager.async_stop()
     cancel["hci0"]()
     assert not manager._background_tasks
+    assert "Shutdown; not disconnecting 1 client(s)" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #608.

`_async_unregister_scanner_internal` tears down every piece of bookkeeping about a
scanner — advertisement tracking, smoothed RSSI, demoted sources, allocations, the
slot-manager adapter — but never touches the connections made through it.

For a local adapter those are BlueZ D-Bus links. BlueZ has no idea Home Assistant
considers the adapter gone, the kernel keeps the link up, and the integration holding
the client is never told. Two consequences:

- the device keeps working through an adapter the user removed, so switching or
  disabling adapters appears to work when nothing is actually carrying the traffic;
- the allocation bookkeeping that was just cleared has forgotten a connection that
  still occupies a real slot. On re-register the adapter starts at `free == slots`
  with that link still up, so the slot budget can be overcommitted.

Observed on a Home Assistant install with two local adapters and an ESPHome proxy: a
connected GATT device kept delivering notifications with `subscribe_scanner_details`
returning `[]` — every transport disabled — because its link was still open on the
adapter that had been unregistered minutes earlier.

### What this does

- `BaseHaScanner` gains `_clients: WeakSet[HaBleakClientWrapper]`, populated by
  `HaBleakClientWrapper.connect()` once a connection is established.
- `_async_unregister_scanner_internal` disconnects everything still connected
  through that scanner, bounded by a timeout and skipping clients that have
  reconnected through another scanner.
- The set is weak, so a client dropped without an explicit disconnect cannot leak.
- `HaBleakClientWrapper.disconnect()` unregisters itself, so an already-disconnected
  client is not disconnected twice.
- `base_scanner.pxd` and `manager.pxd` updated for the new attributes.

Caller visible changes: ``connect()`` raises ``BleakError`` when the scanner
was unregistered while the connect was in flight (after tearing the link down
inline); ``disconnect()`` clears ``_connected_scanner`` /
``_connected_device`` on a clean return (kept only while a raise leaves the
link up); and ``set_connection_params()`` on a disconnected local client is a
debug logged no-op instead of a kernel conn param write or a misleading
"upgrade the backend" warning (backends that implement it keep their own
not connected handling). When a forced teardown gives a client up, the
consumer's disconnected callback fires so integrations schedule their
reconnect.

### Tests

New tests in `tests/test_wrappers.py` (plus a parametrized in flight matrix):

- `test_unregister_scanner_disconnects_only_its_clients`
- `test_disconnected_client_is_not_disconnected_again`
- `test_client_tracking_does_not_keep_client_alive`
- `test_disconnect_error_on_unregister_is_logged_not_raised`
- `test_client_reconnected_elsewhere_is_not_disconnected`
- `test_reconnect_untracks_from_previous_scanner`
- `test_disconnect_timeout_on_unregister_is_logged`
- `test_stop_cancels_pending_disconnects`
- `test_manager_backend_timeout_is_not_misreported`
- `test_give_up_detaches_the_disconnected_callback`
- `test_give_up_survives_a_backend_that_refuses_to_detach`
- `test_failed_disconnect_with_link_down_untracks`
- `test_failed_disconnect_keeps_client_tracked`
- `test_connect_in_flight_when_scanner_unregisters`
- `test_dropped_link_is_not_disconnected_on_unregister`
- `test_track_moves_client_between_scanners`
- `test_no_disconnects_scheduled_after_stop`
- `test_background_task_exception_is_logged`
- `test_disconnect_untracks_even_if_backend_still_reports_connected`
- `test_base_exception_from_disconnect_gives_up_client`
- `test_set_connection_params_disconnected_is_quiet`
- `test_disconnect_without_backend_untracks_stale_pointers`
- `test_disconnect_without_connected_scanner`
- `test_disconnect_keeps_other_clients_tracked`
### Verified against real BlueZ

Not just unit tests. Home Assistant 2026.8.1 on a Raspberry Pi (aarch64), real
TP-Link UB500 adapter, real device (a Truma iNet X panel holding a GATT
connection with notifications). Patched build installed, adapter's config entry
disabled, kernel link state polled once a second:

```
17:14:00  con=1 l2cap=2
17:14:02  con=1 l2cap=2      <- config entry disabled at 17:14:01
17:14:03  con=1 l2cap=2
17:14:04  con=0 l2cap=0      <- link gone
17:14:15  con=0 l2cap=0
```

(`con` = `btmgmt --index 0 con`, `l2cap` = matching lines in
`/sys/kernel/debug/bluetooth/l2cap`.)

On the unpatched build the same action left the link up indefinitely — measured
at two minutes, still delivering notifications, with
`bluetooth/subscribe_scanner_details` returning `[]`.

Re-enabling the entry reconnected cleanly 11 s later. The integration holding the
client handled the forced disconnect without complaint — it logged
`BLE link closed cleanly`, correctly reported `no route to the panel right now`
while no transport existed, and backed off (15 s → 30 s) until the adapter
returned. **Zero tracebacks in the Home Assistant log across the whole test.**

### Points worth a maintainer's opinion

1. **Remote scanners.** This also disconnects clients of an ESPHome proxy when its
   scanner unregisters. Only the local-adapter path is covered by the real-world
   test above. I believe the proxy path is correct — connections through a proxy that
   has gone away are dead anyway, and this makes HA notice immediately instead of
   waiting for a timeout — but it is a behaviour change for that path too, so worth a
   look.

2. **Reload churn.** HA unregisters on config-entry unload, which includes *reload*.
   Reloading a bluetooth entry now drops its connections; integrations reconnect. That
   seems right ("the adapter is going away") but it is more churn than before.

3. **Alternative shape.** The manager already emits `HaScannerRegistrationEvent.REMOVED`
   and `HaBleakClientWrapper` already knows its `_connected_scanner`, so this could
   instead be pushed to consumers via the existing event rather than done centrally.
   I went central because every consumer would otherwise have to reimplement it, but
   happy to reshape.









