### PR TITLE
fix: say when a device is in history but cached by no scanner

### DIFF
--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1556,12 +1556,10 @@ class BluetoothManager:
         else:
             parts.append("unknown (never seen by any scanner)")
 
-        # History is fed but no scanner has the device cached (passive
-        # or_patterns miss); not an out of slots condition.
+        # History outlives any scanner's discovered cache (scanner churn,
+        # cache expiry, passive or_patterns miss); not an out of slots case.
         if not devices and address in self._all_history:
-            parts.append(
-                "in history but no scanner currently has it in its discovered devices"
-            )
+            parts.append("no scanner currently has it in its discovered devices")
             return
 
         connectable_devices = [d for d in devices if d.scanner.connectable]

--- a/src/habluetooth/manager.py
+++ b/src/habluetooth/manager.py
@@ -1556,6 +1556,14 @@ class BluetoothManager:
         else:
             parts.append("unknown (never seen by any scanner)")
 
+        # History is fed but no scanner has the device cached (passive
+        # or_patterns miss); not an out of slots condition.
+        if not devices and address in self._all_history:
+            parts.append(
+                "in history but no scanner currently has it in its discovered devices"
+            )
+            return
+
         connectable_devices = [d for d in devices if d.scanner.connectable]
         non_connectable_devices = [d for d in devices if not d.scanner.connectable]
         if not connectable_devices and non_connectable_devices:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3991,6 +3991,26 @@ async def test_address_reachability_diagnostics_in_history_no_scanner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_address_reachability_diagnostics_connection_in_history_no_scanner() -> (
+    None
+):
+    """A connect intent says the device is not in any discovered map."""
+    manager = get_manager()
+    address = "44:44:33:11:23:4d"
+    device = generate_ble_device(address, "wohand")
+    adv = generate_advertisement_data(local_name="wohand", rssi=-70)
+    # In history but cached by no scanner: no connect path.
+    inject_advertisement_with_source(device, adv, "ghost")
+
+    diag = manager.async_address_reachability_diagnostics(
+        address, BluetoothReachabilityIntent.CONNECTION
+    )
+    assert "in connectable history" in diag
+    assert "no scanner currently has it in its discovered devices" in diag
+    assert "slot" not in diag
+
+
+@pytest.mark.asyncio
 async def test_address_reachability_diagnostics_all_scanners_connecting() -> None:
     """When every scanner is paused connecting, the device cannot be seen."""
     manager = get_manager()


### PR DESCRIPTION
When a device is in history but no scanner has it in its discovered map, the connect error read as an out of slots condition. The connect intent diagnostics now say `in history but no scanner currently has it in its discovered devices`. Found while working on #615.

- [x] test, full suite passes
