### PR TITLE
ci: add Windows ARM64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+          - windows-11-arm
         extension:
           - "skip_cython"
           - "use_cython"
@@ -82,7 +83,8 @@ jobs:
           path: |
             .venv
             src/habluetooth/**/*.so
-          key: venv-v3-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
+            src/habluetooth/**/*.pyd
+          key: venv-v4-${{ runner.os }}-${{ runner.arch }}-py${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/habluetooth/**/*.py', 'src/habluetooth/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         env:
@@ -236,7 +238,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-24.04-arm, ubuntu-latest, macos-latest]
+        os:
+          - windows-latest
+          - windows-11-arm
+          - ubuntu-24.04-arm
+          - ubuntu-latest
+          - macos-latest
         qemu: [""]
         musl: [""]
         pyver: [""]

--- a/build_ext.py
+++ b/build_ext.py
@@ -48,6 +48,8 @@ class BuildExt(build_ext):
             # platform mismatch, etc.) should fall back to the pure-Python
             # install rather than break the build.
             _LOGGER.debug("Failed to build extensions: %s", ex, exc_info=True)
+            if os.environ.get("REQUIRE_CYTHON"):
+                raise
 
 
 def build(setup_kwargs: Any) -> None:


### PR DESCRIPTION
As the title says -- I noticed a few other things which I have fixed, let me know if you would like me to change/remove any of these:
- In the test workflow, the caching did not save/restore compiled `*.pyd` modules on Windows.
- In `build_ext.py`, compile errors would have been silently ignored, even if `REQUIRE_CYTHON` was set.

I tested the wheel build with a [temporary workflow](https://github.com/ndabas/habluetooth/actions/runs/33373121160) in my fork.