### PR TITLE
fix(build): take C types from the .pxd files, not the .py annotations

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -63,7 +63,30 @@ def build(setup_kwargs: Any) -> None:
             {
                 "ext_modules": cythonize(
                     EXTENSIONS,
-                    compiler_directives={"language_level": "3"},  # Python 3
+                    compiler_directives={
+                        "language_level": "3",  # Python 3
+                        # The .pxd files are the authoritative C-level types.
+                        # Cython 3.3 started reconciling them against the .py
+                        # annotations and rejects a bare container type in a
+                        # .pxd against a parameterised one in the .py, e.g.
+                        #
+                        #   .pxd  cpdef void _attach_owned(self, str address,
+                        #                                  dict entries)
+                        #   .py   def _attach_owned(
+                        #             self, address: str,
+                        #             entries: dict[ActiveScanRequest, float],
+                        #         ) -> None
+                        #
+                        # which fails with "Signature not compatible with
+                        # previous declaration". Ten declarations across
+                        # auto_scheduler.pxd and base_scanner.pxd hit this, so
+                        # a source build with an unpinned Cython (the
+                        # build-system requirement is only `Cython>=3`) cannot
+                        # complete. Take the types from the .pxd, which is
+                        # where they were always meant to come from, and leave
+                        # the annotations to mypy and to human readers.
+                        "annotation_typing": False,
+                    },
                     annotate=bool(os.environ.get("CYTHON_ANNOTATE")),
                 ),
                 "cmdclass": {"build_ext": BuildExt},


### PR DESCRIPTION
### The problem

A source build with a current Cython fails outright:

```
src/habluetooth/auto_scheduler.py:328:4: Signature not compatible with previous declaration
src/habluetooth/auto_scheduler.pxd:48:28: Previous declaration is here
```

Cython 3.3 reconciles a `.pxd` declaration against the annotations on the `.py`
definition, and rejects a bare container type in the `.pxd` against a
parameterised one in the `.py`:

```
.pxd   cpdef void _attach_owned(self, str address, dict entries)
.py    def _attach_owned(self, address: str, entries: dict[ActiveScanRequest, float]) -> None
```

Ten declarations hit this — 7 in `auto_scheduler.pxd`, 3 in `base_scanner.pxd`.
`build-system.requires` is only `Cython>=3`, so every source build resolves to
3.3 and stops. The published wheels are unaffected, which is why CI has not
caught it.

I hit this building habluetooth for a Raspberry Pi (aarch64/musl), where there
is no prebuilt wheel to fall back on.

### The fix

Writing the parameterised form into the `.pxd` does **not** help — Cython does
not accept `dict[ActiveScanRequest, float]` as a C parameter type there. The
types Cython should use are the ones already spelled out in the `.pxd` files;
the annotations are there for mypy and for readers. `annotation_typing: False`
says exactly that.

**Trade-off, stated plainly:** functions *not* declared in a `.pxd` no longer
get C types inferred from their annotations. Everything on the hot paths here is
declared in a `.pxd`, so this costs nothing that was not already explicit — but
if you would rather keep annotation typing and correct the ten declarations
another way, I am happy to redo it.

### Verification

With Cython 3.3.0:

- all seven extension modules compile (previously: all seven fail)
- `poetry build -f wheel` produces a wheel carrying all seven `.so`
- the suite passes **against the compiled build**: 899 passed, 1 skipped

### Related

Same defect class as Bluetooth-Devices/bluetooth-data-tools#314 (`tuple` vs
`tuple[bytes, ...]` in `gap.pxd`). Worth a look across the other repos that
ship `.pxd` files.
