### PR TITLE
fix: restore discoveries after an active window flip

### DIFF
--- a/src/habluetooth/scanner_bleak.py
+++ b/src/habluetooth/scanner_bleak.py
@@ -870,7 +870,7 @@ class HaScanner(BaseHaScanner):
         Full teardown: nulls ``self.scanner`` and constructs a fresh
         one. AUTO active-window flips on Linux use
         ``_async_toggle_active_window_mode`` instead to skip the dbus
-        setup + ``restore_discoveries`` cost.
+        client setup; it re-seeds with ``restore_discoveries_sync``.
         """
         await self._async_stop_scanner()
         await self._async_start()

--- a/src/habluetooth/scanner_bleak.py
+++ b/src/habluetooth/scanner_bleak.py
@@ -13,7 +13,11 @@ import async_interrupt
 import bleak
 from bleak import BleakError
 from bleak.assigned_numbers import AdvertisementDataType
-from bleak_retry_connector import Allocations, restore_discoveries
+from bleak_retry_connector import (
+    Allocations,
+    restore_discoveries,
+    restore_discoveries_sync,
+)
 from bleak_retry_connector.bluez import stop_discovery
 from bluetooth_adapters import DEFAULT_ADDRESS
 from bluetooth_data_tools import monotonic_time_coarse
@@ -877,10 +881,9 @@ class HaScanner(BaseHaScanner):
 
         Stops the live ``self.scanner``, mutates its private
         ``_backend._scanning_mode`` to the value from
-        ``_effective_mode()``, restarts the same instance. Skips the
-        new dbus client + ``restore_discoveries`` cost of a fresh
-        construction; bleak's device cache survives same-instance
-        stop+start so ``BleakClient(address)`` keeps working.
+        ``_effective_mode()``, restarts the same instance. bleak clears
+        ``seen_devices`` on ``start()``, so re-seed with
+        ``restore_discoveries_sync`` like a full start.
 
         Linux/BlueZ only — callers must check ``IS_LINUX``. Returns
         False if the scanner is gone or stop/start raised (caller
@@ -938,6 +941,7 @@ class HaScanner(BaseHaScanner):
             return False
         self.scanning = True
         self.set_current_mode(radio_mode)
+        restore_discoveries_sync(self.scanner, self.adapter)
         return True
 
     async def _async_stop_scanner(self) -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -92,6 +92,7 @@ def disable_stop_discovery():
     with (
         patch("habluetooth.scanner_bleak.stop_discovery"),
         patch("habluetooth.scanner_bleak.restore_discoveries"),
+        patch("habluetooth.scanner_bleak.restore_discoveries_sync"),
     ):
         yield
 
@@ -1871,6 +1872,26 @@ async def test_async_toggle_active_window_mode_marks_not_scanning_on_start_error
         assert scanner_obj.scanning is True
         assert await scanner_obj._async_toggle_active_window_mode() is False
         assert scanner_obj.scanning is False
+
+
+@pytest.mark.usefixtures("force_linux_scanner_mode")
+@pytest.mark.asyncio
+async def test_async_toggle_active_window_mode_restores_discoveries() -> None:
+    """A successful in place toggle re-seeds bleak's discovered map."""
+    with (
+        patch_bleak_scanner_factory(MockBleakScanner),
+        patch("habluetooth.scanner_bleak.restore_discoveries", AsyncMock()) as restore,
+        patch("habluetooth.scanner_bleak.restore_discoveries_sync") as restore_sync,
+    ):
+        scanner_obj = HaScanner(BluetoothScanningMode.AUTO, "hci0", "AA:BB:CC:DD:EE:FF")
+        scanner_obj.async_setup()
+        await scanner_obj.async_start()
+        assert restore.await_count == 1
+        scanner_obj._scan_mode_override = BluetoothScanningMode.ACTIVE
+        assert await scanner_obj._async_toggle_active_window_mode() is True
+        assert restore.await_count == 1
+        restore_sync.assert_called_once_with(scanner_obj.scanner, "hci0")
+        await scanner_obj.async_stop()
 
 
 @pytest.mark.usefixtures("force_linux_scanner_mode")


### PR DESCRIPTION
bleak 3 clears `seen_devices` on every `start()` and the in place active window flip skipped the re-seed a full start does, so every AUTO flip emptied the map the connect path reads until devices were rediscovered. Re-seed with `restore_discoveries_sync` (bleak-retry-connector 4.7.0) right after the restart; it never awaits, so nothing runs between the restart and the re-seed. Found while working on #615. Stacked on the 4.7.0 bump PR.

- [x] test asserts one restore per toggle, full suite passes
